### PR TITLE
enable MDX type checking

### DIFF
--- a/app/utils/mdx.tsx
+++ b/app/utils/mdx.tsx
@@ -122,6 +122,23 @@ declare global {
   type MDXProvidedComponents = typeof mdxComponents
 }
 
+interface CalloutProps {
+  children: React.ReactNode
+  class?: string
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'callout-danger': CalloutProps
+      'callout-info': CalloutProps
+      'callout-muted': CalloutProps
+      'callout-success': CalloutProps
+      'callout-warning': CalloutProps
+    }
+  }
+}
+
 /**
  * This should be rendered within a useMemo
  * @param code the code to get the component from

--- a/app/utils/mdx.tsx
+++ b/app/utils/mdx.tsx
@@ -117,6 +117,11 @@ const mdxComponents = {
   SubscribeForm,
   OptionalUser,
 }
+
+declare global {
+  type MDXProvidedComponents = typeof mdxComponents
+}
+
 /**
  * This should be rendered within a useMemo
  * @param code the code to get the component from

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": ["**/*.mdx", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["jest"],
@@ -24,5 +24,8 @@
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true
+  },
+  "mdx": {
+    "checkMdx": true
   }
 }


### PR DESCRIPTION
I thought it would be nice to see how the latest [MDX language server](https://github.com/mdx-js/mdx-analyzer/blob/main/packages/language-server/README.md) changes work out on a real-world project. So I picked an MDX heavy project to enable strict type checking.

In `tsconfig.json` `**/*.mdx` is now included explicitly. This makes the MDX files part of the same TypeScript program as the TypeScript files. This is only needed at all, because the `include` array is defined. It can also be omitted entirely.

The `mdx.checkMdx` option in `tsconfig.json` enables strict type checking for MDX files. It’s analogous to `checkJs` for JavaScript files. Feel free to disable this if it turns out to be annoying.

The global type [`MDXProvidedComponents`](https://github.com/mdx-js/mdx-analyzer/blob/main/packages/language-server/README.md#mdxprovidedcomponents) specified which types are available inside MDX files globally.

There’s a type error in `content/pages/live.mdx`.

Several pages use the `<callout-info>` element. I’m not sure what this is. A fix would be to add this somewhere:

```ts
declare global {
  namespace JSX {
    interface IntrinsicElements {
      'callout-info': CalloutInfoProps
    }
  }
}
```