### PR TITLE
Update todoist link as referral is not applicable anymore

### DIFF
--- a/content/pages/uses.mdx
+++ b/content/pages/uses.mdx
@@ -20,7 +20,7 @@ URL for this page is [`kcd.im/uses`](https://kcd.im/uses)).
 ## Services
 
 - [Fathom](https://kcd.im/fathom) - My preferred tool for ethical analytics
-- [Todoist](https://kcd.im/todoist) - My preferred todo list app
+- [Todoist](https://todoist.com) - My preferred todo list app
 - [Fly.io](https://fly.io) - An amazing hosting platform
 - [Cloudinary](https://kcd.im/cloudinary) - Fantastic image hosting
 - [GitHub](https://github.com) - Where I host my code. I also run CI/CD


### PR DESCRIPTION
Replacing Kent's referral link with the landing page of Todoist.
Due to:
> As of April 2022, Todoist no longer offers a refer-a-friend discount.
If you had a custom referral page prior to this date, this page will no longer be accessible.

https://todoist.com/help/articles/do-you-have-a-refer-a-friend-program