### PR TITLE
Fix typo in Rest/Spread code snippet

### DIFF
--- a/content/blog/javascript-to-know-for-react.mdx
+++ b/content/blog/javascript-to-know-for-react.mdx
@@ -286,7 +286,7 @@ const obj2 = {
   c: 'c from obj2',
   d: {
     g: 'g from obj2',
-    h: 'g from obj2',
+    h: 'h from obj2',
   },
 }
 console.log({...obj1, ...obj2})


### PR DESCRIPTION
In the code snippet for Rest/Spread in the "JS to know for React" page, each key in the object `obj2` is set to a value of `'{key} from obj2'`.  The `h` key is erroneously being set to `'g from obj2'`.