### PR TITLE
fix: use `-dd` for day of month rather than `-ii` for talks

### DIFF
--- a/app/routes/talks.tsx
+++ b/app/routes/talks.tsx
@@ -160,7 +160,7 @@ function Card({
                     <div className="flex-auto" />
                     <Paragraph className="flex-none ml-2" as="span">
                       {delivery.date
-                        ? formatDate(new Date(delivery.date), 'yyyy-MM-ii')
+                        ? formatDate(new Date(delivery.date), 'yyyy-MM-dd')
                         : null}
                     </Paragraph>
                   </div>

--- a/content/data/talks.yml
+++ b/content/data/talks.yml
@@ -21,7 +21,7 @@
       date: 2022-02-17
     - event: '[XTSummit](https://xtsummit.com/)'
       date: 2022-02-18
-    - event: '[Brum.js](https://www.meetup.com/brum_js/)'
+    - event: '[Brum.js](https://brum.js.org/)'
       date: 2022-02-24
   tags:
     - react


### PR DESCRIPTION
Spotted that the Brum.js date was incorrect so checked the data was correct and spotted it was using the wrong value for day of month.

I've also updated the Brum.js website to be our preferred site rather than Meetup :)

I couldn't see that you're doing tests for these components, so didn't add -- just let me know if you'd rather that

**Before:**
![image](https://user-images.githubusercontent.com/23480260/146686847-6066dae6-f625-4c6e-be2f-18f998ae6ad4.png)

**After:**
![image](https://user-images.githubusercontent.com/23480260/146686837-3542280f-f68f-4ee3-87a6-5d3aae6dc5c0.png)
