### PR TITLE
fix: server navigation to `talks/$slug`

### DIFF
--- a/app/routes/talks/$slug.tsx
+++ b/app/routes/talks/$slug.tsx
@@ -27,3 +27,7 @@ export const meta: MetaFunction = ({parentsData, params}) => {
     }),
   }
 }
+
+export default function TalksSlug() {
+  return null;
+}


### PR DESCRIPTION
Fixes server returning `null` when navigating to any `/talks/something` route: https://github.com/kentcdodds/kentcdodds.com/pull/82#issuecomment-985932847

https://user-images.githubusercontent.com/14360171/144715903-fa72194f-dc2f-4f69-bc5d-5fec60d404c3.mov



