### PR TITLE
Discord's new usernames do not include a discriminator

### DIFF
--- a/app/routes/discord+/callback.tsx
+++ b/app/routes/discord+/callback.tsx
@@ -97,7 +97,7 @@ export default function DiscordCallback() {
 							<PartyIcon />
 						</span>
 						<span className="text-team-current">
-							{discordMember.user.username}#{discordMember.user.discriminator}
+							{discordMember.user.username}
 						</span>
 						{` has been connected to `}
 						<span>


### PR DESCRIPTION
Since March 2024, discord usernames no longer include a discriminator. All `username`s are unique :) https://support.discord.com/hc/en-us/articles/12620128861463-New-Usernames-Display-Names