### PR TITLE
Fix Sticker Mule text

### DIFF
--- a/content/pages/uses.mdx
+++ b/content/pages/uses.mdx
@@ -25,7 +25,7 @@ URL for this page is [`kcd.im/uses`](https://kcd.im/uses)).
 - [Cloudinary](https://kcd.im/cloudinary) - Fantastic image hosting
 - [GitHub](https://github.com) - Where I host my code. I also run CI/CD
   pipelines via GitHub Actions.
-- [StickerMule](https://kcd.im/stickermule) - How I get a bunch of stickers of
+- [Sticker Mule](https://kcd.im/stickermule) - How I get a bunch of stickers of
   my OSS projects etc. printed for myself that I can hand out.
 
 ## Tech


### PR DESCRIPTION
Hello! :wave: I love your website; it looks amazing!

This PR makes a small edit which changes `StickerMule` to `Sticker Mule`. At the bottom of Sticker Mule's press page, https://www.stickermule.com/press, it says that Sticker Mule is two words. 
<img width="1111" alt="Screen Shot 2022-02-12 at 19 51 42" src="https://user-images.githubusercontent.com/72365100/153737909-4d533c7a-3920-4245-a96f-6f501bdc4bcc.png">
