### PR TITLE
If the font family is already installed, use it.

### DIFF
--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,7 +9,8 @@
 /* tailwind is configured to prefer this font */
 @font-face {
   font-family: 'Matter';
-  src: url('/fonts/Matter-Medium.woff2') format('woff2'),
+  src: local('Matter'),
+    url('/fonts/Matter-Medium.woff2') format('woff2'),
     url('/fonts/Matter-Medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
@@ -18,7 +19,8 @@
 
 @font-face {
   font-family: 'Matter';
-  src: url('/fonts/Matter-Regular.woff2') format('woff2'),
+  src: local('Matter'),
+    url('/fonts/Matter-Regular.woff2') format('woff2'),
     url('/fonts/Matter-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
If the "Matter" font family is already installed on the user's device, it will be used instead of downloading the font file.