### PR TITLE
Fix duplicate "and" in the problem solution section

### DIFF
--- a/app/components/sections/problem-solution-section.tsx
+++ b/app/components/sections/problem-solution-section.tsx
@@ -158,7 +158,7 @@ function ProblemSolutionSection({
             <Link prefetch="intent" to="/blog?q=career">
               your career
             </Link>
-            {`, and `}
+            {`, `}
             <Link prefetch="intent" to="/blog">
               and more
             </Link>


### PR DESCRIPTION
Currently it's 

![Screenshot 2023-12-30 at 13 21 12](https://github.com/kentcdodds/kentcdodds.com/assets/16667281/c0ae814d-0f12-40d7-bbe3-53250d4e1d81)

This should turn it into: 

> Educational blog
> My 200 blog posts (and counting) have been read 717,715 times by 521,596 people. There you'll find blogs about JavaScript, TypeScript, React, Testing, your career, and more.

Maintaining the _and more_ link.


