### PR TITLE
feat: add Japanese translations for 2 articles about testing

### DIFF
--- a/content/blog/making-your-ui-tests-resilient-to-change.mdx
+++ b/content/blog/making-your-ui-tests-resilient-to-change.mdx
@@ -14,6 +14,8 @@ meta:
 translations:
   - language: 繁體中文
     link: https://medium.com/enjoy-life-enjoy-coding/react-unit-test-%E8%AE%93%E4%BD%A0%E7%9A%84-ui-%E6%B8%AC%E8%A9%A6%E9%81%A9%E6%87%89%E8%AE%8A%E5%8C%96-%E7%BF%BB%E8%AD%AF-b9b2c1c4110f
+  - language: 日本語
+    link: https://makotot.dev/posts/making-your-ui-tests-resilient-to-change-translation-ja
 bannerCloudinaryId: unsplash/photo-1492567291473-fe3dfc175b45
 bannerCredit: Photo by [Warren Wong](https://unsplash.com/photos/tHiGKAJxaA8)
 ---

--- a/content/blog/ui-testing-myths.mdx
+++ b/content/blog/ui-testing-myths.mdx
@@ -6,6 +6,9 @@ meta:
   keywords:
     - react
     - testing
+translations:
+  - language: 日本語
+    link: https://makotot.dev/posts/ui-testing-myth-translation-ja
 bannerCloudinaryId: unsplash/photo-1541414779316-956a5084c0d4
 bannerCredit: Photo by [Geran de Klerk](https://unsplash.com/photos/KsMD_tAdjg0)
 ---


### PR DESCRIPTION
I'd like to add links to Japanese translations of 2 articles.