### PR TITLE
Fix blog search field for iOS Safari dark mode

### DIFF
--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -395,7 +395,7 @@ function BlogHome() {
                   }}
                   name="q"
                   placeholder={searchInputPlaceholder}
-                  className="text-primary bg-primary border-secondary focus:bg-secondary focus:outline-none w-full rounded-full border py-6 pl-14 pr-6 text-lg font-medium hover:border-team-current focus:border-team-current md:pr-24"
+                  className="appearance-none text-primary bg-primary border-secondary focus:bg-secondary focus:outline-none w-full rounded-full border py-6 pl-14 pr-6 text-lg font-medium hover:border-team-current focus:border-team-current md:pr-24"
                 />
                 <div className="absolute right-6 top-0 hidden h-full w-14 items-center justify-between text-lg font-medium text-blueGray-500 md:flex">
                   <MixedCheckbox


### PR DESCRIPTION
The blog search field has white text on white background when using dark mode on iOS Safari. I can confirm using iOS Safari devtools that `-webkit-appearance: none;` on the input fixes the issue. 

Unfortunately I can't run the project to test this. I'm not able to install docker on my work computer and I don't have a personal computer setup for web dev right now. 

If I add the `appearance-none` Tailwind class in devtools, nothing happens. I assume that's because purgeCSS has removed that Tailwind utility class from your production build. Assuming autoprefixer is setup, I assume the Tailwind class will fix the issue. To be clear `appearance: none;` will not work, only `-webkit-appearance: none;`.

PS - Thanks for all the awesome content. Currently going to through Epic React, which my company purchased for me 
😍😍😍