### PR TITLE
Add amazon product link to uses page

### DIFF
--- a/content/pages/uses.mdx
+++ b/content/pages/uses.mdx
@@ -227,6 +227,8 @@ https://x.com/theKevinShen/status/1869803430757433703
 - [Seagate IronWolf 3.84TB NAS SSD Internal Solid State Drive](https://amazon.com/dp/B07R1P55GR/) -
   These are phenomenal SSDs for the NAS.
 
+- [GE Profile PFQ97HSPVDS All-in-One Washer/Dryer](https://amazon.com/dp/B0C72WLSJ1)
+
 ## Podcasts
 
 Here are some podcasts I "use" to keep me informed and entertained while I

--- a/content/pages/uses.mdx
+++ b/content/pages/uses.mdx
@@ -226,7 +226,6 @@ https://x.com/theKevinShen/status/1869803430757433703
   I use this to store all of my pictures/movies/music/etc. It's amazing.
 - [Seagate IronWolf 3.84TB NAS SSD Internal Solid State Drive](https://amazon.com/dp/B07R1P55GR/) -
   These are phenomenal SSDs for the NAS.
-
 - [GE Profile PFQ97HSPVDS All-in-One Washer/Dryer](https://amazon.com/dp/B0C72WLSJ1)
 
 ## Podcasts


### PR DESCRIPTION
Add GE Profile All-in-One Washer/Dryer to the uses page.

---
<a href="https://cursor.com/background-agent?bcId=bc-768bff4c-8f06-4438-a788-4e03a70bfdb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-768bff4c-8f06-4438-a788-4e03a70bfdb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated the Uses page: added GE Profile PFQ97HSPVDS All‑in‑One Washer/Dryer to the Home Stuff list.
  - Included a direct Amazon link for quick access to product details and purchase.
  - Improves completeness of the Home Stuff recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->