### PR TITLE
fix for incorrect lines highlighted

### DIFF
--- a/content/blog/super-simple-start-to-remix.mdx
+++ b/content/blog/super-simple-start-to-remix.mdx
@@ -550,7 +550,7 @@ One other thing we'll want to do is set the `NODE_ENV` to `production` so any
 dependencies we use that operate slightly differently in production mode will
 work as expected, so let's add `cross-env` and set the `NODE_ENV` with that:
 
-```json lines=6,11 filename=package.json
+```json lines=5,10 filename=package.json
 {
   "scripts": {
     "build": "remix build",


### PR DESCRIPTION
These two highlighted lines should (I'm assuming) be the lines mentioning `cross-env`, above them.

![image](https://user-images.githubusercontent.com/142162/196618372-7e2c418b-dd91-4613-9c3d-be649255ac9e.png)
