### PR TITLE
Return null theme session

### DIFF
--- a/app/utils/theme.server.ts
+++ b/app/utils/theme.server.ts
@@ -20,7 +20,7 @@ async function getThemeSession(request: Request) {
   return {
     getTheme: () => {
       const themeValue = session.get('theme')
-      return isTheme(themeValue) ? themeValue : Theme.DARK
+      return isTheme(themeValue) ? themeValue : null
     },
     setTheme: (theme: Theme) => session.set('theme', theme),
     commit: () => themeStorage.commitSession(session),


### PR DESCRIPTION
The dark theme is returned from `getThemeSession` as fallback. This way the client script that detects the user theme isn't executed at all.