### PR TITLE
fix link error in a blog from a recent newsletter

### DIFF
--- a/content/blog/how-getting-into-open-source-has-been-awesome-for-me.mdx
+++ b/content/blog/how-getting-into-open-source-has-been-awesome-for-me.mdx
@@ -134,7 +134,7 @@ See you on [Twitter](https://twitter.com/kentcdodds) and
 
 **Other Resources:**
 
-- [How to Write an Open Source JavaScript Library](https://egghead.io/series/how-to-write-an-open-source-javascript-library)
+- [How to Write an Open Source JavaScript Library](https://egghead.io/courses/how-to-write-an-open-source-javascript-library)
   (this is one of [my courses](/courses))
 - [24 Pull Requests](http://24pullrequests.com/contributing)
 - [First Timers Only](/blog/first-timers-only)


### PR DESCRIPTION
There is a wrong (maybe old) link referenced in a blog post that I found through your recent newsletter and I find and replace with working link.