### PR TITLE
feat: add spanish translation for blog post colocation

### DIFF
--- a/content/blog/colocation.mdx
+++ b/content/blog/colocation.mdx
@@ -22,6 +22,11 @@ translations:
     author:
       name: Woobyeong
       link: https://github.com/woobottle
+  - language: Español
+    link: https://redradix.com/blog/Colocalizacion/
+    author:
+      name: Aarón Contreras
+      link: https://github.com/acontreras89
 ---
 
 We all want to have codebases that are easy to maintain, so we start out with


### PR DESCRIPTION
Add spanish translation for [Colocation](https://kentcdodds.com/blog/colocation).

The translation can be seen [here](https://redradix.com/blog/Colocalizacion/).