### PR TITLE
Use pure css for hero reveal animation

### DIFF
--- a/app/components/sections/hero-section.tsx
+++ b/app/components/sections/hero-section.tsx
@@ -106,9 +106,9 @@ function HeroSection({
               transition={{duration: 0.75}}
             />
           ) : imageBuilder ? (
-            <motion.img
+            <img
               className={clsx(
-                'h-auto w-full object-contain',
+                'h-auto w-full object-contain motion-safe:animate-hero-reveal',
                 {
                   'max-h-50vh': imageSize === 'medium',
                   'max-h-75vh': imageSize === 'giant',
@@ -117,9 +117,6 @@ function HeroSection({
               )}
               style={imageBuilder.style}
               {...getHeroImageProps(imageBuilder)}
-              initial={{scale: shouldReduceMotion ? 1 : 1.5, opacity: 0}}
-              animate={{scale: 1, opacity: 1}}
-              transition={{duration: 0.75}}
             />
           ) : (
             image

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -69,11 +69,22 @@ export default {
         'spin-slow': 'spin 3s linear infinite',
         'spin-xslow': 'spin 7s linear infinite',
         'reverse-spin': 'reverse-spin 1s linear infinite',
+        'hero-reveal': 'hero-reveal 750ms',
       },
       keyframes: {
         'reverse-spin': {
           from: {
             transform: 'rotate(360deg)',
+          },
+        },
+        'hero-reveal': {
+          from: {
+            opacity: '0',
+            transform: 'scale(1.5)',
+          },
+          to: {
+            opacity: '1',
+            transform: 'scale(1)',
           },
         },
       },


### PR DESCRIPTION
Currently to start the animation, the site is waiting for js bundle to load and this results in a significant delay for the user until they can see the animation on a bad network.

I am switching to using pure CSS animation that is preloaded and starts as soon as the html element is rendered.

- uses pure css
- keeps reduced motion preference 

Lets compare before/after pagespeed metrics!