### PR TITLE
Duplicate content normalization

### DIFF
--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -166,7 +166,9 @@ describe('semantic search result normalization', () => {
 			expect(ids).toContain('blog:react-hooks-pitfalls')
 
 			const blogResult = results.find((r) => r.id === 'blog:react-hooks-pitfalls')
-			expect(blogResult?.snippet).toBe('snippet-0')
+			expect(blogResult).toBeDefined()
+			expect(blogResult!.snippet).toBe('snippet-0')
+			expect(blogResult!.score).toBe(0.99)
 
 			// Credits share the same URL, but should not be collapsed (slug differentiates them).
 			expect(ids).toContain('credit:alice')

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -54,8 +54,6 @@ describe('semantic search result normalization', () => {
 			CLOUDFLARE_VECTORIZE_INDEX: process.env.CLOUDFLARE_VECTORIZE_INDEX,
 			CLOUDFLARE_AI_EMBEDDING_MODEL: process.env.CLOUDFLARE_AI_EMBEDDING_MODEL,
 		}
-
-		const originalFetch = globalThis.fetch
 		let vectorizeTopKRequested = 0
 
 		try {
@@ -178,7 +176,7 @@ describe('semantic search result normalization', () => {
 				if (typeof value === 'string') process.env[key] = value
 				else delete process.env[key]
 			}
-			if (originalFetch) vi.stubGlobal('fetch', originalFetch)
+			vi.unstubAllGlobals()
 		}
 	})
 })

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import {
 	isSemanticSearchConfigured,
 	semanticSearchKCD,
@@ -42,6 +42,143 @@ describe('semantic search env gating', () => {
 				if (typeof value === 'string') process.env[key] = value
 				else delete process.env[key]
 			}
+		}
+	})
+})
+
+describe('semantic search result normalization', () => {
+	test('dedupes chunk-level matches into unique docs', async () => {
+		const originalEnv = {
+			CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
+			CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN,
+			CLOUDFLARE_VECTORIZE_INDEX: process.env.CLOUDFLARE_VECTORIZE_INDEX,
+			CLOUDFLARE_AI_EMBEDDING_MODEL: process.env.CLOUDFLARE_AI_EMBEDDING_MODEL,
+		}
+
+		const originalFetch = globalThis.fetch
+		let vectorizeTopKRequested = 0
+
+		try {
+			process.env.CLOUDFLARE_ACCOUNT_ID = 'test-account'
+			process.env.CLOUDFLARE_API_TOKEN = 'test-token'
+			process.env.CLOUDFLARE_VECTORIZE_INDEX = 'test-index'
+			delete process.env.CLOUDFLARE_AI_EMBEDDING_MODEL
+
+			const matches = [
+				{
+					id: 'blog:react-hooks-pitfalls:chunk:0',
+					score: 0.99,
+					metadata: {
+						type: 'blog',
+						slug: 'react-hooks-pitfalls',
+						url: '/blog/react-hooks-pitfalls',
+						title: 'React Hooks Pitfalls',
+						snippet: 'snippet-0',
+						chunkIndex: 0,
+						chunkCount: 3,
+					},
+				},
+				{
+					id: 'blog:react-hooks-pitfalls:chunk:1',
+					score: 0.98,
+					metadata: {
+						type: 'blog',
+						slug: 'react-hooks-pitfalls',
+						url: '/blog/react-hooks-pitfalls',
+						title: 'React Hooks Pitfalls',
+						snippet: 'snippet-1',
+						chunkIndex: 1,
+						chunkCount: 3,
+					},
+				},
+				{
+					id: 'credit:alice:chunk:0',
+					score: 0.97,
+					metadata: {
+						type: 'credit',
+						slug: 'alice',
+						url: '/credits',
+						title: 'Alice',
+						snippet: 'alice-snippet',
+						chunkIndex: 0,
+						chunkCount: 1,
+					},
+				},
+				{
+					id: 'credit:bob:chunk:0',
+					score: 0.96,
+					metadata: {
+						type: 'credit',
+						slug: 'bob',
+						url: '/credits',
+						title: 'Bob',
+						snippet: 'bob-snippet',
+						chunkIndex: 0,
+						chunkCount: 1,
+					},
+				},
+				{
+					id: 'blog:some-other-post:chunk:0',
+					score: 0.95,
+					metadata: {
+						type: 'blog',
+						slug: 'some-other-post',
+						url: '/blog/some-other-post',
+						title: 'Some Other Post',
+						snippet: 'other-snippet',
+						chunkIndex: 0,
+						chunkCount: 2,
+					},
+				},
+			]
+
+			vi.stubGlobal(
+				'fetch',
+				vi.fn(async (input: any, init?: RequestInit) => {
+					const url = String(input)
+					if (url.includes('/ai/run/')) {
+						return new Response(
+							JSON.stringify({ result: { data: [[0.1, 0.2, 0.3]] } }),
+							{ status: 200, headers: { 'Content-Type': 'application/json' } },
+						)
+					}
+					if (url.includes('/vectorize/v2/indexes/') && url.endsWith('/query')) {
+						const body = typeof init?.body === 'string' ? JSON.parse(init.body) : {}
+						vectorizeTopKRequested =
+							typeof body?.topK === 'number' ? body.topK : vectorizeTopKRequested
+						const requestedTopK =
+							typeof body?.topK === 'number' ? body.topK : matches.length
+						const sliced = matches.slice(0, requestedTopK)
+						return new Response(
+							JSON.stringify({ result: { count: sliced.length, matches: sliced } }),
+							{ status: 200, headers: { 'Content-Type': 'application/json' } },
+						)
+					}
+					return new Response('Not found', { status: 404 })
+				}),
+			)
+
+			const results = await semanticSearchKCD({ query: 'hooks', topK: 3 })
+			expect(vectorizeTopKRequested).toBeGreaterThan(3)
+			expect(results).toHaveLength(3)
+
+			// Chunk-level duplicates collapse into a single doc-level result.
+			const ids = results.map((r) => r.id)
+			expect(new Set(ids).size).toBe(ids.length)
+			expect(ids).toContain('blog:react-hooks-pitfalls')
+
+			const blogResult = results.find((r) => r.id === 'blog:react-hooks-pitfalls')
+			expect(blogResult?.snippet).toBe('snippet-0')
+
+			// Credits share the same URL, but should not be collapsed (slug differentiates them).
+			expect(ids).toContain('credit:alice')
+			expect(ids).toContain('credit:bob')
+		} finally {
+			for (const [key, value] of Object.entries(originalEnv)) {
+				if (typeof value === 'string') process.env[key] = value
+				else delete process.env[key]
+			}
+			if (originalFetch) vi.stubGlobal('fetch', originalFetch)
 		}
 	})
 })

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { setupServer } from 'msw/node'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cloudflareHandlers, resetCloudflareMockState } from '../../../mocks/cloudflare.ts'
 import {
 	isSemanticSearchConfigured,

--- a/app/utils/semantic-search.server.ts
+++ b/app/utils/semantic-search.server.ts
@@ -12,12 +12,20 @@ type VectorizeQueryResponse = {
 	}>
 }
 
+/**
+ * Parse a value that may be a string, returning a trimmed non-empty string.
+ */
 function asNonEmptyString(value: unknown): string | undefined {
 	if (typeof value !== 'string') return undefined
 	const trimmed = value.trim()
 	return trimmed ? trimmed : undefined
 }
 
+/**
+ * Normalize a URL/path into a stable key:
+ * - absolute URLs -> pathname
+ * - relative paths -> strip query/fragment and trailing slashes
+ */
 function normalizeUrlForKey(url: string): string {
 	// Prefer treating absolute URLs and relative paths as the same canonical key.
 	try {
@@ -32,11 +40,20 @@ function normalizeUrlForKey(url: string): string {
 	return cleaned && cleaned !== '/' ? cleaned.replace(/\/+$/, '') : cleaned
 }
 
+/**
+ * Normalize a title for canonicalization (case-insensitive).
+ */
 function normalizeTitleForKey(title: string) {
 	// asNonEmptyString already trims; use lowercase to avoid casing-only duplicates.
 	return title.toLowerCase()
 }
 
+/**
+ * Compute a doc-level identifier for semantic search results.
+ *
+ * Vectorize stores one vector per chunk; the canonical ID collapses chunk hits
+ * into a single doc hit so search results don't contain duplicates.
+ */
 function getCanonicalResultId({
 	vectorId,
 	type,

--- a/app/utils/semantic-search.server.ts
+++ b/app/utils/semantic-search.server.ts
@@ -214,7 +214,8 @@ export async function semanticSearchKCD({
 		typeof topK === 'number' && Number.isFinite(topK) ? Math.max(1, Math.floor(topK)) : 15
 	// Vectorize returns chunk-level matches and overlapping chunks commonly score
 	// highly together. Overfetch and then de-dupe down to unique docs.
-	const rawTopK = Math.min(100, safeTopK * 5)
+	// When requesting metadata, Vectorize caps topK at 20.
+	const rawTopK = Math.min(20, safeTopK * 5)
 
 	const vector = await getEmbedding({
 		accountId,

--- a/app/utils/semantic-search.server.ts
+++ b/app/utils/semantic-search.server.ts
@@ -28,7 +28,13 @@ function normalizeUrlForKey(url: string): string {
 	} catch {
 		// ignore
 	}
-	return url && url !== '/' ? url.replace(/\/+$/, '') : url
+	const cleaned = (url.split(/[?#]/)[0] ?? url).trim()
+	return cleaned && cleaned !== '/' ? cleaned.replace(/\/+$/, '') : cleaned
+}
+
+function normalizeTitleForKey(title: string) {
+	// asNonEmptyString already trims; use lowercase to avoid casing-only duplicates.
+	return title.toLowerCase()
 }
 
 function getCanonicalResultId({
@@ -49,7 +55,7 @@ function getCanonicalResultId({
 	if (type && slug) return `${type}:${slug}`
 	if (type && url) return `${type}:${normalizeUrlForKey(url)}`
 	if (url) return normalizeUrlForKey(url)
-	if (type && title) return `${type}:${title}`
+	if (type && title) return `${type}:${normalizeTitleForKey(title)}`
 	return vectorId
 }
 


### PR DESCRIPTION
Normalize semantic search results to prevent multiple entries for the same content by de-duplicating chunk-level matches into single canonical documents.

The semantic search often returned multiple entries for the same content because the indexer stores many "chunk" vectors per document. This change collapses these chunk-level hits into a single canonical document result, keyed by `type:slug` (falling back to `type:url`), while overfetching raw matches to ensure `topK` unique documents are still returned.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e3086083-c781-4916-9309-d5aa5a712642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3086083-c781-4916-9309-d5aa5a712642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect semantic search ranking/identity semantics by rewriting result IDs and deduping/merging matches, which could alter ordering and downstream consumers’ expectations. Test coverage reduces risk, and the transcription change is a low-impact typing/compatibility fix.
> 
> **Overview**
> Semantic search results are now **normalized and de-duplicated** so multiple Vectorize chunk hits collapse into a single doc-level entry, using a canonical `id` (preferring `type:slug`, then falling back to parsed vector IDs, `type:url`, URL-only, or `type:title`). The query path now clamps `topK`, overfetches raw matches, merges duplicates by choosing the best score and snippet, and returns the requested number of unique docs sorted by score.
> 
> Tests were expanded to run against the MSW Cloudflare mock and verify chunk-dedupe behavior (including snippet selection and non-collapsing of same-URL different-slug docs). Separately, Workers AI transcription now sends an `ArrayBuffer`-backed `Uint8Array` body to satisfy stricter TS `fetch` typings without unnecessary copies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a2a21048b75d083f691b9fce5353e43e1accd6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Semantic search now deduplicates document-level results, improves ranking and snippet selection, and handles incomplete metadata more robustly.
  * Audio transcription uploads use an ArrayBuffer-backed request body for more reliable, efficient uploads.

* **Tests**
  * New tests validate semantic search normalization, deduplication, top-K behavior, ranking, and snippet selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->