### PR TITLE
feat: add japanese translation for aha testing

### DIFF
--- a/content/blog/aha-testing/index.mdx
+++ b/content/blog/aha-testing/index.mdx
@@ -15,6 +15,8 @@ meta:
 translations:
   - language: 简体中文
     link: https://juejin.cn/post/7086704811927666719/
+  - language: 日本語
+    link: https://makotot.dev/posts/aha-testing-translation-ja
 bannerCloudinaryId: unsplash/photo-1522424427542-e6fc86ff5253
 bannerCredit:
   Photo by [Alexandru Goman](https://unsplash.com/photos/CM-qccHaQ04)


### PR DESCRIPTION
The link added in [this PR](https://github.com/kentcdodds/kentcdodds.com/pull/380) has disappeared, so let me add it again.
It has probably been removed in this [commit](https://github.com/kentcdodds/kentcdodds.com/commit/5f19e7b78912c5328bd180fcc2b7c5ff8f4b7ced), but if it was not intentionally deleted, I would like to have it added again 🙏 