### PR TITLE
feat(mocks): updates msw to version 2 using intuita #2

### DIFF
--- a/mocks/convert-kit.ts
+++ b/mocks/convert-kit.ts
@@ -14,7 +14,7 @@ type RequestBody = {
 const convertKitHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.convertkit.com/v3/subscribers',
-    (req, res, ctx) => {
+    () => {
       return HttpResponse.json({
         total_subscribers: 0,
         page: 1,
@@ -25,7 +25,7 @@ const convertKitHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.convertkit.com/v3/subscribers/:subscriberId/tags',
-    (req, res, ctx) => {
+    () => {
       return HttpResponse.json({
         tags: [
           {
@@ -39,7 +39,7 @@ const convertKitHandlers: Array<HttpHandler> = [
   ),
   http.post<any, RequestBody>(
     'https://api.convertkit.com/v3/forms/:formId/subscribe',
-    async (req, res, ctx) => {
+    async ({request, params}) => {
       const body = await request.json()
       const {formId} = params
       const {first_name, email, fields} = body
@@ -66,7 +66,7 @@ const convertKitHandlers: Array<HttpHandler> = [
   ),
   http.post<any, RequestBody>(
     'https://api.convertkit.com/v3/tags/:tagId/subscribe',
-    async (req, res, ctx) => {
+    async ({request, params}) => {
       const body = await request.json()
       const {tagId} = params
       const {first_name, email, fields} = body

--- a/mocks/convert-kit.ts
+++ b/mocks/convert-kit.ts
@@ -1,8 +1,8 @@
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 
 type RequestBody = {
@@ -12,9 +12,9 @@ type RequestBody = {
 }
 
 const convertKitHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get('https://api.convertkit.com/v3/subscribers', (req, res, ctx) => {
+  http.get('https://api.convertkit.com/v3/subscribers', (req, res, ctx) => {
     return res(
       ctx.json({
         total_subscribers: 0,
@@ -24,7 +24,7 @@ const convertKitHandlers: Array<
       }),
     )
   }),
-  rest.get(
+  http.get(
     'https://api.convertkit.com/v3/subscribers/:subscriberId/tags',
     (req, res, ctx) => {
       return res(
@@ -40,7 +40,7 @@ const convertKitHandlers: Array<
       )
     },
   ),
-  rest.post(
+  http.post(
     'https://api.convertkit.com/v3/forms/:formId/subscribe',
     (req, res, ctx) => {
       const {formId} = req.params
@@ -68,7 +68,7 @@ const convertKitHandlers: Array<
       )
     },
   ),
-  rest.post(
+  http.post(
     'https://api.convertkit.com/v3/tags/:tagId/subscribe',
     (req, res, ctx) => {
       const {tagId} = req.params

--- a/mocks/convert-kit.ts
+++ b/mocks/convert-kit.ts
@@ -38,9 +38,10 @@ const convertKitHandlers: Array<HttpHandler> = [
   ),
   http.post<any, RequestBody>(
     'https://api.convertkit.com/v3/forms/:formId/subscribe',
-    (req, res, ctx) => {
-      const {formId} = req.params
-      const {first_name, email, fields} = req.body
+    async (req, res, ctx) => {
+      const body = await request.json()
+      const {formId} = params
+      const {first_name, email, fields} = body
       return res(
         ctx.json({
           subscription: {
@@ -66,9 +67,10 @@ const convertKitHandlers: Array<HttpHandler> = [
   ),
   http.post<any, RequestBody>(
     'https://api.convertkit.com/v3/tags/:tagId/subscribe',
-    (req, res, ctx) => {
-      const {tagId} = req.params
-      const {first_name, email, fields} = req.body
+    async (req, res, ctx) => {
+      const body = await request.json()
+      const {tagId} = params
+      const {first_name, email, fields} = body
       return res(
         ctx.json({
           subscription: {

--- a/mocks/convert-kit.ts
+++ b/mocks/convert-kit.ts
@@ -1,9 +1,4 @@
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 
 type RequestBody = {
   first_name: string
@@ -11,20 +6,21 @@ type RequestBody = {
   fields: Array<string>
 }
 
-const convertKitHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get('https://api.convertkit.com/v3/subscribers', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        total_subscribers: 0,
-        page: 1,
-        total_pages: 1,
-        subscribers: [],
-      }),
-    )
-  }),
-  http.get(
+const convertKitHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://api.convertkit.com/v3/subscribers',
+    (req, res, ctx) => {
+      return res(
+        ctx.json({
+          total_subscribers: 0,
+          page: 1,
+          total_pages: 1,
+          subscribers: [],
+        }),
+      )
+    },
+  ),
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.convertkit.com/v3/subscribers/:subscriberId/tags',
     (req, res, ctx) => {
       return res(
@@ -40,11 +36,11 @@ const convertKitHandlers: Array<
       )
     },
   ),
-  http.post(
+  http.post<any, RequestBody>(
     'https://api.convertkit.com/v3/forms/:formId/subscribe',
     (req, res, ctx) => {
       const {formId} = req.params
-      const {first_name, email, fields} = req.body as RequestBody
+      const {first_name, email, fields} = req.body
       return res(
         ctx.json({
           subscription: {
@@ -68,11 +64,11 @@ const convertKitHandlers: Array<
       )
     },
   ),
-  http.post(
+  http.post<any, RequestBody>(
     'https://api.convertkit.com/v3/tags/:tagId/subscribe',
     (req, res, ctx) => {
       const {tagId} = req.params
-      const {first_name, email, fields} = req.body as RequestBody
+      const {first_name, email, fields} = req.body
       return res(
         ctx.json({
           subscription: {

--- a/mocks/convert-kit.ts
+++ b/mocks/convert-kit.ts
@@ -1,4 +1,9 @@
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 
 type RequestBody = {
   first_name: string
@@ -10,30 +15,26 @@ const convertKitHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.convertkit.com/v3/subscribers',
     (req, res, ctx) => {
-      return res(
-        ctx.json({
-          total_subscribers: 0,
-          page: 1,
-          total_pages: 1,
-          subscribers: [],
-        }),
-      )
+      return HttpResponse.json({
+        total_subscribers: 0,
+        page: 1,
+        total_pages: 1,
+        subscribers: [],
+      })
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.convertkit.com/v3/subscribers/:subscriberId/tags',
     (req, res, ctx) => {
-      return res(
-        ctx.json({
-          tags: [
-            {
-              id: 1,
-              name: 'Subscribed: general newsletter',
-              created_at: '2021-06-09T17:54:22Z',
-            },
-          ],
-        }),
-      )
+      return HttpResponse.json({
+        tags: [
+          {
+            id: 1,
+            name: 'Subscribed: general newsletter',
+            created_at: '2021-06-09T17:54:22Z',
+          },
+        ],
+      })
     },
   ),
   http.post<any, RequestBody>(
@@ -42,27 +43,25 @@ const convertKitHandlers: Array<HttpHandler> = [
       const body = await request.json()
       const {formId} = params
       const {first_name, email, fields} = body
-      return res(
-        ctx.json({
-          subscription: {
-            id: 1234567890,
-            state: 'active',
+      return HttpResponse.json({
+        subscription: {
+          id: 1234567890,
+          state: 'active',
+          created_at: new Date().toJSON(),
+          source: 'API::V3::SubscriptionsController (external)',
+          referrer: null,
+          subscribable_id: formId,
+          subscribable_type: 'form',
+          subscriber: {
+            id: 987654321,
+            first_name,
+            email_address: email,
+            state: 'inactive',
             created_at: new Date().toJSON(),
-            source: 'API::V3::SubscriptionsController (external)',
-            referrer: null,
-            subscribable_id: formId,
-            subscribable_type: 'form',
-            subscriber: {
-              id: 987654321,
-              first_name,
-              email_address: email,
-              state: 'inactive',
-              created_at: new Date().toJSON(),
-              fields,
-            },
+            fields,
           },
-        }),
-      )
+        },
+      })
     },
   ),
   http.post<any, RequestBody>(
@@ -71,27 +70,25 @@ const convertKitHandlers: Array<HttpHandler> = [
       const body = await request.json()
       const {tagId} = params
       const {first_name, email, fields} = body
-      return res(
-        ctx.json({
-          subscription: {
-            id: 1234567890,
-            state: 'active',
+      return HttpResponse.json({
+        subscription: {
+          id: 1234567890,
+          state: 'active',
+          created_at: new Date().toJSON(),
+          source: 'API::V3::SubscriptionsController (external)',
+          referrer: null,
+          subscribable_id: tagId,
+          subscribable_type: 'tag',
+          subscriber: {
+            id: 987654321,
+            first_name,
+            email_address: email,
+            state: 'inactive',
             created_at: new Date().toJSON(),
-            source: 'API::V3::SubscriptionsController (external)',
-            referrer: null,
-            subscribable_id: tagId,
-            subscribable_type: 'tag',
-            subscriber: {
-              id: 987654321,
-              first_name,
-              email_address: email,
-              state: 'inactive',
-              created_at: new Date().toJSON(),
-              fields,
-            },
+            fields,
           },
-        }),
-      )
+        },
+      })
     },
   ),
 ]

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -1,13 +1,8 @@
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type HttpHandler,
-  HttpResponse,
-} from 'msw'
+import {HttpResponse, http, type DefaultBodyType, type HttpHandler} from 'msw'
 import {requiredHeader, requiredParam} from './utils.ts'
 
 const discordHandlers: Array<HttpHandler> = [
-  http.post<any, DefaultRequestMultipartBody>(
+  http.post<any, DefaultBodyType>(
     'https://discord.com/api/oauth2/token',
     async ({request}) => {
       const body = await request.text()
@@ -35,7 +30,7 @@ const discordHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.get<any, DefaultRequestMultipartBody>(
+  http.get<any, DefaultBodyType>(
     'https://discord.com/api/users/:userId',
     async ({request}) => {
       requiredHeader(request.headers, 'Authorization')
@@ -47,7 +42,7 @@ const discordHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.get<any, DefaultRequestMultipartBody>(
+  http.get<any, DefaultBodyType>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async ({request, params}) => {
       requiredHeader(request.headers, 'Authorization')
@@ -64,7 +59,7 @@ const discordHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.put<any, DefaultRequestMultipartBody>(
+  http.put<any, DefaultBodyType>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async ({request}) => {
       requiredHeader(request.headers, 'Authorization')
@@ -85,7 +80,7 @@ const discordHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.patch<any, DefaultRequestMultipartBody>(
+  http.patch<any, DefaultBodyType>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async ({request}) => {
       requiredHeader(request.headers, 'Authorization')
@@ -104,7 +99,7 @@ const discordHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.get<any, DefaultRequestMultipartBody>(
+  http.get<any, DefaultBodyType>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async ({request}) => {
       requiredHeader(request.headers, 'Authorization')
@@ -115,7 +110,7 @@ const discordHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.post<any, DefaultRequestMultipartBody>(
+  http.post<any, DefaultBodyType>(
     'https://discord.com/api/channels/:channelId/messages',
     async ({request, params}) => {
       requiredHeader(request.headers, 'Authorization')

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -1,52 +1,51 @@
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 import {requiredHeader, requiredParam} from './utils.ts'
 
-const discordHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.post('https://discord.com/api/oauth2/token', async (req, res, ctx) => {
-    const body = await req.text()
-    if (typeof body !== 'string') {
-      throw new Error('request body must be a string of URLSearchParams')
-    }
-    if (
-      req.headers.get('Content-Type') !== 'application/x-www-form-urlencoded'
-    ) {
-      throw new Error(
-        'Content-Type header must be "application/x-www-form-urlencoded"',
+const discordHandlers: Array<HttpHandler> = [
+  http.post<any, DefaultRequestMultipartBody>(
+    'https://discord.com/api/oauth2/token',
+    async (req, res, ctx) => {
+      const body = await req.text()
+      if (typeof body !== 'string') {
+        throw new Error('request body must be a string of URLSearchParams')
+      }
+      if (
+        req.headers.get('Content-Type') !== 'application/x-www-form-urlencoded'
+      ) {
+        throw new Error(
+          'Content-Type header must be "application/x-www-form-urlencoded"',
+        )
+      }
+      const params = new URLSearchParams(body)
+      requiredParam(params, 'client_id')
+      requiredParam(params, 'client_secret')
+      requiredParam(params, 'grant_type')
+      requiredParam(params, 'redirect_uri')
+      requiredParam(params, 'scope')
+      return res(
+        ctx.json({
+          token_type: 'test_token_type',
+          access_token: 'test_access_token',
+        }),
       )
-    }
-    const params = new URLSearchParams(body)
-    requiredParam(params, 'client_id')
-    requiredParam(params, 'client_secret')
-    requiredParam(params, 'grant_type')
-    requiredParam(params, 'redirect_uri')
-    requiredParam(params, 'scope')
-    return res(
-      ctx.json({
-        token_type: 'test_token_type',
-        access_token: 'test_access_token',
-      }),
-    )
-  }),
+    },
+  ),
 
-  http.get('https://discord.com/api/users/:userId', async (req, res, ctx) => {
-    requiredHeader(req.headers, 'Authorization')
-    return res(
-      ctx.json({
-        id: 'test_discord_id',
-        username: 'test_discord_username',
-        discriminator: '0000',
-      }),
-    )
-  }),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://discord.com/api/users/:userId',
+    async (req, res, ctx) => {
+      requiredHeader(req.headers, 'Authorization')
+      return res(
+        ctx.json({
+          id: 'test_discord_id',
+          username: 'test_discord_username',
+          discriminator: '0000',
+        }),
+      )
+    },
+  ),
 
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -65,7 +64,7 @@ const discordHandlers: Array<
     },
   ),
 
-  http.put(
+  http.put<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -88,7 +87,7 @@ const discordHandlers: Array<
     },
   ),
 
-  http.patch(
+  http.patch<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -109,7 +108,7 @@ const discordHandlers: Array<
     },
   ),
 
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -122,7 +121,7 @@ const discordHandlers: Array<
     },
   ),
 
-  http.post(
+  http.post<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/channels/:channelId/messages',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -1,4 +1,9 @@
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 import {requiredHeader, requiredParam} from './utils.ts'
 
 const discordHandlers: Array<HttpHandler> = [
@@ -22,12 +27,10 @@ const discordHandlers: Array<HttpHandler> = [
       requiredParam(params, 'grant_type')
       requiredParam(params, 'redirect_uri')
       requiredParam(params, 'scope')
-      return res(
-        ctx.json({
-          token_type: 'test_token_type',
-          access_token: 'test_access_token',
-        }),
-      )
+      return HttpResponse.json({
+        token_type: 'test_token_type',
+        access_token: 'test_access_token',
+      })
     },
   ),
 
@@ -35,13 +38,11 @@ const discordHandlers: Array<HttpHandler> = [
     'https://discord.com/api/users/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
-      return res(
-        ctx.json({
-          id: 'test_discord_id',
-          username: 'test_discord_username',
-          discriminator: '0000',
-        }),
-      )
+      return HttpResponse.json({
+        id: 'test_discord_id',
+        username: 'test_discord_username',
+        discriminator: '0000',
+      })
     },
   ),
 
@@ -54,13 +55,11 @@ const discordHandlers: Array<HttpHandler> = [
         username: `${params.userId}username`,
         discriminator: '0000',
       }
-      return res(
-        ctx.json({
-          user,
-          roles: [],
-          ...user,
-        }),
-      )
+      return HttpResponse.json({
+        user,
+        roles: [],
+        ...user,
+      })
     },
   ),
 
@@ -79,11 +78,9 @@ const discordHandlers: Array<HttpHandler> = [
           `access_token required in the body, but not found in ${bodyString}`,
         )
       }
-      return res(
-        ctx.json({
-          // We don't use this response for now so we'll leave this empty
-        }),
-      )
+      return HttpResponse.json({
+        // We don't use this response for now so we'll leave this empty
+      })
     },
   ),
 
@@ -100,11 +97,9 @@ const discordHandlers: Array<HttpHandler> = [
           'patch request to member must include a roles array with the new role',
         )
       }
-      return res(
-        ctx.json({
-          // We don't use this response for now so we'll leave this empty
-        }),
-      )
+      return HttpResponse.json({
+        // We don't use this response for now so we'll leave this empty
+      })
     },
   ),
 
@@ -112,12 +107,10 @@ const discordHandlers: Array<HttpHandler> = [
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
-      return res(
-        ctx.json({
-          user: {id: 'test_discord_id', username: 'test_username'},
-          roles: [],
-        }),
-      )
+      return HttpResponse.json({
+        user: {id: 'test_discord_id', username: 'test_username'},
+        roles: [],
+      })
     },
   ),
 
@@ -136,11 +129,9 @@ const discordHandlers: Array<HttpHandler> = [
         body?.content,
       )
 
-      return res(
-        ctx.json({
-          /* we ignore the response */
-        }),
-      )
+      return HttpResponse.json({
+        /* we ignore the response */
+      })
     },
   ),
 ]

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -9,13 +9,14 @@ import {requiredHeader, requiredParam} from './utils.ts'
 const discordHandlers: Array<HttpHandler> = [
   http.post<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/oauth2/token',
-    async (req, res, ctx) => {
-      const body = await req.text()
+    async ({request}) => {
+      const body = await request.text()
       if (typeof body !== 'string') {
         throw new Error('request body must be a string of URLSearchParams')
       }
       if (
-        req.headers.get('Content-Type') !== 'application/x-www-form-urlencoded'
+        request.headers.get('Content-Type') !==
+        'application/x-www-form-urlencoded'
       ) {
         throw new Error(
           'Content-Type header must be "application/x-www-form-urlencoded"',
@@ -36,8 +37,8 @@ const discordHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/users/:userId',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'Authorization')
+    async ({request}) => {
+      requiredHeader(request.headers, 'Authorization')
       return HttpResponse.json({
         id: 'test_discord_id',
         username: 'test_discord_username',
@@ -48,8 +49,8 @@ const discordHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'Authorization')
+    async ({request, params}) => {
+      requiredHeader(request.headers, 'Authorization')
       const user = {
         id: params.userId,
         username: `${params.userId}username`,
@@ -65,9 +66,9 @@ const discordHandlers: Array<HttpHandler> = [
 
   http.put<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'Authorization')
-      const body = await req.json()
+    async ({request}) => {
+      requiredHeader(request.headers, 'Authorization')
+      const body = await request.json()
       if (typeof body !== 'object') {
         console.error('Request body:', body)
         throw new Error('Request body must be a JSON object')
@@ -86,9 +87,9 @@ const discordHandlers: Array<HttpHandler> = [
 
   http.patch<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'Authorization')
-      const body = await req.json()
+    async ({request}) => {
+      requiredHeader(request.headers, 'Authorization')
+      const body = await request.json()
       if (typeof body !== 'object') {
         throw new Error('patch request to member must have a JSON body')
       }
@@ -105,8 +106,8 @@ const discordHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/guilds/:guildId/members/:userId',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'Authorization')
+    async ({request}) => {
+      requiredHeader(request.headers, 'Authorization')
       return HttpResponse.json({
         user: {id: 'test_discord_id', username: 'test_username'},
         roles: [],
@@ -116,9 +117,9 @@ const discordHandlers: Array<HttpHandler> = [
 
   http.post<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/channels/:channelId/messages',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'Authorization')
-      const body = await req.json()
+    async ({request, params}) => {
+      requiredHeader(request.headers, 'Authorization')
+      const body = await request.json()
       if (typeof body !== 'object') {
         console.error('Request body:', body)
         throw new Error('Request body must be a JSON object')

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -1,15 +1,15 @@
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 import {requiredHeader, requiredParam} from './utils.ts'
 
 const discordHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.post('https://discord.com/api/oauth2/token', async (req, res, ctx) => {
+  http.post('https://discord.com/api/oauth2/token', async (req, res, ctx) => {
     const body = await req.text()
     if (typeof body !== 'string') {
       throw new Error('request body must be a string of URLSearchParams')
@@ -35,7 +35,7 @@ const discordHandlers: Array<
     )
   }),
 
-  rest.get('https://discord.com/api/users/:userId', async (req, res, ctx) => {
+  http.get('https://discord.com/api/users/:userId', async (req, res, ctx) => {
     requiredHeader(req.headers, 'Authorization')
     return res(
       ctx.json({
@@ -46,7 +46,7 @@ const discordHandlers: Array<
     )
   }),
 
-  rest.get(
+  http.get(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -65,7 +65,7 @@ const discordHandlers: Array<
     },
   ),
 
-  rest.put(
+  http.put(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -88,7 +88,7 @@ const discordHandlers: Array<
     },
   ),
 
-  rest.patch(
+  http.patch(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -109,7 +109,7 @@ const discordHandlers: Array<
     },
   ),
 
-  rest.get(
+  http.get(
     'https://discord.com/api/guilds/:guildId/members/:userId',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
@@ -122,7 +122,7 @@ const discordHandlers: Array<
     },
   ),
 
-  rest.post(
+  http.post(
     'https://discord.com/api/channels/:channelId/messages',
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -50,8 +50,8 @@ const discordHandlers: Array<HttpHandler> = [
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'Authorization')
       const user = {
-        id: req.params.userId,
-        username: `${req.params.userId}username`,
+        id: params.userId,
+        username: `${params.userId}username`,
         discriminator: '0000',
       }
       return res(
@@ -132,7 +132,7 @@ const discordHandlers: Array<HttpHandler> = [
       }
 
       console.log(
-        `🤖 Sending bot message to ${req.params.channelId}:\n`,
+        `🤖 Sending bot message to ${params.channelId}:\n`,
         body?.content,
       )
 

--- a/mocks/discord.ts
+++ b/mocks/discord.ts
@@ -1,8 +1,14 @@
-import {HttpResponse, http, type DefaultBodyType, type HttpHandler} from 'msw'
+import {
+  HttpResponse,
+  http,
+  type DefaultBodyType,
+  type HttpHandler,
+  type DefaultRequestMultipartBody,
+} from 'msw'
 import {requiredHeader, requiredParam} from './utils.ts'
 
 const discordHandlers: Array<HttpHandler> = [
-  http.post<any, DefaultBodyType>(
+  http.post<any, DefaultRequestMultipartBody>(
     'https://discord.com/api/oauth2/token',
     async ({request}) => {
       const body = await request.text()

--- a/mocks/github.ts
+++ b/mocks/github.ts
@@ -2,10 +2,10 @@ import * as nodePath from 'path'
 import {fileURLToPath} from 'url'
 import {promises as fs} from 'fs'
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 
 const __dirname = nodePath.dirname(fileURLToPath(import.meta.url))
@@ -52,9 +52,9 @@ type GHContent = {
 }
 
 const githubHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get(
+  http.get(
     `https://api.github.com/repos/:owner/:repo/contents/:path`,
     async (req, res, ctx) => {
       const {owner, repo} = req.params
@@ -133,7 +133,7 @@ const githubHandlers: Array<
       return res(ctx.json(contentDescriptions))
     },
   ),
-  rest.get(
+  http.get(
     `https://api.github.com/repos/:owner/:repo/git/blobs/:sha`,
     async (req, res, ctx) => {
       const {owner, repo} = req.params
@@ -169,7 +169,7 @@ const githubHandlers: Array<
       return res(ctx.json(resource))
     },
   ),
-  rest.get(
+  http.get(
     `https://api.github.com/repos/:owner/:repo/contents/:path*`,
     async (req, res, ctx) => {
       const {owner, repo} = req.params

--- a/mocks/github.ts
+++ b/mocks/github.ts
@@ -1,7 +1,12 @@
 import * as nodePath from 'path'
 import {fileURLToPath} from 'url'
 import {promises as fs} from 'fs'
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 
 const __dirname = nodePath.dirname(fileURLToPath(import.meta.url))
 
@@ -72,25 +77,25 @@ const githubHandlers: Array<HttpHandler> = [
       const isLocalFile = await isFile(localPath)
 
       if (!isLocalDir && !isLocalFile) {
-        return res(
-          ctx.status(404),
-          ctx.json({
+        return HttpResponse.json(
+          {
             message: 'Not Found',
             documentation_url:
               'https://docs.github.com/rest/reference/repos#get-repository-content',
-          }),
+          },
+          {status: 404},
         )
       }
 
       if (isLocalFile) {
         const encoding = 'base64' as const
         const content = await fs.readFile(localPath, {encoding: 'utf-8'})
-        return res(
-          ctx.status(200),
-          ctx.json({
+        return HttpResponse.json(
+          {
             content: Buffer.from(content, 'utf-8').toString(encoding),
             encoding,
-          }),
+          },
+          {status: 200},
         )
       }
 
@@ -124,7 +129,7 @@ const githubHandlers: Array<HttpHandler> = [
         }),
       )
 
-      return res(ctx.json(contentDescriptions))
+      return HttpResponse.json(contentDescriptions)
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
@@ -160,7 +165,7 @@ const githubHandlers: Array<HttpHandler> = [
         encoding,
       }
 
-      return res(ctx.json(resource))
+      return HttpResponse.json(resource)
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
@@ -187,7 +192,7 @@ const githubHandlers: Array<HttpHandler> = [
         encoding,
       }
 
-      return res(ctx.json(resource))
+      return HttpResponse.json(resource)
     },
   ),
 ]

--- a/mocks/github.ts
+++ b/mocks/github.ts
@@ -54,7 +54,7 @@ type GHContent = {
 const githubHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/contents/:path`,
-    async (req, res, ctx) => {
+    async ({request, params}) => {
       const url = new URL(request.url)
       const {owner, repo} = params
       if (typeof params.path !== 'string') {
@@ -134,7 +134,7 @@ const githubHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/git/blobs/:sha`,
-    async (req, res, ctx) => {
+    async ({params}) => {
       const {owner, repo} = params
       if (typeof params.sha !== 'string') {
         throw new Error('req.params.sha must be a string')
@@ -170,7 +170,7 @@ const githubHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/contents/:path*`,
-    async (req, res, ctx) => {
+    async ({params}) => {
       const {owner, repo} = params
 
       const relativePath = params.path

--- a/mocks/github.ts
+++ b/mocks/github.ts
@@ -50,11 +50,12 @@ const githubHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/contents/:path`,
     async (req, res, ctx) => {
-      const {owner, repo} = req.params
-      if (typeof req.params.path !== 'string') {
+      const url = new URL(request.url)
+      const {owner, repo} = params
+      if (typeof params.path !== 'string') {
         throw new Error('req.params.path must be a string')
       }
-      const path = decodeURIComponent(req.params.path).trim()
+      const path = decodeURIComponent(params.path).trim()
       const isMockable =
         owner === 'kentcdodds' &&
         repo === 'kentcdodds.com' &&
@@ -109,13 +110,13 @@ const githubHandlers: Array<HttpHandler> = [
             path: relativePath,
             sha,
             size,
-            url: `https://api.github.com/repos/${owner}/${repo}/contents/${path}?${req.url.searchParams}`,
+            url: `https://api.github.com/repos/${owner}/${repo}/contents/${path}?${url.searchParams}`,
             html_url: `https://github.com/${owner}/${repo}/tree/main/${path}`,
             git_url: `https://api.github.com/repos/${owner}/${repo}/git/trees/${sha}`,
             download_url: null,
             type: isDir ? 'dir' : 'file',
             _links: {
-              self: `https://api.github.com/repos/${owner}/${repo}/contents/${path}${req.url.searchParams}`,
+              self: `https://api.github.com/repos/${owner}/${repo}/contents/${path}${url.searchParams}`,
               git: `https://api.github.com/repos/${owner}/${repo}/git/trees/${sha}`,
               html: `https://github.com/${owner}/${repo}/tree/main/${path}`,
             },
@@ -129,11 +130,11 @@ const githubHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/git/blobs/:sha`,
     async (req, res, ctx) => {
-      const {owner, repo} = req.params
-      if (typeof req.params.sha !== 'string') {
+      const {owner, repo} = params
+      if (typeof params.sha !== 'string') {
         throw new Error('req.params.sha must be a string')
       }
-      const sha = decodeURIComponent(req.params.sha).trim().replace(/\\/g, '/')
+      const sha = decodeURIComponent(params.sha).trim().replace(/\\/g, '/')
       // if the sha includes a "/" that means it's not a sha but a relativePath
       // and therefore the client is getting content it got from the local
       // mock environment, not the actual github API.
@@ -165,9 +166,9 @@ const githubHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/contents/:path*`,
     async (req, res, ctx) => {
-      const {owner, repo} = req.params
+      const {owner, repo} = params
 
-      const relativePath = req.params.path
+      const relativePath = params.path
       if (typeof relativePath !== 'string') {
         throw new Error('req.params.path must be a string')
       }
@@ -179,7 +180,7 @@ const githubHandlers: Array<HttpHandler> = [
 
       const resource: GHContent = {
         sha,
-        node_id: `${req.params.path}_node_id`,
+        node_id: `${params.path}_node_id`,
         size,
         url: `https://api.github.com/repos/${owner}/${repo}/git/blobs/${sha}`,
         content: Buffer.from(content, 'utf-8').toString(encoding),

--- a/mocks/github.ts
+++ b/mocks/github.ts
@@ -1,12 +1,7 @@
 import * as nodePath from 'path'
 import {fileURLToPath} from 'url'
 import {promises as fs} from 'fs'
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 
 const __dirname = nodePath.dirname(fileURLToPath(import.meta.url))
 
@@ -51,10 +46,8 @@ type GHContent = {
   encoding: 'base64'
 }
 
-const githubHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get(
+const githubHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/contents/:path`,
     async (req, res, ctx) => {
       const {owner, repo} = req.params
@@ -133,7 +126,7 @@ const githubHandlers: Array<
       return res(ctx.json(contentDescriptions))
     },
   ),
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/git/blobs/:sha`,
     async (req, res, ctx) => {
       const {owner, repo} = req.params
@@ -169,7 +162,7 @@ const githubHandlers: Array<
       return res(ctx.json(resource))
     },
   ),
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     `https://api.github.com/repos/:owner/:repo/contents/:path*`,
     async (req, res, ctx) => {
       const {owner, repo} = req.params

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -34,8 +34,8 @@ const miscHandlers = [
   http.post(
     'https://api.mailgun.net/v3/:domain/messages',
     async ({request, params}) => {
-      const reqBody = await request.json()
-      const body = Object.fromEntries(new URLSearchParams(reqBody?.toString()))
+      const reqBody = await request.text()
+      const body = Object.fromEntries(new URLSearchParams(reqBody))
       console.info('🔶 mocked email contents:', body)
 
       if (body.text && body.to) {

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,4 +1,4 @@
-import {http} from 'msw'
+import {http, passthrough} from 'msw'
 import {setupServer} from 'msw/node'
 import {convertKitHandlers} from './convert-kit.ts'
 import {discordHandlers} from './discord.ts'
@@ -15,12 +15,12 @@ const remix = process.env.REMIX_DEV_HTTP_ORIGIN as string
 // put one-off handlers that don't really need an entire file to themselves here
 const miscHandlers = [
   http.post(`${remix}/ping`, req => {
-    return req.passthrough()
+    return passthrough()
   }),
   http.get(
     'https://res.cloudinary.com/kentcdodds-com/image/upload/w_100,q_auto,f_webp,e_blur:1000/unsplash/:photoId',
     async (req, res, ctx) => {
-      if (await isConnectedToTheInternet()) return req.passthrough()
+      if (await isConnectedToTheInternet()) return passthrough()
 
       const base64 =
         'UklGRhoBAABXRUJQVlA4IA4BAABwCgCdASpkAEMAPqVInUq5sy+hqvqpuzAUiWcG+BsvrZQel/iYPLGE154ZiYwzeF8UJRAKZ0oAzLdTpjlp8qBuGwW1ntMTe6iQZbxzyP4gBeg7X7SH7NwyBcUDAAD+8MrTwbAD8OLmsoaL1QDPwEE+GrfqLQPn6xkgFHCB8lyjV3K2RvcQ7pSvgA87LOVuDtMrtkm+tTV0x1RcIe4Uvb6J+yygkV48DSejuyrMWrYgoZyjkf/0/L9+bAZgCam6+oHqjBSWTq5jF7wzBxYwfoGY7OdYZOdeGb4euuuLaCzDHz/QRbDCaIsJWJW3Jo4bkbz44AI/8UfFTGX4tMTRcKLXTDIviU+/u7UnlVaDQAA='
@@ -29,7 +29,7 @@ const miscHandlers = [
     },
   ),
   http.get(/res.cloudinary.com\/kentcdodds-com\//, req => {
-    return req.passthrough()
+    return passthrough()
   }),
   http.post(
     'https://api.mailgun.net/v3/:domain/messages',
@@ -55,13 +55,13 @@ const miscHandlers = [
   http.head(
     'https://www.gravatar.com/avatar/:md5Hash',
     async (req, res, ctx) => {
-      if (await isConnectedToTheInternet()) return req.passthrough()
+      if (await isConnectedToTheInternet()) return passthrough()
 
       return res(ctx.status(404))
     },
   ),
-  http.get(/http:\/\/localhost:\d+\/.*/, async req => req.passthrough()),
-  http.post(/http:\/\/localhost:\d+\/.*/, async req => req.passthrough()),
+  http.get(/http:\/\/localhost:\d+\/.*/, async req => passthrough()),
+  http.post(/http:\/\/localhost:\d+\/.*/, async req => passthrough()),
   http.get('https://verifier.meetchopra.com/verify/:email', (req, res, ctx) => {
     return res(ctx.json({status: true}))
   }),

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -34,7 +34,8 @@ const miscHandlers = [
   http.post(
     'https://api.mailgun.net/v3/:domain/messages',
     async (req, res, ctx) => {
-      const body = Object.fromEntries(new URLSearchParams(req.body?.toString()))
+      const reqBody = await request.json()
+      const body = Object.fromEntries(new URLSearchParams(reqBody?.toString()))
       console.info('🔶 mocked email contents:', body)
 
       if (body.text && body.to) {
@@ -47,7 +48,7 @@ const miscHandlers = [
         })
       }
       const randomId = '20210321210543.1.E01B8B612C44B41B'
-      const id = `<${randomId}>@${req.params.domain}`
+      const id = `<${randomId}>@${params.domain}`
       return res(ctx.json({id, message: 'Queued. Thank you.'}))
     },
   ),

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,4 +1,4 @@
-import {rest} from 'msw'
+import {http} from 'msw'
 import {setupServer} from 'msw/node'
 import {convertKitHandlers} from './convert-kit.ts'
 import {discordHandlers} from './discord.ts'
@@ -14,10 +14,10 @@ const remix = process.env.REMIX_DEV_HTTP_ORIGIN as string
 
 // put one-off handlers that don't really need an entire file to themselves here
 const miscHandlers = [
-  rest.post(`${remix}/ping`, req => {
+  http.post(`${remix}/ping`, req => {
     return req.passthrough()
   }),
-  rest.get(
+  http.get(
     'https://res.cloudinary.com/kentcdodds-com/image/upload/w_100,q_auto,f_webp,e_blur:1000/unsplash/:photoId',
     async (req, res, ctx) => {
       if (await isConnectedToTheInternet()) return req.passthrough()
@@ -28,10 +28,10 @@ const miscHandlers = [
       return res(ctx.body(buffer))
     },
   ),
-  rest.get(/res.cloudinary.com\/kentcdodds-com\//, req => {
+  http.get(/res.cloudinary.com\/kentcdodds-com\//, req => {
     return req.passthrough()
   }),
-  rest.post(
+  http.post(
     'https://api.mailgun.net/v3/:domain/messages',
     async (req, res, ctx) => {
       const body = Object.fromEntries(new URLSearchParams(req.body?.toString()))
@@ -51,7 +51,7 @@ const miscHandlers = [
       return res(ctx.json({id, message: 'Queued. Thank you.'}))
     },
   ),
-  rest.head(
+  http.head(
     'https://www.gravatar.com/avatar/:md5Hash',
     async (req, res, ctx) => {
       if (await isConnectedToTheInternet()) return req.passthrough()
@@ -59,9 +59,9 @@ const miscHandlers = [
       return res(ctx.status(404))
     },
   ),
-  rest.get(/http:\/\/localhost:\d+\/.*/, async req => req.passthrough()),
-  rest.post(/http:\/\/localhost:\d+\/.*/, async req => req.passthrough()),
-  rest.get('https://verifier.meetchopra.com/verify/:email', (req, res, ctx) => {
+  http.get(/http:\/\/localhost:\d+\/.*/, async req => req.passthrough()),
+  http.post(/http:\/\/localhost:\d+\/.*/, async req => req.passthrough()),
+  http.get('https://verifier.meetchopra.com/verify/:email', (req, res, ctx) => {
     return res(ctx.json({status: true}))
   }),
 ]

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,4 +1,4 @@
-import {http, passthrough} from 'msw'
+import {http, passthrough, HttpResponse} from 'msw'
 import {setupServer} from 'msw/node'
 import {convertKitHandlers} from './convert-kit.ts'
 import {discordHandlers} from './discord.ts'
@@ -25,7 +25,7 @@ const miscHandlers = [
       const base64 =
         'UklGRhoBAABXRUJQVlA4IA4BAABwCgCdASpkAEMAPqVInUq5sy+hqvqpuzAUiWcG+BsvrZQel/iYPLGE154ZiYwzeF8UJRAKZ0oAzLdTpjlp8qBuGwW1ntMTe6iQZbxzyP4gBeg7X7SH7NwyBcUDAAD+8MrTwbAD8OLmsoaL1QDPwEE+GrfqLQPn6xkgFHCB8lyjV3K2RvcQ7pSvgA87LOVuDtMrtkm+tTV0x1RcIe4Uvb6J+yygkV48DSejuyrMWrYgoZyjkf/0/L9+bAZgCam6+oHqjBSWTq5jF7wzBxYwfoGY7OdYZOdeGb4euuuLaCzDHz/QRbDCaIsJWJW3Jo4bkbz44AI/8UfFTGX4tMTRcKLXTDIviU+/u7UnlVaDQAA='
       const buffer = Buffer.from(base64)
-      return res(ctx.body(buffer))
+      return HttpResponse.json(buffer)
     },
   ),
   http.get(/res.cloudinary.com\/kentcdodds-com\//, req => {
@@ -49,7 +49,7 @@ const miscHandlers = [
       }
       const randomId = '20210321210543.1.E01B8B612C44B41B'
       const id = `<${randomId}>@${params.domain}`
-      return res(ctx.json({id, message: 'Queued. Thank you.'}))
+      return HttpResponse.json({id, message: 'Queued. Thank you.'})
     },
   ),
   http.head(
@@ -57,13 +57,13 @@ const miscHandlers = [
     async (req, res, ctx) => {
       if (await isConnectedToTheInternet()) return passthrough()
 
-      return res(ctx.status(404))
+      return HttpResponse.json(null, {status: 404})
     },
   ),
   http.get(/http:\/\/localhost:\d+\/.*/, async req => passthrough()),
   http.post(/http:\/\/localhost:\d+\/.*/, async req => passthrough()),
   http.get('https://verifier.meetchopra.com/verify/:email', (req, res, ctx) => {
-    return res(ctx.json({status: true}))
+    return HttpResponse.json({status: true})
   }),
 ]
 

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -14,12 +14,12 @@ const remix = process.env.REMIX_DEV_HTTP_ORIGIN as string
 
 // put one-off handlers that don't really need an entire file to themselves here
 const miscHandlers = [
-  http.post(`${remix}/ping`, req => {
+  http.post(`${remix}/ping`, () => {
     return passthrough()
   }),
   http.get(
     'https://res.cloudinary.com/kentcdodds-com/image/upload/w_100,q_auto,f_webp,e_blur:1000/unsplash/:photoId',
-    async (req, res, ctx) => {
+    async () => {
       if (await isConnectedToTheInternet()) return passthrough()
 
       const base64 =
@@ -28,12 +28,12 @@ const miscHandlers = [
       return HttpResponse.json(buffer)
     },
   ),
-  http.get(/res.cloudinary.com\/kentcdodds-com\//, req => {
+  http.get(/res.cloudinary.com\/kentcdodds-com\//, () => {
     return passthrough()
   }),
   http.post(
     'https://api.mailgun.net/v3/:domain/messages',
-    async (req, res, ctx) => {
+    async ({request, params}) => {
       const reqBody = await request.json()
       const body = Object.fromEntries(new URLSearchParams(reqBody?.toString()))
       console.info('🔶 mocked email contents:', body)
@@ -52,17 +52,14 @@ const miscHandlers = [
       return HttpResponse.json({id, message: 'Queued. Thank you.'})
     },
   ),
-  http.head(
-    'https://www.gravatar.com/avatar/:md5Hash',
-    async (req, res, ctx) => {
-      if (await isConnectedToTheInternet()) return passthrough()
+  http.head('https://www.gravatar.com/avatar/:md5Hash', async () => {
+    if (await isConnectedToTheInternet()) return passthrough()
 
-      return HttpResponse.json(null, {status: 404})
-    },
-  ),
-  http.get(/http:\/\/localhost:\d+\/.*/, async req => passthrough()),
-  http.post(/http:\/\/localhost:\d+\/.*/, async req => passthrough()),
-  http.get('https://verifier.meetchopra.com/verify/:email', (req, res, ctx) => {
+    return HttpResponse.json(null, {status: 404})
+  }),
+  http.get(/http:\/\/localhost:\d+\/.*/, async () => passthrough()),
+  http.post(/http:\/\/localhost:\d+\/.*/, async () => passthrough()),
+  http.get('https://verifier.meetchopra.com/verify/:email', () => {
     return HttpResponse.json({status: true})
   }),
 ]

--- a/mocks/oembed.ts
+++ b/mocks/oembed.ts
@@ -1,87 +1,92 @@
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 
-const oembedHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get('https://oembed.com/providers.json', async (req, res, ctx) => {
-    return res(
-      ctx.json([
-        {
-          provider_name: 'YouTube',
-          provider_url: 'https://www.youtube.com/',
-          endpoints: [
-            {
-              schemes: [
-                'https://*.youtube.com/watch*',
-                'https://*.youtube.com/v/*',
-                'https://youtu.be/*',
-                'https://*.youtube.com/playlist?list=*',
-              ],
-              url: 'https://www.youtube.com/oembed',
-              discovery: true,
-            },
-          ],
-        },
-        {
-          provider_name: 'CodeSandbox',
-          provider_url: 'https://codesandbox.io',
-          endpoints: [
-            {
-              schemes: [
-                'https://codesandbox.io/s/*',
-                'https://codesandbox.io/embed/*',
-              ],
-              url: 'https://codesandbox.io/oembed',
-            },
-          ],
-        },
-        {
-          provider_name: 'Twitter',
-          provider_url: 'http://www.twitter.com/',
-          endpoints: [
-            {
-              schemes: [
-                'https://twitter.com/*/status/*',
-                'https://*.twitter.com/*/status/*',
-                'https://twitter.com/*/moments/*',
-                'https://*.twitter.com/*/moments/*',
-              ],
-              url: 'https://publish.twitter.com/oembed',
-            },
-          ],
-        },
-      ]),
-    )
-  }),
+const oembedHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://oembed.com/providers.json',
+    async (req, res, ctx) => {
+      return res(
+        ctx.json([
+          {
+            provider_name: 'YouTube',
+            provider_url: 'https://www.youtube.com/',
+            endpoints: [
+              {
+                schemes: [
+                  'https://*.youtube.com/watch*',
+                  'https://*.youtube.com/v/*',
+                  'https://youtu.be/*',
+                  'https://*.youtube.com/playlist?list=*',
+                ],
+                url: 'https://www.youtube.com/oembed',
+                discovery: true,
+              },
+            ],
+          },
+          {
+            provider_name: 'CodeSandbox',
+            provider_url: 'https://codesandbox.io',
+            endpoints: [
+              {
+                schemes: [
+                  'https://codesandbox.io/s/*',
+                  'https://codesandbox.io/embed/*',
+                ],
+                url: 'https://codesandbox.io/oembed',
+              },
+            ],
+          },
+          {
+            provider_name: 'Twitter',
+            provider_url: 'http://www.twitter.com/',
+            endpoints: [
+              {
+                schemes: [
+                  'https://twitter.com/*/status/*',
+                  'https://*.twitter.com/*/status/*',
+                  'https://twitter.com/*/moments/*',
+                  'https://*.twitter.com/*/moments/*',
+                ],
+                url: 'https://publish.twitter.com/oembed',
+              },
+            ],
+          },
+        ]),
+      )
+    },
+  ),
 
-  http.get('https://publish.twitter.com/oembed', async (req, res, ctx) => {
-    return res(
-      ctx.json({
-        html: '<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I spent a few minutes working on this, just for you all. I promise, it wont disappoint. Though it may surprise 🎉<br><br>🙏 <a href="https://t.co/wgTJYYHOzD">https://t.co/wgTJYYHOzD</a></p>— Kent C. Dodds (@kentcdodds) <a href="https://twitter.com/kentcdodds/status/783161196945944580?ref_src=twsrc%5Etfw">October 4, 2016</a></blockquote>',
-      }),
-    )
-  }),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://publish.twitter.com/oembed',
+    async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          html: '<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I spent a few minutes working on this, just for you all. I promise, it wont disappoint. Though it may surprise 🎉<br><br>🙏 <a href="https://t.co/wgTJYYHOzD">https://t.co/wgTJYYHOzD</a></p>— Kent C. Dodds (@kentcdodds) <a href="https://twitter.com/kentcdodds/status/783161196945944580?ref_src=twsrc%5Etfw">October 4, 2016</a></blockquote>',
+        }),
+      )
+    },
+  ),
 
-  http.get('https://codesandbox.io/oembed', async (req, res, ctx) => {
-    return res(
-      ctx.json({
-        html: '<iframe width="1000" height="500" src="https://codesandbox.io/embed/ynn88nx9x?view=editor" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" style="width: 1000px; height: 500px; border: 0px; border-radius: 4px; overflow: hidden;"></iframe>',
-      }),
-    )
-  }),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://codesandbox.io/oembed',
+    async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          html: '<iframe width="1000" height="500" src="https://codesandbox.io/embed/ynn88nx9x?view=editor" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" style="width: 1000px; height: 500px; border: 0px; border-radius: 4px; overflow: hidden;"></iframe>',
+        }),
+      )
+    },
+  ),
 
-  http.get('https://www.youtube.com/oembed', async (req, res, ctx) => {
-    return res(
-      ctx.json({
-        html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
-      }),
-    )
-  }),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://www.youtube.com/oembed',
+    async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+        }),
+      )
+    },
+  ),
 ]
 
 export {oembedHandlers}

--- a/mocks/oembed.ts
+++ b/mocks/oembed.ts
@@ -8,7 +8,7 @@ import {
 const oembedHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://oembed.com/providers.json',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json([
         {
           provider_name: 'YouTube',
@@ -60,7 +60,7 @@ const oembedHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://publish.twitter.com/oembed',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json({
         html: '<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I spent a few minutes working on this, just for you all. I promise, it wont disappoint. Though it may surprise 🎉<br><br>🙏 <a href="https://t.co/wgTJYYHOzD">https://t.co/wgTJYYHOzD</a></p>— Kent C. Dodds (@kentcdodds) <a href="https://twitter.com/kentcdodds/status/783161196945944580?ref_src=twsrc%5Etfw">October 4, 2016</a></blockquote>',
       })
@@ -69,7 +69,7 @@ const oembedHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://codesandbox.io/oembed',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json({
         html: '<iframe width="1000" height="500" src="https://codesandbox.io/embed/ynn88nx9x?view=editor" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" style="width: 1000px; height: 500px; border: 0px; border-radius: 4px; overflow: hidden;"></iframe>',
       })
@@ -78,7 +78,7 @@ const oembedHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://www.youtube.com/oembed',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json({
         html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
       })

--- a/mocks/oembed.ts
+++ b/mocks/oembed.ts
@@ -1,90 +1,87 @@
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 
 const oembedHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://oembed.com/providers.json',
     async (req, res, ctx) => {
-      return res(
-        ctx.json([
-          {
-            provider_name: 'YouTube',
-            provider_url: 'https://www.youtube.com/',
-            endpoints: [
-              {
-                schemes: [
-                  'https://*.youtube.com/watch*',
-                  'https://*.youtube.com/v/*',
-                  'https://youtu.be/*',
-                  'https://*.youtube.com/playlist?list=*',
-                ],
-                url: 'https://www.youtube.com/oembed',
-                discovery: true,
-              },
-            ],
-          },
-          {
-            provider_name: 'CodeSandbox',
-            provider_url: 'https://codesandbox.io',
-            endpoints: [
-              {
-                schemes: [
-                  'https://codesandbox.io/s/*',
-                  'https://codesandbox.io/embed/*',
-                ],
-                url: 'https://codesandbox.io/oembed',
-              },
-            ],
-          },
-          {
-            provider_name: 'Twitter',
-            provider_url: 'http://www.twitter.com/',
-            endpoints: [
-              {
-                schemes: [
-                  'https://twitter.com/*/status/*',
-                  'https://*.twitter.com/*/status/*',
-                  'https://twitter.com/*/moments/*',
-                  'https://*.twitter.com/*/moments/*',
-                ],
-                url: 'https://publish.twitter.com/oembed',
-              },
-            ],
-          },
-        ]),
-      )
+      return HttpResponse.json([
+        {
+          provider_name: 'YouTube',
+          provider_url: 'https://www.youtube.com/',
+          endpoints: [
+            {
+              schemes: [
+                'https://*.youtube.com/watch*',
+                'https://*.youtube.com/v/*',
+                'https://youtu.be/*',
+                'https://*.youtube.com/playlist?list=*',
+              ],
+              url: 'https://www.youtube.com/oembed',
+              discovery: true,
+            },
+          ],
+        },
+        {
+          provider_name: 'CodeSandbox',
+          provider_url: 'https://codesandbox.io',
+          endpoints: [
+            {
+              schemes: [
+                'https://codesandbox.io/s/*',
+                'https://codesandbox.io/embed/*',
+              ],
+              url: 'https://codesandbox.io/oembed',
+            },
+          ],
+        },
+        {
+          provider_name: 'Twitter',
+          provider_url: 'http://www.twitter.com/',
+          endpoints: [
+            {
+              schemes: [
+                'https://twitter.com/*/status/*',
+                'https://*.twitter.com/*/status/*',
+                'https://twitter.com/*/moments/*',
+                'https://*.twitter.com/*/moments/*',
+              ],
+              url: 'https://publish.twitter.com/oembed',
+            },
+          ],
+        },
+      ])
     },
   ),
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://publish.twitter.com/oembed',
     async (req, res, ctx) => {
-      return res(
-        ctx.json({
-          html: '<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I spent a few minutes working on this, just for you all. I promise, it wont disappoint. Though it may surprise 🎉<br><br>🙏 <a href="https://t.co/wgTJYYHOzD">https://t.co/wgTJYYHOzD</a></p>— Kent C. Dodds (@kentcdodds) <a href="https://twitter.com/kentcdodds/status/783161196945944580?ref_src=twsrc%5Etfw">October 4, 2016</a></blockquote>',
-        }),
-      )
+      return HttpResponse.json({
+        html: '<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I spent a few minutes working on this, just for you all. I promise, it wont disappoint. Though it may surprise 🎉<br><br>🙏 <a href="https://t.co/wgTJYYHOzD">https://t.co/wgTJYYHOzD</a></p>— Kent C. Dodds (@kentcdodds) <a href="https://twitter.com/kentcdodds/status/783161196945944580?ref_src=twsrc%5Etfw">October 4, 2016</a></blockquote>',
+      })
     },
   ),
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://codesandbox.io/oembed',
     async (req, res, ctx) => {
-      return res(
-        ctx.json({
-          html: '<iframe width="1000" height="500" src="https://codesandbox.io/embed/ynn88nx9x?view=editor" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" style="width: 1000px; height: 500px; border: 0px; border-radius: 4px; overflow: hidden;"></iframe>',
-        }),
-      )
+      return HttpResponse.json({
+        html: '<iframe width="1000" height="500" src="https://codesandbox.io/embed/ynn88nx9x?view=editor" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" style="width: 1000px; height: 500px; border: 0px; border-radius: 4px; overflow: hidden;"></iframe>',
+      })
     },
   ),
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://www.youtube.com/oembed',
     async (req, res, ctx) => {
-      return res(
-        ctx.json({
-          html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
-        }),
-      )
+      return HttpResponse.json({
+        html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+      })
     },
   ),
 ]

--- a/mocks/oembed.ts
+++ b/mocks/oembed.ts
@@ -1,14 +1,14 @@
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 
 const oembedHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get('https://oembed.com/providers.json', async (req, res, ctx) => {
+  http.get('https://oembed.com/providers.json', async (req, res, ctx) => {
     return res(
       ctx.json([
         {
@@ -59,7 +59,7 @@ const oembedHandlers: Array<
     )
   }),
 
-  rest.get('https://publish.twitter.com/oembed', async (req, res, ctx) => {
+  http.get('https://publish.twitter.com/oembed', async (req, res, ctx) => {
     return res(
       ctx.json({
         html: '<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I spent a few minutes working on this, just for you all. I promise, it wont disappoint. Though it may surprise 🎉<br><br>🙏 <a href="https://t.co/wgTJYYHOzD">https://t.co/wgTJYYHOzD</a></p>— Kent C. Dodds (@kentcdodds) <a href="https://twitter.com/kentcdodds/status/783161196945944580?ref_src=twsrc%5Etfw">October 4, 2016</a></blockquote>',
@@ -67,7 +67,7 @@ const oembedHandlers: Array<
     )
   }),
 
-  rest.get('https://codesandbox.io/oembed', async (req, res, ctx) => {
+  http.get('https://codesandbox.io/oembed', async (req, res, ctx) => {
     return res(
       ctx.json({
         html: '<iframe width="1000" height="500" src="https://codesandbox.io/embed/ynn88nx9x?view=editor" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" style="width: 1000px; height: 500px; border: 0px; border-radius: 4px; overflow: hidden;"></iframe>',
@@ -75,7 +75,7 @@ const oembedHandlers: Array<
     )
   }),
 
-  rest.get('https://www.youtube.com/oembed', async (req, res, ctx) => {
+  http.get('https://www.youtube.com/oembed', async (req, res, ctx) => {
     return res(
       ctx.json({
         html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',

--- a/mocks/simplecast.ts
+++ b/mocks/simplecast.ts
@@ -144,7 +144,7 @@ ${guest.links.length ? `* ${guest.links.join('\n* ')}` : ''}
 const simplecastHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.simplecast.com/podcasts/:podcastId/seasons',
-    (req, res, ctx) => {
+    () => {
       const response: SimplecastCollectionResponse<SimpelcastSeasonListItem> = {
         collection: seasonListItems,
       }
@@ -153,7 +153,7 @@ const simplecastHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.simplecast.com/seasons/:seasonId/episodes',
-    (req, res, ctx) => {
+    ({params}) => {
       if (typeof params.seasonId !== 'string') {
         throw new Error('req.params.seasonId is not a string')
       }
@@ -175,7 +175,7 @@ const simplecastHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.simplecast.com/episodes/:episodeId`,
-    (req, res, ctx) => {
+    ({params}) => {
       if (typeof params.episodeId !== 'string') {
         throw new Error('req.params.episodeId is not a string')
       }

--- a/mocks/simplecast.ts
+++ b/mocks/simplecast.ts
@@ -149,12 +149,12 @@ const simplecastHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.simplecast.com/seasons/:seasonId/episodes',
     (req, res, ctx) => {
-      if (typeof req.params.seasonId !== 'string') {
+      if (typeof params.seasonId !== 'string') {
         throw new Error('req.params.seasonId is not a string')
       }
-      const episodes = episodesBySeasonId[req.params.seasonId]
+      const episodes = episodesBySeasonId[params.seasonId]
       if (!episodes) {
-        throw new Error(`No mock episodes by season ID: ${req.params.seasonId}`)
+        throw new Error(`No mock episodes by season ID: ${params.seasonId}`)
       }
       const episodeListItemsResponse: SimplecastCollectionResponse<SimplecastEpisodeListItem> =
         {
@@ -171,10 +171,10 @@ const simplecastHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     `https://api.simplecast.com/episodes/:episodeId`,
     (req, res, ctx) => {
-      if (typeof req.params.episodeId !== 'string') {
+      if (typeof params.episodeId !== 'string') {
         throw new Error('req.params.episodeId is not a string')
       }
-      return res(ctx.json(episodesById[req.params.episodeId]))
+      return res(ctx.json(episodesById[params.episodeId]))
     },
   ),
 ]

--- a/mocks/simplecast.ts
+++ b/mocks/simplecast.ts
@@ -1,10 +1,5 @@
 import {faker} from '@faker-js/faker'
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 import {
   type SimpelcastSeasonListItem,
   type SimplecastCollectionResponse,
@@ -141,10 +136,8 @@ ${guest.links.length ? `* ${guest.links.join('\n* ')}` : ''}
   }
 }
 
-const simplecastHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get(
+const simplecastHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.simplecast.com/podcasts/:podcastId/seasons',
     (req, res, ctx) => {
       const response: SimplecastCollectionResponse<SimpelcastSeasonListItem> = {
@@ -153,7 +146,7 @@ const simplecastHandlers: Array<
       return res(ctx.json(response))
     },
   ),
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.simplecast.com/seasons/:seasonId/episodes',
     (req, res, ctx) => {
       if (typeof req.params.seasonId !== 'string') {
@@ -175,7 +168,7 @@ const simplecastHandlers: Array<
       return res(ctx.json(episodeListItemsResponse))
     },
   ),
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     `https://api.simplecast.com/episodes/:episodeId`,
     (req, res, ctx) => {
       if (typeof req.params.episodeId !== 'string') {

--- a/mocks/simplecast.ts
+++ b/mocks/simplecast.ts
@@ -1,9 +1,9 @@
 import {faker} from '@faker-js/faker'
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 import {
   type SimpelcastSeasonListItem,
@@ -142,9 +142,9 @@ ${guest.links.length ? `* ${guest.links.join('\n* ')}` : ''}
 }
 
 const simplecastHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get(
+  http.get(
     'https://api.simplecast.com/podcasts/:podcastId/seasons',
     (req, res, ctx) => {
       const response: SimplecastCollectionResponse<SimpelcastSeasonListItem> = {
@@ -153,7 +153,7 @@ const simplecastHandlers: Array<
       return res(ctx.json(response))
     },
   ),
-  rest.get(
+  http.get(
     'https://api.simplecast.com/seasons/:seasonId/episodes',
     (req, res, ctx) => {
       if (typeof req.params.seasonId !== 'string') {
@@ -175,7 +175,7 @@ const simplecastHandlers: Array<
       return res(ctx.json(episodeListItemsResponse))
     },
   ),
-  rest.get(
+  http.get(
     `https://api.simplecast.com/episodes/:episodeId`,
     (req, res, ctx) => {
       if (typeof req.params.episodeId !== 'string') {

--- a/mocks/simplecast.ts
+++ b/mocks/simplecast.ts
@@ -1,5 +1,10 @@
 import {faker} from '@faker-js/faker'
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 import {
   type SimpelcastSeasonListItem,
   type SimplecastCollectionResponse,
@@ -143,7 +148,7 @@ const simplecastHandlers: Array<HttpHandler> = [
       const response: SimplecastCollectionResponse<SimpelcastSeasonListItem> = {
         collection: seasonListItems,
       }
-      return res(ctx.json(response))
+      return HttpResponse.json(response)
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
@@ -165,7 +170,7 @@ const simplecastHandlers: Array<HttpHandler> = [
             is_published: e.is_published,
           })),
         }
-      return res(ctx.json(episodeListItemsResponse))
+      return HttpResponse.json(episodeListItemsResponse)
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
@@ -174,7 +179,7 @@ const simplecastHandlers: Array<HttpHandler> = [
       if (typeof params.episodeId !== 'string') {
         throw new Error('req.params.episodeId is not a string')
       }
-      return res(ctx.json(episodesById[params.episodeId]))
+      return HttpResponse.json(episodesById[params.episodeId])
     },
   ),
 ]

--- a/mocks/tito.ts
+++ b/mocks/tito.ts
@@ -8,7 +8,7 @@ import {
 const tiToHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/hello',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json({
         accounts: ['kent-c-dodds', 'epic-web'],
       })
@@ -16,7 +16,7 @@ const tiToHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/events',
-    async (req, res, ctx) => {
+    async ({params}) => {
       const slug = 'testing-this-isn-t-a-real-event'
       return HttpResponse.json({
         events: [
@@ -37,7 +37,7 @@ const tiToHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json({
         event: {
           location: 'Zoom',
@@ -55,7 +55,7 @@ const tiToHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug/discount_codes',
-    async (req, res, ctx) => {
+    async ({params}) => {
       const code = 'early'
       return HttpResponse.json({
         discount_codes: [
@@ -75,7 +75,7 @@ const tiToHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug/activities',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json({
         activities: [
           {

--- a/mocks/tito.ts
+++ b/mocks/tito.ts
@@ -1,21 +1,21 @@
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 
 const tiToHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get('https://api.tito.io/v3/hello', async (req, res, ctx) => {
+  http.get('https://api.tito.io/v3/hello', async (req, res, ctx) => {
     return res(
       ctx.json({
         accounts: ['kent-c-dodds', 'epic-web'],
       }),
     )
   }),
-  rest.get('https://api.tito.io/v3/:account/events', async (req, res, ctx) => {
+  http.get('https://api.tito.io/v3/:account/events', async (req, res, ctx) => {
     const slug = 'testing-this-isn-t-a-real-event'
     return res(
       ctx.json({
@@ -37,7 +37,7 @@ const tiToHandlers: Array<
     )
   }),
 
-  rest.get(
+  http.get(
     'https://api.tito.io/v3/:account/:eventSlug',
     async (req, res, ctx) => {
       return res(
@@ -57,7 +57,7 @@ const tiToHandlers: Array<
     },
   ),
 
-  rest.get(
+  http.get(
     'https://api.tito.io/v3/:account/:eventSlug/discount_codes',
     async (req, res, ctx) => {
       const code = 'early'
@@ -79,7 +79,7 @@ const tiToHandlers: Array<
     },
   ),
 
-  rest.get(
+  http.get(
     'https://api.tito.io/v3/:account/:eventSlug/activities',
     async (req, res, ctx) => {
       return res(

--- a/mocks/tito.ts
+++ b/mocks/tito.ts
@@ -21,7 +21,7 @@ const tiToHandlers: Array<HttpHandler> = [
             {
               live: true,
               title: `TESTING (this isn't a real ${
-                req.params.account ?? ''
+                params.account ?? ''
               } event)`,
               description: 'This is a short description',
               banner: {url: null, thumb: {url: null}},
@@ -68,7 +68,7 @@ const tiToHandlers: Array<HttpHandler> = [
               end_at: '2024-03-23T06:00:00.000-06:00',
               quantity: 10,
               quantity_used: 0,
-              share_url: `https://ti.to/kent-c-dodds/${req.params.eventSlug}/discount/${code}`,
+              share_url: `https://ti.to/kent-c-dodds/${params.eventSlug}/discount/${code}`,
               state: 'current',
             },
           ],

--- a/mocks/tito.ts
+++ b/mocks/tito.ts
@@ -1,43 +1,42 @@
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 
-const tiToHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get('https://api.tito.io/v3/hello', async (req, res, ctx) => {
-    return res(
-      ctx.json({
-        accounts: ['kent-c-dodds', 'epic-web'],
-      }),
-    )
-  }),
-  http.get('https://api.tito.io/v3/:account/events', async (req, res, ctx) => {
-    const slug = 'testing-this-isn-t-a-real-event'
-    return res(
-      ctx.json({
-        events: [
-          {
-            live: true,
-            title: `TESTING (this isn't a real ${
-              req.params.account ?? ''
-            } event)`,
-            description: 'This is a short description',
-            banner: {url: null, thumb: {url: null}},
-            slug,
-            metadata: {workshopSlug: 'react-hooks'},
-            url: `https://ti.to/kent-c-dodds/${slug}`,
-          },
-        ],
-        meta: {},
-      }),
-    )
-  }),
+const tiToHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://api.tito.io/v3/hello',
+    async (req, res, ctx) => {
+      return res(
+        ctx.json({
+          accounts: ['kent-c-dodds', 'epic-web'],
+        }),
+      )
+    },
+  ),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://api.tito.io/v3/:account/events',
+    async (req, res, ctx) => {
+      const slug = 'testing-this-isn-t-a-real-event'
+      return res(
+        ctx.json({
+          events: [
+            {
+              live: true,
+              title: `TESTING (this isn't a real ${
+                req.params.account ?? ''
+              } event)`,
+              description: 'This is a short description',
+              banner: {url: null, thumb: {url: null}},
+              slug,
+              metadata: {workshopSlug: 'react-hooks'},
+              url: `https://ti.to/kent-c-dodds/${slug}`,
+            },
+          ],
+          meta: {},
+        }),
+      )
+    },
+  ),
 
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug',
     async (req, res, ctx) => {
       return res(
@@ -57,7 +56,7 @@ const tiToHandlers: Array<
     },
   ),
 
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug/discount_codes',
     async (req, res, ctx) => {
       const code = 'early'
@@ -79,7 +78,7 @@ const tiToHandlers: Array<
     },
   ),
 
-  http.get(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug/activities',
     async (req, res, ctx) => {
       return res(

--- a/mocks/tito.ts
+++ b/mocks/tito.ts
@@ -1,58 +1,55 @@
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 
 const tiToHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/hello',
     async (req, res, ctx) => {
-      return res(
-        ctx.json({
-          accounts: ['kent-c-dodds', 'epic-web'],
-        }),
-      )
+      return HttpResponse.json({
+        accounts: ['kent-c-dodds', 'epic-web'],
+      })
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/events',
     async (req, res, ctx) => {
       const slug = 'testing-this-isn-t-a-real-event'
-      return res(
-        ctx.json({
-          events: [
-            {
-              live: true,
-              title: `TESTING (this isn't a real ${
-                params.account ?? ''
-              } event)`,
-              description: 'This is a short description',
-              banner: {url: null, thumb: {url: null}},
-              slug,
-              metadata: {workshopSlug: 'react-hooks'},
-              url: `https://ti.to/kent-c-dodds/${slug}`,
-            },
-          ],
-          meta: {},
-        }),
-      )
+      return HttpResponse.json({
+        events: [
+          {
+            live: true,
+            title: `TESTING (this isn't a real ${params.account ?? ''} event)`,
+            description: 'This is a short description',
+            banner: {url: null, thumb: {url: null}},
+            slug,
+            metadata: {workshopSlug: 'react-hooks'},
+            url: `https://ti.to/kent-c-dodds/${slug}`,
+          },
+        ],
+        meta: {},
+      })
     },
   ),
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug',
     async (req, res, ctx) => {
-      return res(
-        ctx.json({
-          event: {
-            location: 'Zoom',
-            date_or_range: 'March 23rd, 2024',
-            releases: [
-              {
-                quantity: 40,
-                tickets_count: 2,
-              },
-            ],
-          },
-        }),
-      )
+      return HttpResponse.json({
+        event: {
+          location: 'Zoom',
+          date_or_range: 'March 23rd, 2024',
+          releases: [
+            {
+              quantity: 40,
+              tickets_count: 2,
+            },
+          ],
+        },
+      })
     },
   ),
 
@@ -60,38 +57,34 @@ const tiToHandlers: Array<HttpHandler> = [
     'https://api.tito.io/v3/:account/:eventSlug/discount_codes',
     async (req, res, ctx) => {
       const code = 'early'
-      return res(
-        ctx.json({
-          discount_codes: [
-            {
-              code,
-              end_at: '2024-03-23T06:00:00.000-06:00',
-              quantity: 10,
-              quantity_used: 0,
-              share_url: `https://ti.to/kent-c-dodds/${params.eventSlug}/discount/${code}`,
-              state: 'current',
-            },
-          ],
-          meta: {},
-        }),
-      )
+      return HttpResponse.json({
+        discount_codes: [
+          {
+            code,
+            end_at: '2024-03-23T06:00:00.000-06:00',
+            quantity: 10,
+            quantity_used: 0,
+            share_url: `https://ti.to/kent-c-dodds/${params.eventSlug}/discount/${code}`,
+            state: 'current',
+          },
+        ],
+        meta: {},
+      })
     },
   ),
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.tito.io/v3/:account/:eventSlug/activities',
     async (req, res, ctx) => {
-      return res(
-        ctx.json({
-          activities: [
-            {
-              start_at: '2024-03-24T09:30:00.000-06:00',
-              end_at: '2024-03-24T13:30:00.000-06:00',
-            },
-          ],
-          meta: {},
-        }),
-      )
+      return HttpResponse.json({
+        activities: [
+          {
+            start_at: '2024-03-24T09:30:00.000-06:00',
+            end_at: '2024-03-24T13:30:00.000-06:00',
+          },
+        ],
+        meta: {},
+      })
     },
   ),
 ]

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -1,9 +1,9 @@
 import {faker} from '@faker-js/faker'
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 import {
   type TransistorAuthorizedJson,
@@ -69,9 +69,9 @@ const episodes: Array<TransistorEpisodeData> = Array.from(
 )
 
 const transistorHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get(
+  http.get(
     'https://api.transistor.fm/v1/episodes/authorize_upload',
     async (req, res, ctx) => {
       requiredParam(req.url.searchParams, 'filename')
@@ -91,7 +91,7 @@ const transistorHandlers: Array<
     },
   ),
 
-  rest.put(
+  http.put(
     'https://transistorupload.s3.amazonaws.com/uploads/api/:bucketId/:fileId',
     async (req, res, ctx) => {
       if (!req.body) {
@@ -106,7 +106,7 @@ const transistorHandlers: Array<
     },
   ),
 
-  rest.post('https://api.transistor.fm/v1/episodes', async (req, res, ctx) => {
+  http.post('https://api.transistor.fm/v1/episodes', async (req, res, ctx) => {
     if (!req.body || typeof req.body !== 'object') {
       throw new Error('req.body must be an object')
     }
@@ -129,7 +129,7 @@ const transistorHandlers: Array<
     return res(ctx.json(data))
   }),
 
-  rest.patch(
+  http.patch(
     'https://api.transistor.fm/v1/episodes/:episodeId/publish',
     async (req, res, ctx) => {
       if (!req.body || typeof req.body !== 'object') {
@@ -154,7 +154,7 @@ const transistorHandlers: Array<
     },
   ),
 
-  rest.patch(
+  http.patch(
     'https://api.transistor.fm/v1/episodes/:episodeId',
     async (req, res, ctx) => {
       if (!req.body || typeof req.body !== 'object') {
@@ -174,7 +174,7 @@ const transistorHandlers: Array<
     },
   ),
 
-  rest.get('https://api.transistor.fm/v1/episodes', async (req, res, ctx) => {
+  http.get('https://api.transistor.fm/v1/episodes', async (req, res, ctx) => {
     requiredHeader(req.headers, 'x-api-key')
     const data: TransistorEpisodesJson = {data: episodes}
     return res(ctx.json(data))

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -1,10 +1,5 @@
 import {faker} from '@faker-js/faker'
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type HttpHandler,
-  HttpResponse,
-} from 'msw'
+import {HttpResponse, http, type DefaultBodyType, type HttpHandler} from 'msw'
 import {
   type TransistorAuthorizedJson,
   type TransistorCreatedJson,
@@ -69,7 +64,7 @@ const episodes: Array<TransistorEpisodeData> = Array.from(
 )
 
 const transistorHandlers: Array<HttpHandler> = [
-  http.get<any, DefaultRequestMultipartBody>(
+  http.get<any, DefaultBodyType>(
     'https://api.transistor.fm/v1/episodes/authorize_upload',
     async ({request}) => {
       const url = new URL(request.url)
@@ -91,7 +86,7 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.put<any, DefaultRequestMultipartBody>(
+  http.put<any, DefaultBodyType>(
     'https://transistorupload.s3.amazonaws.com/uploads/api/:bucketId/:fileId',
     async ({request}) => {
       const body = await request.json()
@@ -106,7 +101,7 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.post<any, DefaultRequestMultipartBody>(
+  http.post<any, DefaultBodyType>(
     'https://api.transistor.fm/v1/episodes',
     async ({request}) => {
       const body = await request.json()
@@ -134,7 +129,7 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.patch<any, DefaultRequestMultipartBody>(
+  http.patch<any, DefaultBodyType>(
     'https://api.transistor.fm/v1/episodes/:episodeId/publish',
     async ({request, params}) => {
       const body = await request.json()
@@ -159,7 +154,7 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.patch<any, DefaultRequestMultipartBody>(
+  http.patch<any, DefaultBodyType>(
     'https://api.transistor.fm/v1/episodes/:episodeId',
     async ({request, params}) => {
       const body = await request.json()
@@ -179,7 +174,7 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.get<any, DefaultRequestMultipartBody>(
+  http.get<any, DefaultBodyType>(
     'https://api.transistor.fm/v1/episodes',
     async ({request}) => {
       requiredHeader(request.headers, 'x-api-key')

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -1,10 +1,5 @@
 import {faker} from '@faker-js/faker'
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 import {
   type TransistorAuthorizedJson,
   type TransistorCreatedJson,
@@ -68,10 +63,8 @@ const episodes: Array<TransistorEpisodeData> = Array.from(
     }),
 )
 
-const transistorHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get(
+const transistorHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/authorize_upload',
     async (req, res, ctx) => {
       requiredParam(req.url.searchParams, 'filename')
@@ -91,7 +84,7 @@ const transistorHandlers: Array<
     },
   ),
 
-  http.put(
+  http.put<any, DefaultRequestMultipartBody>(
     'https://transistorupload.s3.amazonaws.com/uploads/api/:bucketId/:fileId',
     async (req, res, ctx) => {
       if (!req.body) {
@@ -106,30 +99,33 @@ const transistorHandlers: Array<
     },
   ),
 
-  http.post('https://api.transistor.fm/v1/episodes', async (req, res, ctx) => {
-    if (!req.body || typeof req.body !== 'object') {
-      throw new Error('req.body must be an object')
-    }
-    requiredHeader(req.headers, 'x-api-key')
-    requiredProperty(req.body, 'episode')
-    requiredProperty(req.body.episode, 'show_id')
-    requiredProperty(req.body.episode, 'season')
-    requiredProperty(req.body.episode, 'audio_url')
-    requiredProperty(req.body.episode, 'title')
-    requiredProperty(req.body.episode, 'summary')
-    requiredProperty(req.body.episode, 'description')
-    const episode: TransistorEpisodeData = makeEpisode({
-      attributes: {
-        number: Math.max(...episodes.map(e => e.attributes.number ?? 0)) + 1,
-        ...req.body.episode,
-      },
-    })
-    const data: TransistorCreatedJson = {data: episode}
-    episodes.push(episode)
-    return res(ctx.json(data))
-  }),
+  http.post<any, DefaultRequestMultipartBody>(
+    'https://api.transistor.fm/v1/episodes',
+    async (req, res, ctx) => {
+      if (!req.body || typeof req.body !== 'object') {
+        throw new Error('req.body must be an object')
+      }
+      requiredHeader(req.headers, 'x-api-key')
+      requiredProperty(req.body, 'episode')
+      requiredProperty(req.body.episode, 'show_id')
+      requiredProperty(req.body.episode, 'season')
+      requiredProperty(req.body.episode, 'audio_url')
+      requiredProperty(req.body.episode, 'title')
+      requiredProperty(req.body.episode, 'summary')
+      requiredProperty(req.body.episode, 'description')
+      const episode: TransistorEpisodeData = makeEpisode({
+        attributes: {
+          number: Math.max(...episodes.map(e => e.attributes.number ?? 0)) + 1,
+          ...req.body.episode,
+        },
+      })
+      const data: TransistorCreatedJson = {data: episode}
+      episodes.push(episode)
+      return res(ctx.json(data))
+    },
+  ),
 
-  http.patch(
+  http.patch<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/:episodeId/publish',
     async (req, res, ctx) => {
       if (!req.body || typeof req.body !== 'object') {
@@ -154,7 +150,7 @@ const transistorHandlers: Array<
     },
   ),
 
-  http.patch(
+  http.patch<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/:episodeId',
     async (req, res, ctx) => {
       if (!req.body || typeof req.body !== 'object') {
@@ -174,11 +170,14 @@ const transistorHandlers: Array<
     },
   ),
 
-  http.get('https://api.transistor.fm/v1/episodes', async (req, res, ctx) => {
-    requiredHeader(req.headers, 'x-api-key')
-    const data: TransistorEpisodesJson = {data: episodes}
-    return res(ctx.json(data))
-  }),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://api.transistor.fm/v1/episodes',
+    async (req, res, ctx) => {
+      requiredHeader(req.headers, 'x-api-key')
+      const data: TransistorEpisodesJson = {data: episodes}
+      return res(ctx.json(data))
+    },
+  ),
 ]
 
 export {transistorHandlers}

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -1,5 +1,11 @@
 import {faker} from '@faker-js/faker'
-import {HttpResponse, http, type DefaultBodyType, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+  type DefaultBodyType,
+} from 'msw'
 import {
   type TransistorAuthorizedJson,
   type TransistorCreatedJson,
@@ -64,7 +70,7 @@ const episodes: Array<TransistorEpisodeData> = Array.from(
 )
 
 const transistorHandlers: Array<HttpHandler> = [
-  http.get<any, DefaultBodyType>(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/authorize_upload',
     async ({request}) => {
       const url = new URL(request.url)
@@ -86,13 +92,13 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.put<any, DefaultBodyType>(
+  http.put<any, DefaultRequestMultipartBody>(
     'https://transistorupload.s3.amazonaws.com/uploads/api/:bucketId/:fileId',
     async ({request}) => {
-      const body = await request.json()
+      const body = await request.blob()
 
-      if (!body) {
-        throw new Error('req.body is required')
+      if (!body.size) {
+        throw new Error('body is required')
       }
 
       return HttpResponse.json({
@@ -174,7 +180,7 @@ const transistorHandlers: Array<HttpHandler> = [
     },
   ),
 
-  http.get<any, DefaultBodyType>(
+  http.get<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes',
     async ({request}) => {
       requiredHeader(request.headers, 'x-api-key')

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -71,11 +71,11 @@ const episodes: Array<TransistorEpisodeData> = Array.from(
 const transistorHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/authorize_upload',
-    async (req, res, ctx) => {
+    async ({request}) => {
       const url = new URL(request.url)
 
       requiredParam(url.searchParams, 'filename')
-      requiredHeader(req.headers, 'x-api-key')
+      requiredHeader(request.headers, 'x-api-key')
       const data: TransistorAuthorizedJson = {
         data: {
           attributes: {
@@ -93,7 +93,7 @@ const transistorHandlers: Array<HttpHandler> = [
 
   http.put<any, DefaultRequestMultipartBody>(
     'https://transistorupload.s3.amazonaws.com/uploads/api/:bucketId/:fileId',
-    async (req, res, ctx) => {
+    async ({request}) => {
       const body = await request.json()
 
       if (!body) {
@@ -108,13 +108,13 @@ const transistorHandlers: Array<HttpHandler> = [
 
   http.post<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes',
-    async (req, res, ctx) => {
+    async ({request}) => {
       const body = await request.json()
 
       if (!body || typeof body !== 'object') {
         throw new Error('req.body must be an object')
       }
-      requiredHeader(req.headers, 'x-api-key')
+      requiredHeader(request.headers, 'x-api-key')
       requiredProperty(body, 'episode')
       requiredProperty(body.episode, 'show_id')
       requiredProperty(body.episode, 'season')
@@ -136,14 +136,14 @@ const transistorHandlers: Array<HttpHandler> = [
 
   http.patch<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/:episodeId/publish',
-    async (req, res, ctx) => {
+    async ({request, params}) => {
       const body = await request.json()
 
       if (!body || typeof body !== 'object') {
         throw new Error('req.body must be an object')
       }
       requiredProperty(body, 'episode')
-      requiredHeader(req.headers, 'x-api-key')
+      requiredHeader(request.headers, 'x-api-key')
       if (body.episode.status !== 'published') {
         throw new Error(
           `req.body.episode.status must be published. Was "${body.episode.status}"`,
@@ -161,14 +161,14 @@ const transistorHandlers: Array<HttpHandler> = [
 
   http.patch<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes/:episodeId',
-    async (req, res, ctx) => {
+    async ({request, params}) => {
       const body = await request.json()
 
       if (!body || typeof body !== 'object') {
         throw new Error('req.body must be an object')
       }
       requiredProperty(body, 'episode')
-      requiredHeader(req.headers, 'x-api-key')
+      requiredHeader(request.headers, 'x-api-key')
       const episode = episodes.find(e => e.id === params.episodeId)
       if (!episode) {
         throw new Error(`No episode exists with the id of ${params.episodeId}`)
@@ -181,8 +181,8 @@ const transistorHandlers: Array<HttpHandler> = [
 
   http.get<any, DefaultRequestMultipartBody>(
     'https://api.transistor.fm/v1/episodes',
-    async (req, res, ctx) => {
-      requiredHeader(req.headers, 'x-api-key')
+    async ({request}) => {
+      requiredHeader(request.headers, 'x-api-key')
       const data: TransistorEpisodesJson = {data: episodes}
       return HttpResponse.json(data)
     },

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -1,5 +1,10 @@
 import {faker} from '@faker-js/faker'
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 import {
   type TransistorAuthorizedJson,
   type TransistorCreatedJson,
@@ -82,7 +87,7 @@ const transistorHandlers: Array<HttpHandler> = [
           },
         },
       }
-      return res(ctx.json(data))
+      return HttpResponse.json(data)
     },
   ),
 
@@ -95,11 +100,9 @@ const transistorHandlers: Array<HttpHandler> = [
         throw new Error('req.body is required')
       }
 
-      return res(
-        ctx.json({
-          // we don't use the response so no need to put something real here.
-        }),
-      )
+      return HttpResponse.json({
+        // we don't use the response so no need to put something real here.
+      })
     },
   ),
 
@@ -127,7 +130,7 @@ const transistorHandlers: Array<HttpHandler> = [
       })
       const data: TransistorCreatedJson = {data: episode}
       episodes.push(episode)
-      return res(ctx.json(data))
+      return HttpResponse.json(data)
     },
   ),
 
@@ -152,7 +155,7 @@ const transistorHandlers: Array<HttpHandler> = [
       }
       episode.attributes.status = 'published'
       const data: TransistorPublishedJson = {data: episode}
-      return res(ctx.json(data))
+      return HttpResponse.json(data)
     },
   ),
 
@@ -172,7 +175,7 @@ const transistorHandlers: Array<HttpHandler> = [
       }
       Object.assign(episode, body.episode)
       const data: TransistorPublishedJson = {data: episode}
-      return res(ctx.json(data))
+      return HttpResponse.json(data)
     },
   ),
 
@@ -181,7 +184,7 @@ const transistorHandlers: Array<HttpHandler> = [
     async (req, res, ctx) => {
       requiredHeader(req.headers, 'x-api-key')
       const data: TransistorEpisodesJson = {data: episodes}
-      return res(ctx.json(data))
+      return HttpResponse.json(data)
     },
   ),
 ]

--- a/mocks/twitter.ts
+++ b/mocks/twitter.ts
@@ -35,6 +35,8 @@ const twitterHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://cdn.syndication.twimg.com/tweet-result',
     async (req, res, ctx) => {
+      const url = new URL(request.url)
+
       // if you want to mock out specific tweets, comment out this next line
       // eslint-disable-next-line
       if (
@@ -43,7 +45,7 @@ const twitterHandlers: Array<HttpHandler> = [
       ) {
         return
       }
-      const tweetId = req.url.searchParams.get('tweet_id')
+      const tweetId = url.searchParams.get('tweet_id')
       // uncomment this and send whatever tweet you want to work with...
       // return res(ctx.json(tweets.linkWithMetadata))
 
@@ -71,7 +73,7 @@ const twitterHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://t.co/:tweetUrlId',
     async (req, res, ctx) => {
-      return res(ctx.text(getSiteMetadata(req.params.tweetUrlId as string)))
+      return res(ctx.text(getSiteMetadata(params.tweetUrlId as string)))
     },
   ),
   http.head<any, DefaultRequestMultipartBody>(

--- a/mocks/twitter.ts
+++ b/mocks/twitter.ts
@@ -1,10 +1,10 @@
 import path from 'path'
 import fsExtra from 'fs-extra'
 import {
-  rest,
+  http,
   type DefaultRequestMultipartBody,
   type MockedRequest,
-  type RestHandler,
+  type HttpHandler,
 } from 'msw'
 import type SiteMetadata from './data/site-metadata.json'
 import type Tweets from './data/tweets.json'
@@ -37,9 +37,9 @@ function getSiteMetadata(tweetUrlId: string) {
 }
 
 const twitterHandlers: Array<
-  RestHandler<MockedRequest<DefaultRequestMultipartBody>>
+  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
 > = [
-  rest.get(
+  http.get(
     'https://cdn.syndication.twimg.com/tweet-result',
     async (req, res, ctx) => {
       // if you want to mock out specific tweets, comment out this next line
@@ -75,10 +75,10 @@ const twitterHandlers: Array<
       return res(ctx.json(tweet))
     },
   ),
-  rest.get('https://t.co/:tweetUrlId', async (req, res, ctx) => {
+  http.get('https://t.co/:tweetUrlId', async (req, res, ctx) => {
     return res(ctx.text(getSiteMetadata(req.params.tweetUrlId as string)))
   }),
-  rest.head('https://t.co/:tweetUrlId', async (req, res, ctx) => {
+  http.head('https://t.co/:tweetUrlId', async (req, res, ctx) => {
     return res(ctx.set('x-head-mock', 'true'))
   }),
 ]

--- a/mocks/twitter.ts
+++ b/mocks/twitter.ts
@@ -1,11 +1,6 @@
 import path from 'path'
 import fsExtra from 'fs-extra'
-import {
-  http,
-  type DefaultRequestMultipartBody,
-  type MockedRequest,
-  type HttpHandler,
-} from 'msw'
+import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
 import type SiteMetadata from './data/site-metadata.json'
 import type Tweets from './data/tweets.json'
 import {isConnectedToTheInternet} from './utils.ts'
@@ -36,10 +31,8 @@ function getSiteMetadata(tweetUrlId: string) {
   return metadata
 }
 
-const twitterHandlers: Array<
-  HttpHandler<MockedRequest<DefaultRequestMultipartBody>>
-> = [
-  http.get(
+const twitterHandlers: Array<HttpHandler> = [
+  http.get<any, DefaultRequestMultipartBody>(
     'https://cdn.syndication.twimg.com/tweet-result',
     async (req, res, ctx) => {
       // if you want to mock out specific tweets, comment out this next line
@@ -75,12 +68,18 @@ const twitterHandlers: Array<
       return res(ctx.json(tweet))
     },
   ),
-  http.get('https://t.co/:tweetUrlId', async (req, res, ctx) => {
-    return res(ctx.text(getSiteMetadata(req.params.tweetUrlId as string)))
-  }),
-  http.head('https://t.co/:tweetUrlId', async (req, res, ctx) => {
-    return res(ctx.set('x-head-mock', 'true'))
-  }),
+  http.get<any, DefaultRequestMultipartBody>(
+    'https://t.co/:tweetUrlId',
+    async (req, res, ctx) => {
+      return res(ctx.text(getSiteMetadata(req.params.tweetUrlId as string)))
+    },
+  ),
+  http.head<any, DefaultRequestMultipartBody>(
+    'https://t.co/:tweetUrlId',
+    async (req, res, ctx) => {
+      return res(ctx.set('x-head-mock', 'true'))
+    },
+  ),
 ]
 
 export {twitterHandlers}

--- a/mocks/twitter.ts
+++ b/mocks/twitter.ts
@@ -1,6 +1,11 @@
 import path from 'path'
 import fsExtra from 'fs-extra'
-import {http, type DefaultRequestMultipartBody, type HttpHandler} from 'msw'
+import {
+  http,
+  type DefaultRequestMultipartBody,
+  type HttpHandler,
+  HttpResponse,
+} from 'msw'
 import type SiteMetadata from './data/site-metadata.json'
 import type Tweets from './data/tweets.json'
 import {isConnectedToTheInternet} from './utils.ts'
@@ -67,19 +72,19 @@ const twitterHandlers: Array<HttpHandler> = [
           `no tweet found for id ${tweetId}. This should be impossible...`,
         )
       }
-      return res(ctx.json(tweet))
+      return HttpResponse.json(tweet)
     },
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://t.co/:tweetUrlId',
     async (req, res, ctx) => {
-      return res(ctx.text(getSiteMetadata(params.tweetUrlId as string)))
+      return HttpResponse.text(getSiteMetadata(params.tweetUrlId as string))
     },
   ),
   http.head<any, DefaultRequestMultipartBody>(
     'https://t.co/:tweetUrlId',
     async (req, res, ctx) => {
-      return res(ctx.set('x-head-mock', 'true'))
+      return HttpResponse.json(null, {headers: {'x-head-mock': 'true'}})
     },
   ),
 ]

--- a/mocks/twitter.ts
+++ b/mocks/twitter.ts
@@ -39,7 +39,7 @@ function getSiteMetadata(tweetUrlId: string) {
 const twitterHandlers: Array<HttpHandler> = [
   http.get<any, DefaultRequestMultipartBody>(
     'https://cdn.syndication.twimg.com/tweet-result',
-    async (req, res, ctx) => {
+    async ({request}) => {
       const url = new URL(request.url)
 
       // if you want to mock out specific tweets, comment out this next line
@@ -77,13 +77,13 @@ const twitterHandlers: Array<HttpHandler> = [
   ),
   http.get<any, DefaultRequestMultipartBody>(
     'https://t.co/:tweetUrlId',
-    async (req, res, ctx) => {
+    async ({params}) => {
       return HttpResponse.text(getSiteMetadata(params.tweetUrlId as string))
     },
   ),
   http.head<any, DefaultRequestMultipartBody>(
     'https://t.co/:tweetUrlId',
-    async (req, res, ctx) => {
+    async () => {
       return HttpResponse.json(null, {headers: {'x-head-mock': 'true'}})
     },
   ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,11 +157,10 @@
         "eslint": "^8.49.0",
         "eslint-config-kentcdodds": "^20.5.0",
         "glob": "^10.3.4",
-        "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-watch-typeahead": "^2.2.2",
-        "msw": "^1.3.1",
+        "msw": "^2.0.8",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.3",
         "prettier-plugin-tailwindcss": "^0.5.4",
@@ -938,6 +937,33 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "dependencies": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
     },
     "node_modules/@cld-apis/types": {
       "version": "0.1.6",
@@ -3464,41 +3490,29 @@
       }
     },
     "node_modules/@mswjs/cookies": {
-      "version": "0.2.2",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.17.10",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.12.tgz",
+      "integrity": "sha512-a+zyoR01cPQeukSmaDEkE6aMwSjjfcT5ILzsyxmctEeCePnc2DMOd0X8Fn9bytq1IsAfMxJf/lu2aTfdivDbRg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "3.2.5",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
+        "strict-event-emitter": "^0.5.1"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@mswjs/interceptors/node_modules/strict-event-emitter": {
-      "version": "0.2.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0"
+        "node": ">=18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3879,10 +3893,27 @@
         "@octokit/openapi-types": "^18.0.0"
       }
     },
-    "node_modules/@open-draft/until": {
-      "version": "1.0.3",
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5565,14 +5596,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/source-map-support": {
       "version": "0.5.9",
       "dev": true,
@@ -5600,6 +5623,12 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.4.tgz",
+      "integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==",
+      "dev": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.4",
@@ -6002,14 +6031,6 @@
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "license": "(Apache-2.0 AND MIT)"
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/@xstate/fsm": {
       "version": "1.4.0",
@@ -9975,14 +9996,6 @@
       "version": "5.0.1",
       "license": "MIT"
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/exec-sh": {
       "version": "0.3.6",
       "dev": true,
@@ -11547,9 +11560,10 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.2.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "node_modules/helmet": {
       "version": "7.0.0",
@@ -11678,20 +11692,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -18247,28 +18247,31 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "1.3.2",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.8.tgz",
+      "integrity": "sha512-/5nQCotVka62lvubQ3tMfUS3TukyeBwvWyvAthcXvDlXGhkA/85HlEwZyFlJ3ZsPW45Ty+ao0S4oFvuM12R/kA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.10",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.11",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "^4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
         "graphql": "^16.8.1",
-        "headers-polyfill": "3.2.5",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
         "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.4.3",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -18276,14 +18279,14 @@
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.2.x"
+        "typescript": ">= 4.7.x <= 5.2.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -18336,33 +18339,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/msw/node_modules/cookie": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/msw/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/msw/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -18374,11 +18350,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/msw/node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/msw/node_modules/type-fest": {
       "version": "2.19.0",
       "dev": true,
@@ -18388,20 +18359,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/msw/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/msw/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/mute-stream": {
@@ -19422,8 +19379,9 @@
     },
     "node_modules/outvariant": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "dev": true
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -23490,9 +23448,10 @@
       "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
-      "version": "0.4.6",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
-    "msw": "^1.3.1",
+    "msw": "^2.0.8",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",
     "prettier-plugin-tailwindcss": "^0.5.4",


### PR DESCRIPTION
This pull request is the result of running [upgrade-recipe](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2) sequence of codemods. Manual corrections were made to make sure no TypeScript errors remained present.

MSW v2 now uses native browser API as a standard, adhering to the modern standards. Verbosity is lowered, as one might use the HttpResponse helper function alongside with simple key-value configuration object which improves the readability and simplifies MSW's API usage.

Metrics:
**Effort**: Codemod sequence was built in a week, and had been run on 5+ codebases to ensure it covers the most used cases.
**Automation coverage**: covered all the necessary changes. Manual changes had to be done to ensure TypeScript is happy.
**Estimated time save**: 8 hours total. Each mod run performed changes on a set of handlers, covering various use-cases. In order to make this happen manually, one would have to go through the entire documentation and perform manual changes. Documentation also does not cover TypeScript changes.
**Number of files changed**: 9 (11 with package.json)
**FP (unwanted changes)**: no known FPs as of now.
**FN (missed changes)**:
- Current codemod does not cover factory methods, meaning if your msw calls have a wrapper around it, we do not support this use-case at the moment.
- If you were using req.body in your interceptors, this codemod will blindly assume you want `await request.json()` instead of any other type. You will have to correct that manually if you want another body type.