### PR TITLE
Set up temporary Fly deployments for PRs

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,46 +30,9 @@ jobs:
 
       - name: 📝 Setup PR-specific configurations
         run: |
-          # Copy and modify fly.toml for PR preview
-          cp fly.toml fly.toml.backup
-          
-          # Update app name for PR
-          sed -i 's/^app = .*/app = "${{ steps.app-name.outputs.app_name }}"/' fly.toml
-          
-          # Remove consul from experimental section (if present)
-          sed -i '/enable_consul = true/d' fly.toml
-          
-          # Add auto-scaling configuration to services section
-          # Find the [[services]] section and add auto-scaling after internal_port
-          awk '
-          /^\[\[services\]\]/ { in_services = 1 }
-          /^  internal_port = / && in_services { 
-            print $0
-            print "  auto_stop_machines = true"
-            print "  auto_start_machines = true" 
-            print "  min_machines_running = 0"
-            print "  processes = [\"app\"]"
-            in_services = 0
-            next
-          }
-          { print }
-          ' fly.toml > fly.toml.tmp && mv fly.toml.tmp fly.toml
-          
-          # Copy and modify litefs.yml for PR preview (standalone, no consul)
-          cp other/litefs.yml other/litefs.yml.backup
-          
-          # Replace consul lease with static lease for PR preview isolation
-          # This makes each PR preview a standalone instance
-          sed -i '/^lease:/,/^exec:/c\
-lease:\
-  type: static\
-\
-exec:' other/litefs.yml
-          
-          # Add a comment explaining the isolation
-          sed -i '/^lease:/i\
-# PR Preview: Using static lease type for standalone instance\
-# This prevents syncing with production data' other/litefs.yml
+          # Make script executable and run it
+          chmod +x other/setup-pr-preview.js
+          node other/setup-pr-preview.js "${{ steps.app-name.outputs.app_name }}"
           
           echo "=== Modified fly.toml ==="
           cat fly.toml

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,7 +28,11 @@ jobs:
           echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
           echo "url=https://$APP_NAME.fly.dev" >> $GITHUB_OUTPUT
 
-      - name: 📝 Setup PR-specific configurations
+      - name: � Install dependencies for setup script
+        run: |
+          npm install js-yaml
+
+      - name: �📝 Setup PR-specific configurations
         run: |
           # Make script executable and run it
           chmod +x other/setup-pr-preview.js
@@ -104,6 +108,24 @@ jobs:
         run: |
           APP_NAME="kcd-pr-${{ github.event.number }}"
           echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+
+      - name: 🧹 Cleanup volumes
+        run: |
+          # List and delete all volumes for the PR app
+          echo "Checking for volumes to cleanup..."
+          VOLUMES=$(flyctl volumes list --app ${{ steps.app-name.outputs.app_name }} --json 2>/dev/null || echo "[]")
+          
+          if [ "$VOLUMES" != "[]" ] && [ -n "$VOLUMES" ]; then
+            echo "Found volumes to cleanup"
+            echo "$VOLUMES" | jq -r '.[].id' | while read -r VOLUME_ID; do
+              if [ -n "$VOLUME_ID" ]; then
+                echo "Destroying volume: $VOLUME_ID"
+                flyctl volumes destroy "$VOLUME_ID" --yes || echo "Failed to destroy volume $VOLUME_ID"
+              fi
+            done
+          else
+            echo "No volumes found to cleanup"
+          fi
 
       - name: 🗑️ Delete PR app
         run: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -60,13 +60,16 @@ jobs:
           
           # Replace consul lease with static lease for PR preview isolation
           # This makes each PR preview a standalone instance
-          sed -i '/^lease:/,/^$/c\
+          sed -i '/^lease:/,/^exec:/c\
 lease:\
-  type: '\''static'\''
-' other/litefs.yml
+  type: static\
+\
+exec:' other/litefs.yml
           
           # Add a comment explaining the isolation
-          sed -i '/^lease:/i\\n# PR Preview: Using static lease type for standalone instance\n# This prevents syncing with production data' other/litefs.yml
+          sed -i '/^lease:/i\
+# PR Preview: Using static lease type for standalone instance\
+# This prevents syncing with production data' other/litefs.yml
           
           echo "=== Modified fly.toml ==="
           cat fly.toml

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -41,7 +41,6 @@ jobs:
 
           [experimental]
             auto_rollback = true
-            enable_consul = true
 
           [[mounts]]
             source = "data_machines"
@@ -113,7 +112,58 @@ jobs:
               path = "/litefs/health"
           EOF
 
-      - name: 🚀 Deploy PR app
+      - name: � Generate PR litefs.yml
+        run: |
+          # Create a litefs.yml file for this PR deployment (without consul)
+          cat > other/litefs.yml << 'EOF'
+          # LiteFS configuration for PR preview (standalone, no consul)
+          fuse:
+            dir: '${LITEFS_DIR}'
+            debug: false
+
+          data:
+            dir: '/data/litefs'
+
+          proxy:
+            addr: ':${INTERNAL_PORT}'
+            target: 'localhost:${PORT}'
+            db: '${DATABASE_FILENAME}'
+            debug: false
+            passthrough:
+              - '/build/*'
+              - '/favicons/*'
+              - '/images/*'
+              - '/fonts/*'
+              - '/*.png'
+              - '/*.ico'
+              - '/*.txt'
+              - '/*.webmanifest'
+
+          tracing:
+            enabled: true
+            path: '/var/log/litefs/trace.log'
+            max-size: 64
+            max-count: 3
+            compress: true
+
+          exit-on-error: false
+
+          # No lease configuration - this makes it a standalone instance
+          # No consul, no clustering, isolated from production
+
+          exec:
+            - cmd: npx prisma migrate deploy
+
+            # Set the journal mode for the database to WAL
+            - cmd: sqlite3 $DATABASE_PATH "PRAGMA journal_mode = WAL;"
+
+            # Set the journal mode for the cache to WAL
+            - cmd: sqlite3 $CACHE_DATABASE_PATH "PRAGMA journal_mode = WAL;"
+
+            - cmd: npm start
+          EOF
+
+      - name: �🚀 Deploy PR app
         run: |
           flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app-name.outputs.app_name }}
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -74,7 +74,11 @@ jobs:
           echo "=== Modified litefs.yml ==="
           cat other/litefs.yml
 
-      - name: � Deploy PR app
+      - name: 🏗️ Create PR app
+        run: |
+          flyctl apps create ${{ steps.app-name.outputs.app_name }} --org personal || echo "App already exists"
+
+      - name: 🚀 Deploy PR app
         run: |
           flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app-name.outputs.app_name }}
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -8,10 +8,38 @@ env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
 jobs:
+  changes:
+    name: 🔎 Determine deployable changes
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    outputs:
+      DEPLOYABLE: ${{steps.changes.outputs.DEPLOYABLE}}
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '50'
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: 🔎 Determine deployable changes
+        id: changes
+        run: >-
+          echo ::set-output name=DEPLOYABLE::$(node ./other/is-deployable.js ${{
+          github.sha }})
+
+      - name: ❓ Deployable
+        run: >-
+          echo "DEPLOYABLE: ${{steps.changes.outputs.DEPLOYABLE}}"
+
   deploy-pr:
     name: 🚀 Deploy PR Preview
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
+    needs: [changes]
+    if: github.event.action != 'closed' && needs.changes.outputs.DEPLOYABLE == 'true'
     
     steps:
       - name: ⬇️ Checkout repo
@@ -38,7 +66,7 @@ jobs:
           cp .env.example .env
           echo "✓ Environment variables copied from .env.example"
 
-      - name: �📝 Setup PR-specific configurations
+      - name: �� Setup PR-specific configurations
         run: |
           # Make script executable and run it
           chmod +x other/setup-pr-preview.js
@@ -80,6 +108,52 @@ jobs:
             
             This preview will automatically scale to zero when not in use to save costs.
             The app will be automatically deleted when this PR is closed or merged.
+            
+            ---
+            <sub>Updated: ${new Date().toISOString()}</sub>`;
+            
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+            } else {
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody
+              });
+            }
+
+  no-deploy-pr:
+    name: 💬 Comment on non-deployable changes
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.event.action != 'closed' && needs.changes.outputs.DEPLOYABLE == 'false'
+    
+    steps:
+      - name: 💬 Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && comment.body.includes('PR Preview')
+            );
+            
+            const commentBody = `🔍 **PR Preview Skipped**
+            
+            No preview deployment was created because this PR only contains content changes.
+            
+            Content-only changes don't require a full deployment preview since they don't affect the application functionality.
             
             ---
             <sub>Updated: ${new Date().toISOString()}</sub>`;

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,6 +7,11 @@ on:
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   changes:
     name: 🔎 Determine deployable changes
@@ -83,7 +88,7 @@ jobs:
 
       - name: 🚀 Deploy PR app
         run: |
-          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --build-arg INSTALL_DEV_DEPS=true --app ${{ steps.app-name.outputs.app_name }}
+          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app-name.outputs.app_name }}
 
       - name: 💬 Comment on PR
         uses: actions/github-script@v7
@@ -96,7 +101,8 @@ jobs:
             });
             
             const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && comment.body.includes('PR Preview')
+              (comment.user.login === 'github-actions[bot]' || comment.user.type === 'Bot') && 
+              comment.body.includes('PR Preview')
             );
             
             const commentBody = `🚀 **PR Preview Deployed**
@@ -146,7 +152,8 @@ jobs:
             });
             
             const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && comment.body.includes('PR Preview')
+              (comment.user.login === 'github-actions[bot]' || comment.user.type === 'Bot') && 
+              comment.body.includes('PR Preview')
             );
             
             const commentBody = `🔍 **PR Preview Skipped**

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,198 @@
+name: 🔍 PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  deploy-pr:
+    name: 🚀 Deploy PR Preview
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🎈 Setup Fly
+        uses: superfly/flyctl-actions/setup-flyctl@1.5
+
+      - name: 🏷️ Generate app name
+        id: app-name
+        run: |
+          # Create a unique app name for this PR
+          APP_NAME="kcd-pr-${{ github.event.number }}"
+          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+          echo "url=https://$APP_NAME.fly.dev" >> $GITHUB_OUTPUT
+
+      - name: 📝 Generate PR fly.toml
+        run: |
+          # Create a fly.toml file for this PR deployment
+          cat > fly.toml << 'EOF'
+          # fly.toml app configuration file for PR preview
+          app = "${{ steps.app-name.outputs.app_name }}"
+          primary_region = "den"
+          kill_signal = "SIGINT"
+          kill_timeout = "5s"
+          swap_size_mb = 512
+
+          [experimental]
+            auto_rollback = true
+            enable_consul = true
+
+          [[mounts]]
+            source = "data_machines"
+            destination = "/data"
+            processes = ["app"]
+
+          [[statics]]
+            guest_path = "/app/build/client/.vite"
+            url_prefix = "/.vite"
+
+          [[statics]]
+            guest_path = "/app/build/client/assets"
+            url_prefix = "/assets"
+
+          [[statics]]
+            guest_path = "/app/build/client/fonts"
+            url_prefix = "/fonts"
+
+          [[statics]]
+            guest_path = "/app/build/client/images"
+            url_prefix = "/images"
+
+          [[statics]]
+            guest_path = "/app/build/client/favicons"
+            url_prefix = "/favicons"
+
+          [[services]]
+            protocol = "tcp"
+            internal_port = 8080
+            auto_stop_machines = true
+            auto_start_machines = true
+            min_machines_running = 0
+            processes = ["app"]
+
+            [[services.ports]]
+              port = 80
+              handlers = ["http"]
+              force_https = true
+
+            [[services.ports]]
+              port = 443
+              handlers = ["tls", "http"]
+            
+            [services.concurrency]
+              type = "requests"
+              hard_limit = 200
+              soft_limit = 150
+
+            [[services.tcp_checks]]
+              interval = "15s"
+              timeout = "2s"
+              grace_period = "10s"
+              restart_limit = 6
+
+            [[services.http_checks]]
+              interval = "10s"
+              timeout = "5s"
+              grace_period = "1m0s"
+              restart_limit = 0
+              method = "get"
+              path = "/healthcheck"
+              protocol = "http"
+
+            [[services.http_checks]]
+              grace_period = "10s"
+              interval = "30s"
+              method = "GET"
+              timeout = "5s"
+              path = "/litefs/health"
+          EOF
+
+      - name: 🚀 Deploy PR app
+        run: |
+          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app-name.outputs.app_name }}
+
+      - name: 💬 Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && comment.body.includes('PR Preview')
+            );
+            
+            const commentBody = `🚀 **PR Preview Deployed**
+            
+            Your pull request has been deployed to a temporary Fly machine:
+            
+            🔗 **Preview URL**: ${{ steps.app-name.outputs.url }}
+            📱 **App Name**: \`${{ steps.app-name.outputs.app_name }}\`
+            
+            This preview will automatically scale to zero when not in use to save costs.
+            The app will be automatically deleted when this PR is closed or merged.
+            
+            ---
+            <sub>Updated: ${new Date().toISOString()}</sub>`;
+            
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+            } else {
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody
+              });
+            }
+
+  cleanup-pr:
+    name: 🧹 Cleanup PR Preview
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+    
+    steps:
+      - name: 🎈 Setup Fly
+        uses: superfly/flyctl-actions/setup-flyctl@1.5
+
+      - name: 🏷️ Generate app name
+        id: app-name
+        run: |
+          APP_NAME="kcd-pr-${{ github.event.number }}"
+          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+
+      - name: 🗑️ Delete PR app
+        run: |
+          flyctl apps destroy ${{ steps.app-name.outputs.app_name }} --yes || echo "App doesn't exist or already deleted"
+
+      - name: 💬 Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentBody = `🧹 **PR Preview Cleaned Up**
+            
+            The temporary Fly machine for this PR has been deleted.
+            
+            ---
+            <sub>Cleaned up: ${new Date().toISOString()}</sub>`;
+            
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody
+            });

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,142 +28,53 @@ jobs:
           echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
           echo "url=https://$APP_NAME.fly.dev" >> $GITHUB_OUTPUT
 
-      - name: 📝 Generate PR fly.toml
+      - name: 📝 Setup PR-specific configurations
         run: |
-          # Create a fly.toml file for this PR deployment
-          cat > fly.toml << 'EOF'
-          # fly.toml app configuration file for PR preview
-          app = "${{ steps.app-name.outputs.app_name }}"
-          primary_region = "den"
-          kill_signal = "SIGINT"
-          kill_timeout = "5s"
-          swap_size_mb = 512
+          # Copy and modify fly.toml for PR preview
+          cp fly.toml fly.toml.backup
+          
+          # Update app name for PR
+          sed -i 's/^app = .*/app = "${{ steps.app-name.outputs.app_name }}"/' fly.toml
+          
+          # Remove consul from experimental section (if present)
+          sed -i '/enable_consul = true/d' fly.toml
+          
+          # Add auto-scaling configuration to services section
+          # Find the [[services]] section and add auto-scaling after internal_port
+          awk '
+          /^\[\[services\]\]/ { in_services = 1 }
+          /^  internal_port = / && in_services { 
+            print $0
+            print "  auto_stop_machines = true"
+            print "  auto_start_machines = true" 
+            print "  min_machines_running = 0"
+            print "  processes = [\"app\"]"
+            in_services = 0
+            next
+          }
+          { print }
+          ' fly.toml > fly.toml.tmp && mv fly.toml.tmp fly.toml
+          
+          # Copy and modify litefs.yml for PR preview (standalone, no consul)
+          cp other/litefs.yml other/litefs.yml.backup
+          
+          # Remove the entire lease section to make it standalone
+          # This removes everything from "lease:" to the next top-level section
+          awk '
+          /^lease:/ { in_lease = 1; next }
+          /^[a-zA-Z]/ && in_lease && !/^  / { in_lease = 0 }
+          !in_lease { print }
+          ' other/litefs.yml > other/litefs.yml.tmp && mv other/litefs.yml.tmp other/litefs.yml
+          
+          # Add a comment explaining the isolation
+          sed -i '/^exit-on-error:/a\\n# PR Preview: No lease configuration - standalone instance\n# This prevents syncing with production data' other/litefs.yml
+          
+          echo "=== Modified fly.toml ==="
+          cat fly.toml
+          echo "=== Modified litefs.yml ==="
+          cat other/litefs.yml
 
-          [experimental]
-            auto_rollback = true
-
-          [[mounts]]
-            source = "data_machines"
-            destination = "/data"
-            processes = ["app"]
-
-          [[statics]]
-            guest_path = "/app/build/client/.vite"
-            url_prefix = "/.vite"
-
-          [[statics]]
-            guest_path = "/app/build/client/assets"
-            url_prefix = "/assets"
-
-          [[statics]]
-            guest_path = "/app/build/client/fonts"
-            url_prefix = "/fonts"
-
-          [[statics]]
-            guest_path = "/app/build/client/images"
-            url_prefix = "/images"
-
-          [[statics]]
-            guest_path = "/app/build/client/favicons"
-            url_prefix = "/favicons"
-
-          [[services]]
-            protocol = "tcp"
-            internal_port = 8080
-            auto_stop_machines = true
-            auto_start_machines = true
-            min_machines_running = 0
-            processes = ["app"]
-
-            [[services.ports]]
-              port = 80
-              handlers = ["http"]
-              force_https = true
-
-            [[services.ports]]
-              port = 443
-              handlers = ["tls", "http"]
-            
-            [services.concurrency]
-              type = "requests"
-              hard_limit = 200
-              soft_limit = 150
-
-            [[services.tcp_checks]]
-              interval = "15s"
-              timeout = "2s"
-              grace_period = "10s"
-              restart_limit = 6
-
-            [[services.http_checks]]
-              interval = "10s"
-              timeout = "5s"
-              grace_period = "1m0s"
-              restart_limit = 0
-              method = "get"
-              path = "/healthcheck"
-              protocol = "http"
-
-            [[services.http_checks]]
-              grace_period = "10s"
-              interval = "30s"
-              method = "GET"
-              timeout = "5s"
-              path = "/litefs/health"
-          EOF
-
-      - name: � Generate PR litefs.yml
-        run: |
-          # Create a litefs.yml file for this PR deployment (without consul)
-          cat > other/litefs.yml << 'EOF'
-          # LiteFS configuration for PR preview (standalone, no consul)
-          fuse:
-            dir: '${LITEFS_DIR}'
-            debug: false
-
-          data:
-            dir: '/data/litefs'
-
-          proxy:
-            addr: ':${INTERNAL_PORT}'
-            target: 'localhost:${PORT}'
-            db: '${DATABASE_FILENAME}'
-            debug: false
-            passthrough:
-              - '/build/*'
-              - '/favicons/*'
-              - '/images/*'
-              - '/fonts/*'
-              - '/*.png'
-              - '/*.ico'
-              - '/*.txt'
-              - '/*.webmanifest'
-
-          tracing:
-            enabled: true
-            path: '/var/log/litefs/trace.log'
-            max-size: 64
-            max-count: 3
-            compress: true
-
-          exit-on-error: false
-
-          # No lease configuration - this makes it a standalone instance
-          # No consul, no clustering, isolated from production
-
-          exec:
-            - cmd: npx prisma migrate deploy
-
-            # Set the journal mode for the database to WAL
-            - cmd: sqlite3 $DATABASE_PATH "PRAGMA journal_mode = WAL;"
-
-            # Set the journal mode for the cache to WAL
-            - cmd: sqlite3 $CACHE_DATABASE_PATH "PRAGMA journal_mode = WAL;"
-
-            - cmd: npm start
-          EOF
-
-      - name: �🚀 Deploy PR app
+      - name: � Deploy PR app
         run: |
           flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app-name.outputs.app_name }}
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -58,16 +58,15 @@ jobs:
           # Copy and modify litefs.yml for PR preview (standalone, no consul)
           cp other/litefs.yml other/litefs.yml.backup
           
-          # Remove the entire lease section to make it standalone
-          # This removes everything from "lease:" to the next top-level section
-          awk '
-          /^lease:/ { in_lease = 1; next }
-          /^[a-zA-Z]/ && in_lease && !/^  / { in_lease = 0 }
-          !in_lease { print }
-          ' other/litefs.yml > other/litefs.yml.tmp && mv other/litefs.yml.tmp other/litefs.yml
+          # Replace consul lease with static lease for PR preview isolation
+          # This makes each PR preview a standalone instance
+          sed -i '/^lease:/,/^$/c\
+lease:\
+  type: '\''static'\''
+' other/litefs.yml
           
           # Add a comment explaining the isolation
-          sed -i '/^exit-on-error:/a\\n# PR Preview: No lease configuration - standalone instance\n# This prevents syncing with production data' other/litefs.yml
+          sed -i '/^lease:/i\\n# PR Preview: Using static lease type for standalone instance\n# This prevents syncing with production data' other/litefs.yml
           
           echo "=== Modified fly.toml ==="
           cat fly.toml

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: 🚀 Deploy PR app
         run: |
-          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app-name.outputs.app_name }}
+          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --build-arg INSTALL_DEV_DEPS=true --app ${{ steps.app-name.outputs.app_name }}
 
       - name: 💬 Comment on PR
         uses: actions/github-script@v7

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,9 +28,15 @@ jobs:
           echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
           echo "url=https://$APP_NAME.fly.dev" >> $GITHUB_OUTPUT
 
-      - name: � Install dependencies for setup script
+      - name: 📦 Install dependencies for setup script
         run: |
           npm install js-yaml
+
+      - name: � Setup environment variables
+        run: |
+          # Copy environment variables for PR preview
+          cp .env.example .env
+          echo "✓ Environment variables copied from .env.example"
 
       - name: �📝 Setup PR-specific configurations
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,14 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) && \
     npm run build
 
+# choose which node_modules to use based on build arg
+FROM production-deps as runtime-deps-prod
+FROM deps as runtime-deps-dev
+
 # build smaller image for running
 FROM base
+
+ARG INSTALL_DEV_DEPS
 
 ENV FLY="true"
 ENV LITEFS_DIR="/litefs"
@@ -81,7 +87,20 @@ RUN echo "#!/bin/sh\nset -x\nsqlite3 \$CACHE_DATABASE_PATH" > /usr/local/bin/cac
 RUN mkdir /app/
 WORKDIR /app/
 
-COPY --from=production-deps /app/node_modules /app/node_modules
+# Copy node_modules - use full deps (including dev) for PR previews, production-deps otherwise
+COPY --from=runtime-deps-prod /app/node_modules /app/node_modules_prod
+COPY --from=runtime-deps-dev /app/node_modules /app/node_modules_dev
+
+RUN if [ "$INSTALL_DEV_DEPS" = "true" ]; then \
+      echo "Using dev dependencies for PR preview" && \
+      mv /app/node_modules_dev /app/node_modules && \
+      rm -rf /app/node_modules_prod; \
+    else \
+      echo "Using production dependencies" && \
+      mv /app/node_modules_prod /app/node_modules && \
+      rm -rf /app/node_modules_dev; \
+    fi
+
 COPY --from=build /app/node_modules/.prisma /app/node_modules/.prisma
 COPY --from=build /app/build /app/build
 COPY --from=build /app/public /app/public

--- a/other/setup-pr-preview.js
+++ b/other/setup-pr-preview.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { load, dump } from 'js-yaml';
 
 function setupPRPreview() {
   const appName = process.argv[2];
@@ -27,35 +28,46 @@ function setupFlyToml(appName) {
   
   console.log('Modifying fly.toml...');
   
-  // Create backup
-  fs.copyFileSync(flyTomlPath, backupPath);
-  
-  // Read and modify fly.toml
-  let flyToml = fs.readFileSync(flyTomlPath, 'utf8');
-  
-  // Update app name
-  flyToml = flyToml.replace(/^app = .*/m, `app = "${appName}"`);
-  
-  // Remove consul from experimental section
-  flyToml = flyToml.replace(/^\s*enable_consul = true.*$/m, '');
-  
-  // Add auto-scaling configuration to services section
-  // Find [[services]] section and add auto-scaling after internal_port
-  const servicesRegex = /(\[\[services\]\][\s\S]*?internal_port = \d+)/;
-  if (servicesRegex.test(flyToml)) {
-    flyToml = flyToml.replace(
-      servicesRegex,
-      `$1
+  try {
+    // Check if source file exists
+    if (!fs.existsSync(flyTomlPath)) {
+      throw new Error(`Source file ${flyTomlPath} does not exist`);
+    }
+    
+    // Create backup
+    fs.copyFileSync(flyTomlPath, backupPath);
+    
+    // Read and modify fly.toml
+    let flyToml = fs.readFileSync(flyTomlPath, 'utf8');
+    
+    // Update app name
+    flyToml = flyToml.replace(/^app = .*/m, `app = "${appName}"`);
+    
+    // Remove consul from experimental section
+    flyToml = flyToml.replace(/^\s*enable_consul = true.*$/m, '');
+    
+    // Add auto-scaling configuration to services section
+    // Find [[services]] section and add auto-scaling after internal_port
+    const servicesRegex = /(\[\[services\]\][\s\S]*?internal_port = \d+)/;
+    if (servicesRegex.test(flyToml)) {
+      flyToml = flyToml.replace(
+        servicesRegex,
+        `$1
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
   processes = ["app"]`
-    );
+      );
+    }
+    
+    // Write modified fly.toml
+    fs.writeFileSync(flyTomlPath, flyToml);
+    console.log('✓ fly.toml updated');
+    
+  } catch (error) {
+    console.error('Error modifying fly.toml:', error.message);
+    process.exit(1);
   }
-  
-  // Write modified fly.toml
-  fs.writeFileSync(flyTomlPath, flyToml);
-  console.log('✓ fly.toml updated');
 }
 
 function setupLitefsYml() {
@@ -64,33 +76,47 @@ function setupLitefsYml() {
   
   console.log('Modifying litefs.yml...');
   
-  // Create backup
-  fs.copyFileSync(litefsPath, backupPath);
-  
-  // Read litefs.yml
-  let litefsYml = fs.readFileSync(litefsPath, 'utf8');
-  
-  // Replace the lease section with static lease
-  // Find the lease section and replace it with static configuration
-  const leaseRegex = /^lease:[\s\S]*?(?=^exec:)/m;
-  const staticLeaseConfig = `lease:
-  type: 'static'
-
-`;
-  
-  litefsYml = litefsYml.replace(leaseRegex, staticLeaseConfig);
-  
-  // Add explanatory comment before the lease section
-  litefsYml = litefsYml.replace(
-    /^lease:/m,
-    `# PR Preview: Using static lease type for standalone instance
+  try {
+    // Check if source file exists
+    if (!fs.existsSync(litefsPath)) {
+      throw new Error(`Source file ${litefsPath} does not exist`);
+    }
+    
+    // Create backup
+    fs.copyFileSync(litefsPath, backupPath);
+    
+    // Read and parse litefs.yml
+    const litefsYmlContent = fs.readFileSync(litefsPath, 'utf8');
+    const litefsConfig = load(litefsYmlContent);
+    
+    // Replace the lease section with static lease
+    litefsConfig.lease = {
+      type: 'static'
+    };
+    
+    // Convert back to YAML
+    let modifiedYml = dump(litefsConfig, {
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false
+    });
+    
+    // Add explanatory comment before the lease section
+    modifiedYml = modifiedYml.replace(
+      /^lease:/m,
+      `# PR Preview: Using static lease type for standalone instance
 # This prevents syncing with production data
 lease:`
-  );
-  
-  // Write modified litefs.yml
-  fs.writeFileSync(litefsPath, litefsYml);
-  console.log('✓ litefs.yml updated');
+    );
+    
+    // Write modified litefs.yml
+    fs.writeFileSync(litefsPath, modifiedYml);
+    console.log('✓ litefs.yml updated');
+    
+  } catch (error) {
+    console.error('Error modifying litefs.yml:', error.message);
+    process.exit(1);
+  }
 }
 
 // Run the setup

--- a/other/setup-pr-preview.js
+++ b/other/setup-pr-preview.js
@@ -20,6 +20,7 @@ function setupPRPreview() {
   setupLitefsYml();
 
   console.log('PR preview configuration complete!');
+  console.log('✓ App will run in mocks mode with environment variables from .env.example');
 }
 
 function setupFlyToml(appName) {
@@ -93,6 +94,25 @@ function setupLitefsYml() {
     litefsConfig.lease = {
       type: 'static'
     };
+    
+    // Update the exec section to use mocks mode
+    if (litefsConfig.exec && Array.isArray(litefsConfig.exec)) {
+      // Find the main startup command (usually the last one)
+      const startCommand = litefsConfig.exec.find(cmd => 
+        cmd.cmd && (cmd.cmd.includes('npm start') || cmd.cmd.includes('node'))
+      );
+      
+      if (startCommand) {
+        startCommand.cmd = 'npm run start:mocks';
+        console.log('✓ Updated startup command to use mocks mode');
+      } else {
+        // If no start command found, add one
+        litefsConfig.exec.push({
+          cmd: 'npm run start:mocks'
+        });
+        console.log('✓ Added mocks startup command');
+      }
+    }
     
     // Convert back to YAML
     let modifiedYml = dump(litefsConfig, {

--- a/other/setup-pr-preview.js
+++ b/other/setup-pr-preview.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function setupPRPreview() {
+  const appName = process.argv[2];
+  if (!appName) {
+    console.error('Usage: node setup-pr-preview.js <app-name>');
+    process.exit(1);
+  }
+
+  console.log(`Setting up PR preview for app: ${appName}`);
+
+  // Modify fly.toml
+  setupFlyToml(appName);
+  
+  // Modify litefs.yml
+  setupLitefsYml();
+
+  console.log('PR preview configuration complete!');
+}
+
+function setupFlyToml(appName) {
+  const flyTomlPath = 'fly.toml';
+  const backupPath = 'fly.toml.backup';
+  
+  console.log('Modifying fly.toml...');
+  
+  // Create backup
+  fs.copyFileSync(flyTomlPath, backupPath);
+  
+  // Read and modify fly.toml
+  let flyToml = fs.readFileSync(flyTomlPath, 'utf8');
+  
+  // Update app name
+  flyToml = flyToml.replace(/^app = .*/m, `app = "${appName}"`);
+  
+  // Remove consul from experimental section
+  flyToml = flyToml.replace(/^\s*enable_consul = true.*$/m, '');
+  
+  // Add auto-scaling configuration to services section
+  // Find [[services]] section and add auto-scaling after internal_port
+  const servicesRegex = /(\[\[services\]\][\s\S]*?internal_port = \d+)/;
+  if (servicesRegex.test(flyToml)) {
+    flyToml = flyToml.replace(
+      servicesRegex,
+      `$1
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]`
+    );
+  }
+  
+  // Write modified fly.toml
+  fs.writeFileSync(flyTomlPath, flyToml);
+  console.log('✓ fly.toml updated');
+}
+
+function setupLitefsYml() {
+  const litefsPath = 'other/litefs.yml';
+  const backupPath = 'other/litefs.yml.backup';
+  
+  console.log('Modifying litefs.yml...');
+  
+  // Create backup
+  fs.copyFileSync(litefsPath, backupPath);
+  
+  // Read litefs.yml
+  let litefsYml = fs.readFileSync(litefsPath, 'utf8');
+  
+  // Replace the lease section with static lease
+  // Find the lease section and replace it with static configuration
+  const leaseRegex = /^lease:[\s\S]*?(?=^exec:)/m;
+  const staticLeaseConfig = `lease:
+  type: 'static'
+
+`;
+  
+  litefsYml = litefsYml.replace(leaseRegex, staticLeaseConfig);
+  
+  // Add explanatory comment before the lease section
+  litefsYml = litefsYml.replace(
+    /^lease:/m,
+    `# PR Preview: Using static lease type for standalone instance
+# This prevents syncing with production data
+lease:`
+  );
+  
+  // Write modified litefs.yml
+  fs.writeFileSync(litefsPath, litefsYml);
+  console.log('✓ litefs.yml updated');
+}
+
+// Run the setup
+setupPRPreview();


### PR DESCRIPTION
Add GitHub Action to deploy PR previews to temporary Fly.io machines with isolated databases and automatic cleanup.

The workflow programmatically modifies `fly.toml` and `litefs.yml` to ensure PR preview environments are completely isolated from production data. Specifically, it removes Consul integration and the LiteFS `lease` section, making each preview a standalone LiteFS instance with its own clean database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced automated deployment and cleanup of preview environments for pull requests, providing live preview URLs and ensuring environments are removed when PRs are closed.
* **New Features**
  * Added automatic configuration adjustments for preview environments, including mock data usage and app-specific settings for each pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->