### PR TITLE
align theme-color meta tag with selected theme

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -75,7 +75,7 @@ export const meta: MetaFunction = ({data}) => {
     'Come check out how Kent C. Dodds can help you level up your career as a software engineer.'
   return {
     viewport: 'width=device-width,initial-scale=1,viewport-fit=cover',
-    'theme-color': '#A9ADC1',
+    'theme-color': requestInfo?.session.theme === 'dark' ? '#1F2028' : '#FFF',
     ...getSocialMetas({
       origin: requestInfo?.origin ?? '',
       keywords:


### PR DESCRIPTION
Hi!

Big fan. Reading some of the articles on an iPhone running iOS 15 made me want to change the `theme-color` of the page. So this mini PR does just that. But I do understand if this is something not desired, as the `theme-color` was explicitly set to be a middleground `#A9ADC1`. With this change, the theme is set based on the background color of the body for the two themes.

|          | Before | After | 
|:-----|:----:|:-----:|
| dark |    ![IMG_1761](https://user-images.githubusercontent.com/31474146/170128877-9eb74ada-385e-4b20-9d43-598c3d14aab0.PNG)   |    ![IMG_1760](https://user-images.githubusercontent.com/31474146/170128867-014ac4ab-6c73-466f-8a30-28a219fa82ea.PNG)     |
| light |    ![IMG_1762](https://user-images.githubusercontent.com/31474146/170128880-7b8b7e14-ca3e-4e07-9c9b-1b8b9b791434.PNG)     |  ![IMG_1763](https://user-images.githubusercontent.com/31474146/170128882-2fe0e26d-72a4-4204-9eb0-2db582722296.PNG) |      

## Alternative approaches

### Media query
I could leverage the media query available instead, but as I noticed you opted to keep theming to the requestInfo session, I opted to have it depend on that. 

```js
// something like this would do
'theme-color-dark': {
 httpEquiv: 'theme-color',
 media: "(prefers-color-scheme: dark)",
 content: '#1f2028'
}

```


### Not hardcoding the theme-color.

Since the background in this PR is hardcoded, I tried using querySelector and grabbing the background color of the body, but as I have no prior experience with Remix, it seemed to dislike that. 

```js
// the rough idea was 
const bgColor = getComputedStyle(document.querySelector('body')).backgroundColor
```

Essentially, a mismatch between server rendered HTML and client rendered HTML.



## Wrap up
Ultimately, this is what I came up with, which makes the experience on iPhones a bit more smooth.
I'm happy to improve on this if desired.

