### PR TITLE
Add translation for "Avoid Nesting when you're Testing" in Japanese

### DIFF
--- a/content/blog/avoid-nesting-when-youre-testing/index.mdx
+++ b/content/blog/avoid-nesting-when-youre-testing/index.mdx
@@ -20,6 +20,11 @@ translations:
     author:
       name: Jaehyeon Kim
       link: https://github.com/jaehyeon48
+  - language: 日本語
+    link: https://zenn.dev/jay_es/articles/2025-08-11-avoid-nesting-when-youre-testing
+    author:
+      name: jay-es
+      link: https://github.com/jay-es
 bannerCloudinaryId: unsplash/photo-1486338892246-cd25343d5338
 bannerCredit: Photo by [Kate Remmer](https://unsplash.com/photos/05_sUnshoaE)
 ---


### PR DESCRIPTION
Add Japanese translation link for "Avoid Nesting when you're Testing" post

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Japanese translation for the “Avoid Nesting When You’re Testing” blog post, now listed alongside existing translations on the article page.
  - Translation credited to jay-es with a direct link to the translated article.
  - No changes to the post’s content, banner, or other metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->