### PR TITLE
fix color of strong link

### DIFF
--- a/content/blog/but-really-what-is-a-javascript-test.mdx
+++ b/content/blog/but-really-what-is-a-javascript-test.mdx
@@ -39,9 +39,8 @@ const subtract = (a, b) => a - b
 module.exports = {sum, subtract}
 ```
 
-**I've made**
-[**a repo on GitHub**](https://github.com/kentcdodds/js-test-example) **you can
-reference as well 🐙😸**
+**I've made [a repo on GitHub](https://github.com/kentcdodds/js-test-example)
+you can reference as well 🐙😸**
 
 ### Step 1
 


### PR DESCRIPTION
Color of `<strong>` was winning over the color of `<a>` in the previous version, hiding the existence of a link:

![image](https://user-images.githubusercontent.com/1087670/137634496-36d8db6b-e611-4c4e-b1c6-c1283498f68f.png)
