### PR TITLE
add a white container around the testing trophy to make it look better

### DIFF
--- a/content/blog/the-testing-trophy-and-testing-classifications.mdx
+++ b/content/blog/the-testing-trophy-and-testing-classifications.mdx
@@ -20,7 +20,11 @@ bannerCredit: Photo by [Fauzan Saari](https://unsplash.com/photos/Y_upPEyxXN8)
 Allow me to indulge in a little personal history. If you're unfamiliar with the
 testing trophy, here it is:
 
-![Illustration of a trophy separated into 4 sections labeled from top to bottom: End to End, Integration, Unit, Static](https://res.cloudinary.com/kentcdodds-com/image/upload/v1622744540/kentcdodds.com/blog/the-testing-trophy-and-testing-classifications/trophy_wx9aen.png)
+<div style={{backgroundColor: 'white', padding: 30, borderRadius: '0.5rem'}}>
+  ![Illustration of a trophy separated into 4 sections labeled from top to
+  bottom: End to End, Integration, Unit,
+  Static](https://res.cloudinary.com/kentcdodds-com/image/upload/v1622744540/kentcdodds.com/blog/the-testing-trophy-and-testing-classifications/trophy_wx9aen.png)
+</div>
 
 I initially introduced this in a tweet with a quick drawing I made with Google
 Drive:


### PR DESCRIPTION
## Problem
The Testing Trophy image lacks padding around its edges, which causes it to appear odd on dark mode.

![image](https://user-images.githubusercontent.com/26747997/222984001-9adf22cc-4b54-4940-8d60-6a4eabbc6c27.png)


## Solution
Inspiration by the solution found on the article [Static vs Unit vs Integration vs E2E Testing for Frontend Apps](https://kentcdodds.com/blog/static-vs-unit-vs-integration-vs-e2e-tests), this PR suggests the same solution for the Testing Trophy image on the [The Testing Trophy and Testing Classifications](https://kentcdodds.com/blog/the-testing-trophy-and-testing-classifications) article as well.

