### PR TITLE
fix: set pointer-events to none for codeblocks

### DIFF
--- a/styles/prose.css
+++ b/styles/prose.css
@@ -111,6 +111,7 @@ pre {
   top: 0;
   width: 100%;
   opacity: 0.15;
+  pointer-events: none;
 }
 
 .codeblock-line[data-highlight='true']:before {


### PR DESCRIPTION
This fixes a small issue when trying to quickly copy-paste some code 😅!

**Before**

_**cannot** select highlighted lines_

https://user-images.githubusercontent.com/53900565/144989098-7d613f19-eb56-41f2-93e6-2babf66df5c1.mp4


**After**

_**can** select highlighted lines_

https://user-images.githubusercontent.com/53900565/144989105-15e0ca50-5afa-4c37-b57b-a3ec6f35898e.mp4


