### PR TITLE
Fix punctuation in CourseCard description: pro's 👉 pros

### DIFF
--- a/app/routes/courses.tsx
+++ b/app/routes/courses.tsx
@@ -134,7 +134,7 @@ function CoursesHome() {
         <div className="col-span-full lg:col-span-6">
           <CourseCard
             title="Epic React"
-            description="The most comprehensive guide for pro's."
+            description="The most comprehensive guide for pros."
             imageBuilder={images.courseEpicReact}
             courseUrl="https://epicreact.dev"
           />


### PR DESCRIPTION
This is a copy edit change to remove an unneeded apostrophe.