### PR TITLE
feat: add japanese translation for Colocation

### DIFF
--- a/content/blog/colocation.mdx
+++ b/content/blog/colocation.mdx
@@ -27,6 +27,8 @@ translations:
     author:
       name: Aarón Contreras
       link: https://github.com/acontreras89
+  - language: 日本語
+    link: https://makotot.dev/posts/colocation-translation-ja
 ---
 
 We all want to have codebases that are easy to maintain, so we start out with


### PR DESCRIPTION
Added Japanese translation for https://kentcdodds.com/blog/colocation.