### PR TITLE
Add call-to-question card on blog posts

### DIFF
--- a/app/routes/blog_+/$slug.tsx
+++ b/app/routes/blog_+/$slug.tsx
@@ -3,7 +3,7 @@ import {
 	json,
 	type HeadersFunction,
 } from '@remix-run/node'
-import { useLoaderData, useParams } from '@remix-run/react'
+import { Link, useLoaderData, useParams } from '@remix-run/react'
 import { clsx } from 'clsx'
 import * as React from 'react'
 import { serverOnly$ } from 'vite-env-only'
@@ -313,19 +313,26 @@ development tools and practices. He lives with his wife and four kids in Utah.
 
 function ArticleQuestionCard() {
 	return (
-		<Grid className="mb-24">
+		<Grid>
 			<div className="col-span-full lg:col-span-8 lg:col-start-3">
 				<div className="bg-secondary border-secondary flex flex-col gap-6 rounded-lg border px-8 py-10 md:flex-row md:items-center md:justify-between md:gap-10 md:px-12">
-					<div className="space-y-3">
+					<div className="flex flex-col gap-3">
 						<H4>Have a question about this article?</H4>
 						<Paragraph prose={false} className="max-w-2xl">
-							Bring it to Call Kent. Ask on{' '}
-							<span className="text-primary font-medium">/calls</span> and I
-							may answer it on the podcast.
+							Bring it to the Call Kent podcast. Ask on{' '}
+							<Link to="/calls" className="text-primary font-medium">
+								/calls
+							</Link>{' '}
+							and I may answer it on the podcast.
 						</Paragraph>
 					</div>
-					<ArrowLink to="/calls" direction="right" prefetch="intent">
-						Go to /calls
+					<ArrowLink
+						className="flex-shrink-0"
+						to="/calls"
+						direction="right"
+						prefetch="intent"
+					>
+						Place a call
 					</ArrowLink>
 				</div>
 			</div>
@@ -570,7 +577,7 @@ export default function MdxScreen() {
 				isDraft={isDraft}
 			/>
 
-			<Spacer size="base" />
+			<Spacer size="sm" />
 
 			{data.workshops.length > 0 ? (
 				<>
@@ -602,9 +609,13 @@ export default function MdxScreen() {
 						</div>
 					</Grid>
 
-					<Spacer size="base" />
+					<Spacer size="sm" />
 				</>
 			) : null}
+
+			<ArticleQuestionCard />
+
+			<Spacer size="sm" />
 
 			<BlogSection
 				articles={data.recommendations}
@@ -612,10 +623,6 @@ export default function MdxScreen() {
 				description="You will love these ones as well."
 				showArrowButton={false}
 			/>
-
-			<Spacer size="base" />
-
-			<ArticleQuestionCard />
 		</div>
 	)
 }

--- a/app/routes/blog_+/$slug.tsx
+++ b/app/routes/blog_+/$slug.tsx
@@ -17,7 +17,7 @@ import { BlogSection } from '#app/components/sections/blog-section.tsx'
 import { HeaderSection } from '#app/components/sections/header-section.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { TeamStats } from '#app/components/team-stats.tsx'
-import { H2, H6, Paragraph } from '#app/components/typography.tsx'
+import { H2, H4, H6, Paragraph } from '#app/components/typography.tsx'
 import { WorkshopCard } from '#app/components/workshop-card.tsx'
 import { externalLinks } from '#app/external-links.tsx'
 import { getImageBuilder, getImgProps, images } from '#app/images.tsx'
@@ -311,6 +311,28 @@ development tools and practices. He lives with his wife and four kids in Utah.
 	)
 }
 
+function ArticleQuestionCard() {
+	return (
+		<Grid className="mb-24">
+			<div className="col-span-full lg:col-span-8 lg:col-start-3">
+				<div className="bg-secondary border-secondary flex flex-col gap-6 rounded-lg border px-8 py-10 md:flex-row md:items-center md:justify-between md:gap-10 md:px-12">
+					<div className="space-y-3">
+						<H4>Have a question about this article?</H4>
+						<Paragraph prose={false} className="max-w-2xl">
+							Bring it to Call Kent. Ask on{' '}
+							<span className="text-primary font-medium">/calls</span> and I
+							may answer it on the podcast.
+						</Paragraph>
+					</div>
+					<ArrowLink to="/calls" direction="right" prefetch="intent">
+						Go to /calls
+					</ArrowLink>
+				</div>
+			</div>
+		</Grid>
+	)
+}
+
 export default function MdxScreen() {
 	const data = useLoaderData<typeof loader>()
 	const { requestInfo } = useRootData()
@@ -590,6 +612,10 @@ export default function MdxScreen() {
 				description="You will love these ones as well."
 				showArrowButton={false}
 			/>
+
+			<Spacer size="base" />
+
+			<ArticleQuestionCard />
 		</div>
 	)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only changes to the blog post page layout and navigation links; no changes to server logic, data fetching, or auth.
> 
> **Overview**
> Adds a new end-of-article CTA on blog post pages: an `ArticleQuestionCard` that links readers to `/calls` (via inline `Link` and a “Place a call” `ArrowLink`) to submit questions for the Call Kent podcast.
> 
> Adjusts layout spacing around the footer/workshop section (using smaller `Spacer` sizes) and updates imports to support the new card (`Link` and `H4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7072b7f662eca0a65a0d05b2fb95755dbf31cd19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a call-to-action card inserted into blog articles that lets readers schedule calls directly from article pages.
* **Style**
  * Improved article spacing and visual flow by adjusting spacer sizes and adding spacing around the new CTA card for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->