### PR TITLE
Update index.mdx

### DIFF
--- a/content/blog/usememo-and-usecallback/index.mdx
+++ b/content/blog/usememo-and-usecallback/index.mdx
@@ -291,7 +291,7 @@ function Blub() {
 }
 ```
 
-The reason this is problematic is because `useEffect` is going to do a
+The reason this is problematic is `useEffect` is going to do a
 referential equality check on `options` between every render, and thanks to the
 way JavaScript works, `options` will be new every time so when React tests
 whether `options` changed between renders it'll always evaluate to `true`,
@@ -486,7 +486,7 @@ function RenderPrimes({ iterations, multiplier }) {
 }
 ```
 
-The reason this works is because even though you're defining the function to
+The reason this works is even though you're defining the function to
 calculate the primes on every render (which is VERY fast), React is only calling
 that function when the value is needed. On top of that React also stores
 previous values given the inputs and will return the previous value given the


### PR DESCRIPTION
"The reason is ... because ... " is redundant. I have deleted two instances of "because".

(This was a super helpful article to me! Thank you!!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Improved clarity and readability of a blog post by refining phrasing (removed redundant “because” in two sentences).
  - Grammar and style enhancements only; no changes to examples, code snippets, or semantics.
  - No impact on functionality or APIs; purely editorial improvements for end-user comprehension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->