### PR TITLE
fix: fix 'Discuss on Twitter' link

### DIFF
--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -243,7 +243,7 @@ function ArticleFooter({
             })}`}
           >
             Discuss on Twitter
-          </Link>
+          </a>
           <span className="self-center mx-3 text-xs">•</span>
           <Link
             className="underlined dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -234,9 +234,11 @@ function ArticleFooter({
         </div>
 
         <div className="flex">
-          <Link
+          <a
             className="underlined dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
-            to={`https://twitter.com/search?${new URLSearchParams({
+            target="_blank"
+            rel="noreferrer noopener"
+            href={`https://twitter.com/search?${new URLSearchParams({
               q: permalink,
             })}`}
           >


### PR DESCRIPTION
It was going to `https://kentcdodds.com/blog/introducing-the-new-kentcdodds.com/https:/twitter.com/search?q=https%3A%2F%2Fkentcdodds.com%2Fblog%2Fintroducing-the-new-kentcdodds.com` for https://kentcdodds.com/blog/introducing-the-new-kentcdodds.com