### PR TITLE
fix typo on the words resilience and resilient

### DIFF
--- a/content/blog/why-i-love-remix.mdx
+++ b/content/blog/why-i-love-remix.mdx
@@ -54,7 +54,7 @@ are a few:
 - Pending management
 - State management
 - Progressive enhancement
-- Resiliance (behavior in poor network conditions)
+- Resilience (behavior in poor network conditions)
 - Layout
 - Content clarity
 
@@ -77,7 +77,7 @@ rendered/hydrated and every page is completely unique to every user (so a shared
 HTTP cache on a CDN is not possible).
 
 Remix's use of the platform APIs is what enables this. That's also what makes
-Remix so resiliant and great for progressive enhancement as well. In poor
+Remix so resilient and great for progressive enhancement as well. In poor
 network conditions where loading the JavaScript is slow/fails, Remix's standard
 API for mutations (`<Form />`) will actually work even before the app is
 hydrated. This means that the user can start getting work done with the app,


### PR DESCRIPTION
Noticed a typo (or 2) while reading a great blog written by an excited KCD. 