### PR TITLE
Syntax that works with return values

### DIFF
--- a/content/blog/fix-the-not-wrapped-in-act-warning/index.mdx
+++ b/content/blog/fix-the-not-wrapped-in-act-warning/index.mdx
@@ -298,7 +298,7 @@ to await that promise resolution:
 
 ```tsx [2,3,13]
 test('calls updateUsername with the new username', async () => {
-  const promise = Promise.resolve()
+  const promise = Promise.resolve() // You can also resolve with a mocked return value if necessary
   const handleUpdateUsername = jest.fn(() => promise)
   const fakeUsername = 'sonicthehedgehog'
 
@@ -309,7 +309,8 @@ test('calls updateUsername with the new username', async () => {
   user.click(screen.getByText(/submit/i))
 
   expect(handleUpdateUsername).toHaveBeenCalledWith(fakeUsername)
-  await act(() => promise)
+  // we await the promise instead of returning directly, because act expects a "void" result
+  await act(async () => { await promise })
 })
 ```
 


### PR DESCRIPTION
Hi,
It seems that after updating to React 17, the `act` function accepts only a "void" return. However, if your promise must return a value, for instance a mock of a success message from the server, the current code will throw a TypeScript error, because the promise have a type different from undefined/void.
This version is safer (yet a bit more verbose, I personally don't get this choice in React...).

You might want to double check though, I've noticed that in the context of a massive migration, and I didn't test React 18 either