### PR TITLE
Fix duplicate router issue

### DIFF
--- a/content/blog/how-i-structure-express-apps.mdx
+++ b/content/blog/how-i-structure-express-apps.mdx
@@ -338,7 +338,7 @@ function getRoutes() {
   // create a router for all the routes of our app
   const router = express.Router()
 
-  router.use('/math', getMathRoutes())
+  router.use('/math', getMathRoutes(router))
   // any additional routes would go here
 
   return router
@@ -357,8 +357,8 @@ import express from 'express'
 // A function to get the routes.
 // That way all the route definitions are in one place which I like.
 // This is the only thing that's exported
-function getMathRoutes() {
-  const router = express.Router()
+// Provide a router instance to attach routing methods
+function getMathRoutes(router) {
   router.get('/add', add)
   router.get('/subtract', subtract)
   return router


### PR DESCRIPTION
TL;DR: Provide router instance to route methods.

Great article sir. I have one small change that cropped up when I was implementing this solution. You actually declare two routers one in the getRoutes() method and one in the getMathRoutes() method. This was causing an issue where the routes weren't mounting to the server instance because one router was being returned while two were created. So I simply made the change to provide the router instance to the route methods I wanted mounted, I saw you had a github link for it so figured I'd just do a quick PR. 

Keep up the great work.