### PR TITLE
fix: broken meta on single call's  episode page

### DIFF
--- a/app/routes/calls+/$season.$episode_.$slug.tsx
+++ b/app/routes/calls+/$season.$episode_.$slug.tsx
@@ -48,11 +48,11 @@ export const handle: KCDHandle = {
 
 export const meta: V2_MetaFunction<
   typeof loader,
-  {root: RootLoaderType; 'routes/calls+/_calls': typeof callsLoader}
+  {root: RootLoaderType; 'routes/calls': typeof callsLoader}
 > = ({matches, params}) => {
   const {requestInfo} = matches.find(m => m.id === 'root')
     ?.data as RootLoaderData
-  const callsData = matches.find(m => m.id === 'routes/calls+/_calls')?.data as
+  const callsData = matches.find(m => m.id === 'routes/calls')?.data as
     | CallsLoaderData
     | undefined
   if (!callsData) {


### PR DESCRIPTION
Noticed the meta func is broken on single episodes of Call Kent Podcast.
E.g. https://kentcdodds.com/calls/04/07/remix-full-stack-components-vs-server-components has a page title of "Call not found"
![image](https://github.com/kentcdodds/kentcdodds.com/assets/26747997/d6911c4b-7c87-4dcf-ab7e-ca29dd1b9265)

Please check this on your side as well because I couldn't fully verify the solution as some e2e tests were already broken.

Thanks!