### PR TITLE
Add <link> for items in RSS feed

### DIFF
--- a/app/utils/blog-rss-feed.server.ts
+++ b/app/utils/blog-rss-feed.server.ts
@@ -33,6 +33,7 @@ async function getRssFeedXml(request: Request) {
                 ),
                 'yyyy-MM-ii',
               )}</pubDate>
+              <link>${blogUrl}/${post.slug}</link>
               <guid>${blogUrl}/${post.slug}</guid>
             </item>
           `.trim(),


### PR DESCRIPTION
Fixes opening blog posts from RSS readers that expect blog posts to have links