### PR TITLE
Replace the Codesandbox

### DIFF
--- a/content/blog/dont-sync-state-derive-it.mdx
+++ b/content/blog/dont-sync-state-derive-it.mdx
@@ -19,9 +19,8 @@ bannerCredit: Photo by [Gabriel Gusmao](https://unsplash.com/photos/pMmw3ynuXHw)
 
 In [my Learn React Hooks workshop](/workshops/react-hooks) material, we have an
 exercise where we build a tic-tac-toe game using React's `useState` hook (based
-on the official React tutorial). Here's the finished version of that exercise:
+on the official React tutorial). [Here's the Github file for the finished version of that exercise](https://github.com/kentcdodds/react-hooks/blob/main/src/final/04.js)
 
-https://codesandbox.io/s/github/kentcdodds/react-hooks/tree/main/?fontsize=14&hidenavigation=1&initialpath=/isolated/final/04.js&module=/src/final/04.js&theme=dark&file=/src/final/04.js
 
 We have a few variables of state. There's a `squares` state variable via
 `React.useState`. There's also `nextValue`, `winner`, and `status` are each


### PR DESCRIPTION
Replace the *broken* Codesandbox with a link that leads to the exercise file in Github