### PR TITLE
update chinese translation link

### DIFF
--- a/content/blog/application-state-management-with-react.mdx
+++ b/content/blog/application-state-management-with-react.mdx
@@ -22,7 +22,7 @@ translations:
   - language: 한국어
     link: https://im-developer.tistory.com/222
   - language: 中文
-    link: https://liyanlance.github.io/docs/react-state-management
+    link: https://liyanlance.github.io/#/frontend/react-state-management
     author:
       name: Li Yan
       link: https://liyanlance.github.io/


### PR DESCRIPTION
The original link is no longer working. It seems the author has rephrased his articles' links on his site.