### PR TITLE
Fix typos in blog post

### DIFF
--- a/content/blog/how-remix-makes-css-clashes-predictable.mdx
+++ b/content/blog/how-remix-makes-css-clashes-predictable.mdx
@@ -72,7 +72,7 @@ enough. We need the CSS to not only arrive in the browser when the user gets to
 the `/about` page but also make sure it's _removed_ from the page when the user
 navigates away from the `/about` page.
 
-And _that_ is the magic ingridiant of Remix's anti-clash potion. Observe:
+And _that_ is the magic ingredient of Remix's anti-clash potion. Observe:
 
 ![Gif showing a link tag getting removed when navigating from the about page to the homepage](https://res.cloudinary.com/kentcdodds-com/image/upload/kentcdodds.com/blog/how-remix-makes-css-clashes-impossible/css-link-removed)
 
@@ -146,7 +146,7 @@ The point of this post is more to call out this fact:
 </callout-success>
 
 Having a [predictable](https://www.youtube.com/watch?v=hwJUuN3JUPE) outcome to
-the changes you're making is a huge win for maintainablility.
+the changes you're making is a huge win for maintainability.
 
 ## Tailwind
 
@@ -157,7 +157,7 @@ over time later and use this feature of Remix.
 
 By the end of it I realized that Tailwind does more than side-step the Cascade
 clashing issues, it also gives you a great set of constraints to keep your UI
-looking consistant. So I decided to keep it.
+looking consistent. So I decided to keep it.
 
 ## Conclusion
 


### PR DESCRIPTION
Fix typos in "How Remix Makes CSS Clashes Predictable"