### PR TITLE
Add more CN translation for posts

### DIFF
--- a/content/blog/aha-testing/index.mdx
+++ b/content/blog/aha-testing/index.mdx
@@ -12,6 +12,9 @@ meta:
     - dry
     - wet
     - aha
+translations:
+  - language: 简体中文
+    link: https://juejin.cn/post/7086704811927666719/
 bannerCloudinaryId: unsplash/photo-1522424427542-e6fc86ff5253
 bannerCredit:
   Photo by [Alexandru Goman](https://unsplash.com/photos/CM-qccHaQ04)

--- a/content/blog/common-mistakes-with-react-testing-library.mdx
+++ b/content/blog/common-mistakes-with-react-testing-library.mdx
@@ -15,6 +15,8 @@ meta:
 translations:
   - language: Português (do Brasil)
     link: https://giovanisleite.dev/erros-comuns-com-react-testing-library
+  - language: 简体中文
+    link: https://mp.weixin.qq.com/s/pgdcDNjDGPgNq76Zh_dZxg
   - language: 한국어
     link: https://seongry.github.io/2021/06-20-common-mistakes-with-rty/
   - language: 日本語

--- a/content/blog/how-to-know-what-to-test.mdx
+++ b/content/blog/how-to-know-what-to-test.mdx
@@ -10,6 +10,8 @@ meta:
     - javascript
     - coverage
 translations:
+  - language: 简体中文
+    link: https://juejin.cn/post/7084526003548061703
   - language: Português (do Brasil)
     link: https://segredo.dev/como-saber-o-que-testar/?utm_source=kentcdodds&utm_medium=translate&utm_campaign=howknowtest
 bannerCloudinaryId: unsplash/photo-1494017411273-233a4d225d36


### PR DESCRIPTION
Adding CN (simplified) translation for 3 posts:
* [How to know what to test](https://kentcdodds.com/blog/how-to-know-what-to-test)
* [AHA Testing](https://kentcdodds.com/blog/aha-testing)
* [Common mistakes with React Testing Library](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)