### PR TITLE
fix: update talk links

### DIFF
--- a/content/blog/2010s-decade-in-review.mdx
+++ b/content/blog/2010s-decade-in-review.mdx
@@ -457,8 +457,8 @@ did get a few accepted. 2015 is when I had to deliver.
 
 The first conference of the year was Jfokus. I submitted several talks to speak
 and was selected for two of them
-["Using ReactJS with existing AngularJS codebase"](/talks/#using-react-js-with-existing-angular-js-codebase)
-and [Intro to AngularJS](/talks/#intro-to-angular-js). They wanted the "Intro"
+["Using ReactJS with existing AngularJS codebase"](/talks/using-react-js-with-existing-angular-js-codebase)
+and [Intro to AngularJS](/talks/intro-to-angular-js). They wanted the "Intro"
 talk to be a 3 hour "talk". I wasn't experienced enough to know that this is
 ill-advised 😆 It actually went pretty well considering that. I basically just
 walked through the whole intro workshop I had given my friends in school the

--- a/content/blog/a-review-of-my-time-at-remix.mdx
+++ b/content/blog/a-review-of-my-time-at-remix.mdx
@@ -88,7 +88,7 @@ plenty more, but those I really don't think I am allowed to talk about yet 😅
 I've spent my time at Remix working on pushing all these quantitative metrics
 and qualitative properties around adoption forward. Since joining Remix, I have
 given
-[my introductory talk](https://kentcdodds.com/talks/building-excellent-user-experiences-with-remix)
+[my introductory talk](/talks/building-excellent-user-experiences-with-remix)
 over 20 times (many to some of the aforementioned companies). I traveled to 6
 conferences and gave talks about Remix all over the world (I have
 [more coming up soon too](/talks)!). I also

--- a/content/blog/becoming-an-open-source-project-maintainer.mdx
+++ b/content/blog/becoming-an-open-source-project-maintainer.mdx
@@ -14,7 +14,7 @@ published over 100 packages to npm. Not all of them are widely used (or used at
 all), but many of them are. I have some ideas about how to maintain open source
 projects. I've given a talk on this in the past (unfortunately each time the
 recording sadly failed, but there's a practice run, so
-[check it out here](/talks/#managing-an-open-source-project)).
+[check it out here](/talks/managing-an-open-source-project)).
 
 In this post though, I want to talk about how you become a project maintainer.
 The easiest way to do this is to create your own project from scratch, but often

--- a/content/blog/how-to-get-experience-as-a-software-engineer.mdx
+++ b/content/blog/how-to-get-experience-as-a-software-engineer.mdx
@@ -93,7 +93,7 @@ followed by
 months and PRs later, and I found myself a core maintainer, and then later the
 sole maintainer of the project. That whole project presented a TON of
 "experience-building problems" for me (as well as
-[opportunities to speak internationally](/talks/#json-powered-forms)). I learned
+[opportunities to speak internationally](/talks/json-powered-forms)). I learned
 a TON about how forms work on the web and as a maintainer of the project.
 
 When you find a problem. DIG. If you have problems digging, then awesome! You

--- a/content/blog/what-is-a-polyfill.mdx
+++ b/content/blog/what-is-a-polyfill.mdx
@@ -62,7 +62,7 @@ With these, if you
 the `includes` function is not transpiled because it's not a syntax issue, but a
 built-in API one and babel's env preset only includes transforms for syntax
 transformations. You _could_
-[write your own babel plugin](/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
+[write your own babel plugin](talks/writing-custom-babel-and-es-lint-plugins-with-asts)
 ([like this](https://astexplorer.net/#/gist/538b72e2af148a14d7c0f5824b431cd6/47a57f42697199d6cfa1d4b1027951ef170a980e))
 to transform the code, but for _some_ APIs it just wouldn't be practical because
 the transformed version would be significantly complex.

--- a/content/blog/why-youve-been-bad-about-testing.mdx
+++ b/content/blog/why-youve-been-bad-about-testing.mdx
@@ -41,7 +41,7 @@ component and your test breaks. 😡 I wouldn't want to write tests either.
 When I got started with testing years ago, I struggled. I struggled hard. I've
 spent countless hours learning, building, and rebuilding tools. I even gave a
 _full hour_ talk called
-["ES6, Webpack, Karma, and Code Coverage"](/talks/#es-6-webpack-karma-and-code-coverage).
+["ES6, Webpack, Karma, and Code Coverage"](/talks/es-6-webpack-karma-and-code-coverage).
 It took a full 60 minutes to explain how to make these tools play nicely
 together. It took dozens more hours behind the scenes to figure out what I
 explain in that talk.


### PR DESCRIPTION
## Problem
While reading "2010s decade in review", I noticed that the link to the talks were not working.

After a quick test, it seems that without the `#` it works as expected.

## Solution
- Replace the `/talks/#my-slug` by `talks/my-slug` links in the MDX files

✅  Tested locally