### PR TITLE
Issue 583 blog reference

### DIFF
--- a/content/blog/use-ternaries-rather-than-and-and-in-jsx.mdx
+++ b/content/blog/use-ternaries-rather-than-and-and-in-jsx.mdx
@@ -139,6 +139,11 @@ returning `undefined`. But on top of that layer of protection, how about we be
 more explicit about our intentions. If you want to do something _conditionally_,
 don't abuse the logical AND operator (`&&`).
 
+If you'd like an extra layer of protection, you can also use
+[`eslint-plugin-react`'s `jsx-no-leaked-render` rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md)
+to help catch cases where `&&` might accidentally leak something like `0` into
+your render output.
+
 It actually seems counter-intuitive because we often use `&&` in an `if`
 condition to say: if both of these values are truthy, then do this thing,
 otherwise don't. Unfortunately for our use-case, the `&&` operator also has this


### PR DESCRIPTION
Add a reference to the `jsx-no-leaked-render` ESLint rule in the "use ternaries" blog post to address issue 583.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8cc522c-b344-4d6d-9c48-6391e1537cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8cc522c-b344-4d6d-9c48-6391e1537cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the "Use ternaries rather than && in JSX" post with an extra safeguard recommendation and a small example tweak.
> 
> - Adds a note linking to `eslint-plugin-react`’s `jsx-no-leaked-render` rule to help catch leaked renders from `&&`
> - Extends the falsy-return examples with `true && '' // ''`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a556c8545ce9a1f912fc1b2267c7993107a36854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JSX conditional rendering best practices with enhanced guidance on preferring ternary operators over && operators.
  * Added recommendation for eslint-plugin-react's jsx-no-leaked-render rule to provide extra protection against unintended value leakage.
  * Expanded discussion with revised code examples demonstrating safer conditional rendering patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->