### PR TITLE
"Candy dispenser" dark theme fix

### DIFF
--- a/content/blog/usememo-and-usecallback/index.mdx
+++ b/content/blog/usememo-and-usecallback/index.mdx
@@ -31,9 +31,8 @@ Here's a candy dispenser:
 
 <div
   style={{
-    background: 'white',
     padding: 20,
-    border: '2px solid black',
+    border: '2px solid var(--border-secondary)',
     borderRadius: 5,
     marginBottom: 20,
   }}


### PR DESCRIPTION
At ["When to useMemo and useCallback" article](https://kentcdodds.com/blog/usememo-and-usecallback) there is a live demo of "Candy dispenser". I found that div wrapper of that demo has inline styles (especially background color and border) that doesn't respect dark theme.
This quick fix makes it a little bit better.