### PR TITLE
Fix mobile navigation menu responsiveness

### DIFF
--- a/app/components/navbar.css
+++ b/app/components/navbar.css
@@ -1,25 +1,22 @@
-body:has(#mobile-menu:popover-open) {
-	overflow: hidden;
-
-	[popovertarget='mobile-menu'] {
-		rect:nth-of-type(1) {
-			transform: translateY(7px) rotate(45deg);
-			transform-origin: 16px 10px;
-			transition:
-				transform 0.2s ease,
-				opacity 0.2s ease;
-		}
-		rect:nth-of-type(2) {
-			opacity: 0;
-			transition: opacity 0.2s ease;
-		}
-		rect:nth-of-type(3) {
-			transform: translateY(-5px) rotate(-45deg);
-			transform-origin: 16px 22px;
-			transition:
-				transform 0.2s ease,
-				opacity 0.2s ease;
-		}
+/* Note: overflow: hidden is now managed by JavaScript to avoid race conditions */
+body:has(#mobile-menu:popover-open) [popovertarget='mobile-menu'] {
+	rect:nth-of-type(1) {
+		transform: translateY(7px) rotate(45deg);
+		transform-origin: 16px 10px;
+		transition:
+			transform 0.2s ease,
+			opacity 0.2s ease;
+	}
+	rect:nth-of-type(2) {
+		opacity: 0;
+		transition: opacity 0.2s ease;
+	}
+	rect:nth-of-type(3) {
+		transform: translateY(-5px) rotate(-45deg);
+		transform-origin: 16px 22px;
+		transition:
+			transform 0.2s ease,
+			opacity 0.2s ease;
 	}
 }
 


### PR DESCRIPTION
Fix mobile navigation menu getting stuck by robustly managing body overflow and closing popover on route change.

The previous implementation had a race condition where the `body:has(#mobile-menu:popover-open) { overflow: hidden; }` CSS rule would sometimes persist `overflow: hidden` on the body even after the popover visually closed, preventing user interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the behavior of the mobile menu to prevent background scrolling when the menu is open.
  * Ensured the mobile menu automatically closes when navigating to a new page.

* **Style**
  * Updated CSS to better manage mobile menu transitions and interactions.

* **Chores**
  * Added comments to clarify how overflow behavior is now managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->