### PR TITLE
Markdown pages accept header

### DIFF
--- a/other/markdown-accept-check.mjs
+++ b/other/markdown-accept-check.mjs
@@ -1,0 +1,125 @@
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+const defaultPort = 4789
+const port = Number(process.env.PORT || process.env.MARKDOWN_ACCEPT_TEST_PORT || defaultPort)
+
+const repoRoot = process.cwd()
+const tsxPath = path.join(repoRoot, 'node_modules', '.bin', 'tsx')
+
+function startServer() {
+	const env = {
+		...process.env,
+		DOTENV_CONFIG_PATH: process.env.DOTENV_CONFIG_PATH ?? '.env.example',
+		NODE_ENV: process.env.NODE_ENV ?? 'development',
+		MOCKS: process.env.MOCKS ?? 'true',
+		PORT: String(port),
+		STARTUP_SHORTCUTS: process.env.STARTUP_SHORTCUTS ?? 'false',
+		REMIX_DEV_HTTP_ORIGIN:
+			process.env.REMIX_DEV_HTTP_ORIGIN ?? `http://localhost:${port}`,
+	}
+
+	const child = spawn(tsxPath, ['./index.js'], {
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env,
+	})
+
+	let localUrl = null
+	let stdout = ''
+
+	child.stdout.on('data', (chunk) => {
+		const text = chunk.toString()
+		stdout += text
+		process.stdout.write(text)
+
+		if (!localUrl) {
+			const cleaned = text.replace(/\x1b\[[0-9;]*m/g, '')
+			const match = cleaned.match(/Local:\s+(\S+)/)
+			if (match?.[1]) localUrl = match[1]
+		}
+	})
+
+	child.stderr.on('data', (chunk) => {
+		process.stderr.write(chunk)
+	})
+
+	return { child, getLocalUrl: () => localUrl, getStdout: () => stdout }
+}
+
+async function waitForLocalUrl(getLocalUrl, getStdout, timeoutMs = 60_000) {
+	const start = Date.now()
+	while (!getLocalUrl()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error(
+				`Timed out waiting for Local URL. Output so far:\n${getStdout()}`,
+			)
+		}
+		await delay(100)
+	}
+	return getLocalUrl()
+}
+
+async function fetchWithRetry(url, init, { attempts = 30, delayMs = 250 } = {}) {
+	let lastError
+	for (let i = 0; i < attempts; i++) {
+		try {
+			return await fetch(url, init)
+		} catch (e) {
+			lastError = e
+			await delay(delayMs)
+		}
+	}
+	throw lastError
+}
+
+async function assertMarkdownResponse(baseUrl, pathname, expectedNeedle) {
+	const url = `${baseUrl}${pathname}`
+	const res = await fetchWithRetry(url, {
+		headers: { Accept: 'text/markdown' },
+	})
+	const contentType = res.headers.get('content-type') ?? ''
+	const vary = res.headers.get('vary') ?? ''
+	const body = await res.text()
+
+	if (res.status !== 200) {
+		throw new Error(
+			`${pathname}: expected 200, got ${res.status}. Body starts with: ${body.slice(0, 200)}`,
+		)
+	}
+	if (!contentType.toLowerCase().includes('text/markdown')) {
+		throw new Error(
+			`${pathname}: expected content-type to include text/markdown, got ${contentType}`,
+		)
+	}
+	if (!vary.toLowerCase().includes('accept')) {
+		throw new Error(`${pathname}: expected vary to include Accept, got ${vary}`)
+	}
+	if (!body.includes(expectedNeedle)) {
+		throw new Error(
+			`${pathname}: expected body to include ${JSON.stringify(expectedNeedle)}. Body starts with: ${body.slice(0, 200)}`,
+		)
+	}
+
+	console.log(`\nOK: ${pathname} -> ${contentType}`)
+}
+
+const { child, getLocalUrl, getStdout } = startServer()
+
+try {
+	const baseUrl = await waitForLocalUrl(getLocalUrl, getStdout)
+	await assertMarkdownResponse(baseUrl, '/about-mcp', 'title: About KCD MCP')
+	await assertMarkdownResponse(
+		baseUrl,
+		'/blog/aha-programming',
+		'title: AHA Programming',
+	)
+} catch (error) {
+	console.error('\nmarkdown-accept-check failed:', error)
+	process.exitCode = 1
+} finally {
+	child.kill('SIGTERM')
+	await Promise.race([new Promise((r) => child.once('exit', r)), delay(5_000)])
+	if (!child.killed) child.kill('SIGKILL')
+}
+

--- a/other/markdown-accept-check.mjs
+++ b/other/markdown-accept-check.mjs
@@ -119,7 +119,10 @@ try {
 	process.exitCode = 1
 } finally {
 	child.kill('SIGTERM')
-	await Promise.race([new Promise((r) => child.once('exit', r)), delay(5_000)])
-	if (!child.killed) child.kill('SIGKILL')
+	const exited = await Promise.race([
+		new Promise((resolve) => child.once('exit', () => resolve(true))),
+		delay(5_000).then(() => false),
+	])
+	if (!exited) child.kill('SIGKILL')
 }
 

--- a/other/markdown-accept-check.mjs
+++ b/other/markdown-accept-check.mjs
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { spawn } from 'node:child_process'
+import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 
 const defaultPort = 4789

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
 	oldImgSocial,
 	rickRollMiddleware,
 } from './redirects.js'
+import { markdownAcceptMiddleware } from './markdown-accept.js'
 import { registerStartupShortcuts } from './startup-shortcuts.js'
 
 sourceMapSupport.install()
@@ -314,6 +315,10 @@ app.use('/.well-known/*', (req, res, next) => {
 	res.header('Access-Control-Allow-Origin', '*')
 	next()
 })
+
+// Content negotiation for MDX-backed pages:
+// `Accept: text/markdown` returns the raw markdown source.
+app.use(markdownAcceptMiddleware)
 
 async function getRequestHandler(): Promise<RequestHandler> {
 	function getLoadContext(req: any, res: any) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,12 +23,12 @@ import serverTiming from 'server-timing'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
 import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
+import { markdownAcceptMiddleware } from './markdown-accept.js'
 import {
 	getRedirectsMiddleware,
 	oldImgSocial,
 	rickRollMiddleware,
 } from './redirects.js'
-import { markdownAcceptMiddleware } from './markdown-accept.js'
 import { registerStartupShortcuts } from './startup-shortcuts.js'
 
 sourceMapSupport.install()

--- a/server/markdown-accept.ts
+++ b/server/markdown-accept.ts
@@ -78,7 +78,7 @@ const markdownAcceptMiddleware: RequestHandler = (req, res, next) => {
 
 	void (async () => {
 		const markdownSource = await readMarkdownSourceFromDisk(routeInfo)
-		if (!markdownSource) return next()
+		if (markdownSource === null) return next()
 
 		res.status(200)
 		res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
@@ -90,7 +90,10 @@ const markdownAcceptMiddleware: RequestHandler = (req, res, next) => {
 
 		if (req.method === 'HEAD') return void res.end()
 		res.send(markdownSource)
-	})().catch(() => next())
+	})().catch((error) => {
+		console.error('Failed to read markdown source.', error)
+		next()
+	})
 }
 
 export { markdownAcceptMiddleware }

--- a/server/markdown-accept.ts
+++ b/server/markdown-accept.ts
@@ -1,0 +1,88 @@
+import type { NextFunction, Request, Response } from 'express'
+import { downloadMdxFilesCached } from '../app/utils/mdx.server.ts'
+
+type MdxRouteInfo = { contentDir: 'blog' | 'pages'; slug: string }
+
+const MARKDOWN_MIME = 'text/markdown'
+const validSlugRegex = /^[a-zA-Z0-9-_.]+$/
+
+function requestAcceptsMarkdown(req: Request): boolean {
+	const accept = req.get('accept')
+	return Boolean(accept && accept.toLowerCase().includes(MARKDOWN_MIME))
+}
+
+function isValidSlug(slug: string): boolean {
+	return validSlugRegex.test(slug)
+}
+
+function getMdxRouteInfoFromPath(pathname: string): MdxRouteInfo | null {
+	const blogMatch = pathname.match(/^\/blog\/([^/]+)$/)
+	if (blogMatch?.[1] && isValidSlug(blogMatch[1])) {
+		return { contentDir: 'blog', slug: blogMatch[1] }
+	}
+
+	const pageMatch = pathname.match(/^\/([^/]+)$/)
+	if (pageMatch?.[1] && pageMatch[1] !== 'blog' && isValidSlug(pageMatch[1])) {
+		return { contentDir: 'pages', slug: pageMatch[1] }
+	}
+
+	return null
+}
+
+function findMdxIndexFileContent(
+	files: Array<{ path: string; content: string }>,
+	slug: string,
+): string | null {
+	// Mirrors the `compileMdx` index-file selection, but without regex pitfalls
+	// when slugs contain "." or other special chars.
+	for (const ext of ['mdx', 'md'] as const) {
+		const suffix = `${slug}/index.${ext}`
+		const found = files.find((f) => f.path.replace(/\\/g, '/').endsWith(suffix))
+		if (found) return found.content
+	}
+	return null
+}
+
+async function handleMarkdownAcceptRequest(
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) {
+	if (req.method !== 'GET' && req.method !== 'HEAD') return next()
+	if (!requestAcceptsMarkdown(req)) return next()
+
+	const routeInfo = getMdxRouteInfoFromPath(req.path)
+	if (!routeInfo) return next()
+
+	try {
+		const downloaded = await downloadMdxFilesCached(
+			routeInfo.contentDir,
+			routeInfo.slug,
+			{},
+		)
+		if (!downloaded.files.length) return next()
+
+		const markdownSource = findMdxIndexFileContent(
+			downloaded.files,
+			routeInfo.slug,
+		)
+		if (!markdownSource) return next()
+
+		res.status(200)
+		res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+		// Ensure caches don't mix the HTML and markdown representations.
+		res.append('Vary', 'Accept')
+		// Keep parity with the existing MDX page loaders' caching behavior.
+		res.append('Vary', 'Cookie')
+		res.setHeader('Cache-Control', 'private, max-age=3600')
+
+		if (req.method === 'HEAD') return res.end()
+		return res.send(markdownSource)
+	} catch {
+		// If anything goes sideways, defer to Remix's normal handling.
+		return next()
+	}
+}
+
+export { handleMarkdownAcceptRequest as markdownAcceptMiddleware }
+

--- a/server/markdown-accept.ts
+++ b/server/markdown-accept.ts
@@ -1,4 +1,4 @@
-import type { Request, RequestHandler } from 'express'
+import { type Request, type RequestHandler } from 'express'
 import { downloadMdxFilesCached } from '../app/utils/mdx.server.ts'
 
 type MdxRouteInfo = { contentDir: 'blog' | 'pages'; slug: string }


### PR DESCRIPTION
Add `Accept: text/markdown` support for markdown-driven pages to enable agents to retrieve raw markdown content.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d7281383-768b-42e3-b03b-5cfffca69f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7281383-768b-42e3-b03b-5cfffca69f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new request path that reads and serves on-disk content based on URL slugs; while it includes basic slug validation and path traversal checks, it changes server routing behavior and caching headers for matching requests.
> 
> **Overview**
> Adds a new Express middleware that intercepts `GET`/`HEAD` requests with `Accept: text/markdown` and, for `/blog/:slug` and single-segment page routes, reads the corresponding `.mdx`/`.md` file from `content/` and returns it as `text/markdown`.
> 
> The response sets `Vary: Accept` (and `Vary: Cookie`) plus a private cache policy to avoid cache mixing with the normal HTML representation, and includes a small script (`other/markdown-accept-check.mjs`) that boots the app and asserts markdown responses for a couple of routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1846a2565e02910a6b3d4946536021793b0e53a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Serve raw Markdown source for blog posts and pages when requests include Accept: text/markdown, while preserving normal HTML behavior otherwise.
  * Responses include appropriate Vary headers, respect HEAD requests, and use short private caching.

* **Chores**
  * Added an automated check to exercise and validate Markdown endpoints during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->