### PR TITLE
Checkout vs Check out

### DIFF
--- a/app/utils/mdx.tsx
+++ b/app/utils/mdx.tsx
@@ -334,7 +334,7 @@ function mdxPageMeta({
             'Untitled',
           preTitle:
             data.page.frontmatter.socialImagePreTitle ??
-            `Checkout this article`,
+            `Check out this article`,
         }),
       }),
       ...extraMeta,


### PR DESCRIPTION
Checkout is a noun, check out is the verb.

![image](https://user-images.githubusercontent.com/8754/147865327-dca776ae-72b1-4991-81f0-107a0d570ca9.png)
