### PR TITLE
update example code to reuse prepared statements

### DIFF
--- a/content/blog/i-migrated-from-a-postgres-cluster-to-distributed-sqlite-with-litefs.mdx
+++ b/content/blog/i-migrated-from-a-postgres-cluster-to-distributed-sqlite-with-litefs.mdx
@@ -395,31 +395,33 @@ well. There were just a few different (better) option names and I needed to
 write a SQLite adapter:
 
 ```ts
+const preparedGet = cacheDb.prepare(
+  'SELECT value, metadata FROM cache WHERE key = ?'
+)
+const preparedSet = cacheDb.prepare(
+  'INSERT OR REPLACE INTO cache (key, value, metadata) VALUES (@key, @value, @metadata)'
+)
+const preparedDelete = cacheDb.prepare('DELETE FROM cache WHERE key = ?')
+
 export const cache: CachifiedCache = {
   name: 'SQLite cache',
   get(key) {
-    const result = cacheDb
-      .prepare('SELECT value, metadata FROM cache WHERE key = ?')
-      .get(key)
+    const result = preparedGet.get(key)
     if (!result) return null
     return {
       metadata: JSON.parse(result.metadata),
       value: JSON.parse(result.value),
     }
   },
-  set(key, {value, metadata}) {
-    cacheDb
-      .prepare(
-        'INSERT OR REPLACE INTO cache (key, value, metadata) VALUES (@key, @value, @metadata)',
-      )
-      .run({
-        key,
-        value: JSON.stringify(value),
-        metadata: JSON.stringify(metadata),
-      })
+  set(key, { value, metadata }) {
+    preparedSet.run({
+      key,
+      value: JSON.stringify(value),
+      metadata: JSON.stringify(metadata),
+    })
   },
-  async delete(key) {
-    cacheDb.prepare('DELETE FROM cache WHERE key = ?').run(key)
+  delete(key) {
+    preparedDelete.run(key)
   },
 }
 ```


### PR DESCRIPTION
great article Kent! 

feel free to close this without doing anything, as it's just a tip.

While reading, I noticed in your example code that you create a new sqlite prepared statement every time you `get`/`set`/`delete` from the cache. I don't know if you did that for brevity or if your actual code looks like that, but it would be faster to reuse that prepared statement every time (that's the beauty of prepared statements, [they let you skip the sql string parsing and stuff on subsequent calls](https://www.sqlite.org/c3ref/stmt.html#:~:text=Create%20the%20prepared,or%20more%20times) ) 

So this is just a tip for you to change your app code if that is indeed how you're using it, and maybe change your example code so if people copy/paste it, their app also benefits from just preparing it once.