### PR TITLE
added a Japanese translation for Get a catch block error message with TypeScript

### DIFF
--- a/content/blog/get-a-catch-block-error-message-with-typescript.mdx
+++ b/content/blog/get-a-catch-block-error-message-with-typescript.mdx
@@ -22,6 +22,11 @@ translations:
     author:
       name: Marlon E. Ruttmann
       link: https://www.linkedin.com/in/marlon-ruttmann/
+  - language: 日本語
+    link: https://note.com/lada496/n/n88c5aab6d0f9
+    author:
+      name: Lada496
+      link: https://github.com/Lada496
 bannerCloudinaryId: unsplash/photo-1525785967371-87ba44b3e6cf
 bannerAlt: brown and white cat in shallow focus shot
 bannerCredit: Photo by [傅甬 华](https://unsplash.com/photos/tEMU4lzAL0w)


### PR DESCRIPTION
Added a Japanese translation for [Get a catch block error message with TypeScript](https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript)