### PR TITLE
add AI Engineer World's Fair to talks

### DIFF
--- a/content/data/talks.yml
+++ b/content/data/talks.yml
@@ -93,6 +93,9 @@
       recording: https://www.youtube.com/watch?v=7l9cMhQndiY&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf
     - event: '[CityJS London](https://london.cityjsconf.org/)'
       date: 2025-04-23
+    - event: "[AI Engineer World's Fair](https://ai.engineer)"
+      date: 2025-06-03
+      recording: https://youtu.be/EyZiAp0pelw
     - event: '[Frontend Nation](https://frontendnation.com/)'
       date: 2025-06-03
     - event: '[Render ATL](https://www.renderatl.com/)'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new event entry for the talk "Letting AI Interface with Your App with MCPs," including details for its presentation at the AI Engineer World's Fair and a link to the YouTube recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->