### PR TITLE
fix: Center DarkModeToggle icons if browser font size is changed

### DIFF
--- a/app/components/icons/moon-icon.tsx
+++ b/app/components/icons/moon-icon.tsx
@@ -3,8 +3,7 @@ import * as React from 'react'
 function MoonIcon() {
   return (
     <svg
-      width="32"
-      height="32"
+      className="w-full"
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/app/components/icons/sun-icon.tsx
+++ b/app/components/icons/sun-icon.tsx
@@ -3,8 +3,7 @@ import * as React from 'react'
 function SunIcon() {
   return (
     <svg
-      width="32"
-      height="32"
+      className="w-full"
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Before:
![kentcdodds com_toggle previous](https://user-images.githubusercontent.com/12292047/135998896-c2cf31d1-bea7-4c9c-9879-948ac8267827.png)


After:
![kentcdodds com_toggle next](https://user-images.githubusercontent.com/12292047/135998886-c0d5d5b8-dce1-4137-a4c5-1e3cf86e0351.png)


How to reproduce:
Customize font size in the browser (e.g. Chrome > Settings > Appearance > Font Size > Large)