### PR TITLE
Scrollbar color now follows theme (fix)

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -36,6 +36,7 @@
   --border-secondary: var(--color-gray-200);
   --text-primary: var(--color-black);
   --text-secondary: var(--color-gray-500);
+  color-scheme: light;
 }
 
 .dark {


### PR DESCRIPTION
This is to fix a regression caused by #350 in which the scrollbar is stuck in dark mode even after changing to light mode.
No idea atm why this happened, It was working fine locally.