### PR TITLE
Fix 'Discuss on Twitter' link

### DIFF
--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -236,7 +236,9 @@ function ArticleFooter({
         <div className="flex">
           <Link
             className="underlined dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
-            to="/"
+            to={`https://twitter.com/search?${new URLSearchParams({
+              q: permalink,
+            })}`}
           >
             Discuss on Twitter
           </Link>


### PR DESCRIPTION
I noticed that the "Edit on GitHub" and "Discuss on Twitter" links are currently just pointing to `kentcdodds.com`. I wasn't sure how to fix the GitHub one right away (since it looks like that may have changed with some of the `mdx-bundler` changes). But, I thought I'd go ahead and try to fix the Twitter one anyway :)

# Changed
- Change "Discuss on Twitter" link on blog posts to point to Twitter search page