### PR TITLE
Cloudflare API mocks

### DIFF
--- a/app/utils/cloudflare-ai-transcription.server.ts
+++ b/app/utils/cloudflare-ai-transcription.server.ts
@@ -25,7 +25,8 @@ export async function transcribeMp3WithWorkersAi({
 	mp3,
 	model = getRequiredEnv('CLOUDFLARE_AI_TRANSCRIPTION_MODEL'),
 }: {
-	mp3: Uint8Array
+	// Keep this specific so it satisfies Node/undici `BodyInit` typings.
+	mp3: Uint8Array<ArrayBuffer>
 	/**
 	 * Recommended: `@cf/openai/whisper` because it supports raw binary audio via
 	 * the REST API. `@cf/openai/whisper-large-v3-turbo` typically expects base64,
@@ -49,8 +50,7 @@ export async function transcribeMp3WithWorkersAi({
 			// Best-effort content-type; CF can infer in many cases, but be explicit.
 			'Content-Type': 'audio/mpeg',
 		},
-		// Wrap in a Blob so `fetch` BodyInit types are satisfied in TS.
-		body: new Blob([mp3], { type: 'audio/mpeg' }),
+		body: mp3,
 	})
 
 	if (!res.ok) {

--- a/app/utils/cloudflare-ai-transcription.server.ts
+++ b/app/utils/cloudflare-ai-transcription.server.ts
@@ -49,7 +49,8 @@ export async function transcribeMp3WithWorkersAi({
 			// Best-effort content-type; CF can infer in many cases, but be explicit.
 			'Content-Type': 'audio/mpeg',
 		},
-		body: mp3,
+		// Wrap in a Blob so `fetch` BodyInit types are satisfied in TS.
+		body: new Blob([mp3], { type: 'audio/mpeg' }),
 	})
 
 	if (!res.ok) {

--- a/app/utils/cloudflare-ai-transcription.server.ts
+++ b/app/utils/cloudflare-ai-transcription.server.ts
@@ -25,8 +25,8 @@ export async function transcribeMp3WithWorkersAi({
 	mp3,
 	model = getRequiredEnv('CLOUDFLARE_AI_TRANSCRIPTION_MODEL'),
 }: {
-	// Keep this specific so it satisfies Node/undici `BodyInit` typings.
-	mp3: Uint8Array<ArrayBuffer>
+	// Accept Buffers and other Uint8Array views.
+	mp3: Uint8Array
 	/**
 	 * Recommended: `@cf/openai/whisper` because it supports raw binary audio via
 	 * the REST API. `@cf/openai/whisper-large-v3-turbo` typically expects base64,
@@ -50,7 +50,9 @@ export async function transcribeMp3WithWorkersAi({
 			// Best-effort content-type; CF can infer in many cases, but be explicit.
 			'Content-Type': 'audio/mpeg',
 		},
-		body: mp3,
+		// Some fetch/undici TS typings are stricter than runtime and require
+		// `Uint8Array<ArrayBuffer>` rather than `Uint8Array<ArrayBufferLike>`.
+		body: mp3 as unknown as Uint8Array<ArrayBuffer>,
 	})
 
 	if (!res.ok) {

--- a/mocks/__tests__/cloudflare.test.ts
+++ b/mocks/__tests__/cloudflare.test.ts
@@ -1,11 +1,15 @@
 import { setupServer } from 'msw/node'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
-import { cloudflareHandlers } from '../cloudflare.ts'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { cloudflareHandlers, resetCloudflareMockState } from '../cloudflare.ts'
 
 const server = setupServer(...cloudflareHandlers)
 
 beforeAll(() => {
 	server.listen({ onUnhandledRequest: 'error' })
+})
+
+beforeEach(() => {
+	resetCloudflareMockState()
 })
 
 afterAll(() => {

--- a/mocks/__tests__/cloudflare.test.ts
+++ b/mocks/__tests__/cloudflare.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { setupServer } from 'msw/node'
+import { cloudflareHandlers } from '../cloudflare.ts'
+
+const server = setupServer(...cloudflareHandlers)
+
+beforeAll(() => {
+	server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterAll(() => {
+	server.close()
+})
+
+describe('cloudflare MSW mocks', () => {
+	test('Workers AI embeddings endpoint returns { result: { data } }', async () => {
+		const res = await fetch(
+			'https://api.cloudflare.com/client/v4/accounts/acc123/ai/run/@cf/google/embeddinggemma-300m',
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer test-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ text: ['hello world'] }),
+			},
+		)
+
+		expect(res.ok).toBe(true)
+		const json = (await res.json()) as any
+		expect(json.success).toBe(true)
+		expect(Array.isArray(json.result.data)).toBe(true)
+		expect(Array.isArray(json.result.data[0])).toBe(true)
+		expect(json.result.data[0].length).toBeGreaterThan(0)
+	})
+
+	test('Workers AI transcription endpoint returns { result: { text } }', async () => {
+		const res = await fetch(
+			'https://api.cloudflare.com/client/v4/accounts/acc123/ai/run/%40cf%2Fopenai%2Fwhisper',
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer test-token',
+					'Content-Type': 'audio/mpeg',
+				},
+				body: new Uint8Array([1, 2, 3, 4]),
+			},
+		)
+
+		expect(res.ok).toBe(true)
+		const json = (await res.json()) as any
+		expect(json.success).toBe(true)
+		expect(typeof json.result.text).toBe('string')
+		expect(json.result.text.toLowerCase()).toContain('mock transcription')
+	})
+
+	test('Vectorize query returns seeded matches with metadata', async () => {
+		const res = await fetch(
+			'https://api.cloudflare.com/client/v4/accounts/acc123/vectorize/v2/indexes/semantic-index/query',
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer test-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					vector: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+					topK: 3,
+					returnMetadata: 'all',
+				}),
+			},
+		)
+
+		expect(res.ok).toBe(true)
+		const json = (await res.json()) as any
+		expect(json.success).toBe(true)
+		expect(Array.isArray(json.result.matches)).toBe(true)
+		expect(json.result.matches.length).toBeGreaterThan(0)
+		expect(typeof json.result.matches[0].id).toBe('string')
+		expect(typeof json.result.matches[0].score).toBe('number')
+		expect(typeof json.result.matches[0].metadata?.title).toBe('string')
+	})
+
+	test('Vectorize upsert + query + delete_by_ids works', async () => {
+		const accountId = 'acc999'
+		const indexName = 'upsert-index'
+		const id = '/mock/doc'
+		const values = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+		const ndjson = `${JSON.stringify({
+			id,
+			values,
+			metadata: {
+				type: 'doc',
+				title: 'Mock Doc',
+				url: 'https://kentcdodds.com/mock/doc',
+				snippet: 'Inserted via Vectorize upsert mock.',
+			},
+		})}\n`
+
+		const form = new FormData()
+		form.set(
+			'vectors',
+			new Blob([ndjson], { type: 'application/x-ndjson' }),
+			'vectors.ndjson',
+		)
+
+		const upsertRes = await fetch(
+			`https://api.cloudflare.com/client/v4/accounts/${accountId}/vectorize/v2/indexes/${indexName}/upsert`,
+			{
+				method: 'POST',
+				headers: { Authorization: 'Bearer test-token' },
+				body: form,
+			},
+		)
+		expect(upsertRes.ok).toBe(true)
+
+		const queryRes = await fetch(
+			`https://api.cloudflare.com/client/v4/accounts/${accountId}/vectorize/v2/indexes/${indexName}/query`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer test-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ vector: values, topK: 5, returnMetadata: 'all' }),
+			},
+		)
+		expect(queryRes.ok).toBe(true)
+		const queryJson = (await queryRes.json()) as any
+		const ids = queryJson.result.matches.map((m: any) => m.id)
+		expect(ids).toContain(id)
+
+		const deleteRes = await fetch(
+			`https://api.cloudflare.com/client/v4/accounts/${accountId}/vectorize/v2/indexes/${indexName}/delete_by_ids`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: 'Bearer test-token',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ ids: [id] }),
+			},
+		)
+		expect(deleteRes.ok).toBe(true)
+		const deleteJson = (await deleteRes.json()) as any
+		expect(deleteJson.success).toBe(true)
+		expect(deleteJson.result.deleted).toBeGreaterThan(0)
+	})
+})
+

--- a/mocks/__tests__/cloudflare.test.ts
+++ b/mocks/__tests__/cloudflare.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { setupServer } from 'msw/node'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { cloudflareHandlers } from '../cloudflare.ts'
 
 const server = setupServer(...cloudflareHandlers)

--- a/mocks/__tests__/cloudflare.test.ts
+++ b/mocks/__tests__/cloudflare.test.ts
@@ -61,13 +61,13 @@ describe('cloudflare MSW mocks', () => {
 	test('Vectorize query uses match-sorter when embedding text is known', async () => {
 		// Seed the expected doc so the test is independent of the filesystem.
 		const seedNdjson = `${JSON.stringify({
-			id: '/__mock__/about-kcd-mcp',
+			id: '/__mock__/about-mcp',
 			values: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 			namespace: 'test',
 			metadata: {
 				type: 'page',
 				title: 'About KCD MCP',
-				url: '/__mock__/about-kcd-mcp',
+				url: '/__mock__/about-mcp',
 				snippet: 'About KCD MCP',
 			},
 		})}\n`

--- a/mocks/cloudflare.ts
+++ b/mocks/cloudflare.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { promises as fs } from 'node:fs'
+import { promises as fs, type Dirent } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import slugify from '@sindresorhus/slugify'
@@ -11,8 +11,8 @@ import {
 	type DefaultRequestMultipartBody,
 	type HttpHandler,
 } from 'msw'
-import { requiredHeader } from './utils.ts'
 import { mockTransistorEpisodes } from './transistor.ts'
+import { requiredHeader } from './utils.ts'
 
 const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4'
 
@@ -242,7 +242,7 @@ async function listFilesRecursively({
 	const walk = async (current: string, depth: number) => {
 		if (results.length >= maxFiles) return
 		if (depth > maxDepth) return
-		let entries: Array<import('node:fs').Dirent> = []
+		let entries: Dirent[] = []
 		try {
 			entries = await fs.readdir(current, { withFileTypes: true })
 		} catch {

--- a/mocks/cloudflare.ts
+++ b/mocks/cloudflare.ts
@@ -1,0 +1,549 @@
+import { createHash } from 'node:crypto'
+import {
+	http,
+	HttpResponse,
+	type DefaultBodyType,
+	type DefaultRequestMultipartBody,
+	type HttpHandler,
+} from 'msw'
+import { requiredHeader } from './utils.ts'
+
+const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4'
+
+// Keep vectors small to avoid wasting CPU/memory in local mocks.
+const DEFAULT_EMBEDDING_DIMS = 12
+
+type CloudflareApiEnvelope<T> = {
+	success: boolean
+	errors: Array<{ code: number; message: string }>
+	messages: Array<{ code: number; message: string }>
+	result: T
+}
+
+type VectorizeStoredVector = {
+	id: string
+	values: number[]
+	metadata: Record<string, unknown>
+	namespace: string
+}
+
+type VectorizeIndexStore = Map<string, Map<string, VectorizeStoredVector>>
+
+// Keyed by `${accountId}:${indexName}`.
+const vectorizeIndexes = new Map<string, VectorizeIndexStore>()
+
+function jsonOk<T>(result: T, init?: { status?: number }) {
+	const body: CloudflareApiEnvelope<T> = {
+		success: true,
+		errors: [],
+		messages: [],
+		result,
+	}
+	return HttpResponse.json(body, { status: init?.status ?? 200 })
+}
+
+function jsonError(
+	status: number,
+	message: string,
+	code = 10000, // generic
+) {
+	const body: CloudflareApiEnvelope<null> = {
+		success: false,
+		errors: [{ code, message }],
+		messages: [],
+		result: null,
+	}
+	return HttpResponse.json(body, { status })
+}
+
+function clamp(n: number, min: number, max: number) {
+	return Math.min(max, Math.max(min, n))
+}
+
+function dot(a: number[], b: number[]) {
+	const len = Math.min(a.length, b.length)
+	let sum = 0
+	for (let i = 0; i < len; i++) sum += a[i]! * b[i]!
+	return sum
+}
+
+function norm(a: number[]) {
+	let sum = 0
+	for (const v of a) sum += v * v
+	return Math.sqrt(sum)
+}
+
+function cosineSimilarity(a: number[], b: number[]) {
+	const na = norm(a)
+	const nb = norm(b)
+	if (!na || !nb) return 0
+	return dot(a, b) / (na * nb)
+}
+
+function scoreFromSimilarity(sim: number) {
+	// Cosine sim is [-1, 1]; CF Vectorize "score" is typically [0, 1].
+	return clamp((sim + 1) / 2, 0, 1)
+}
+
+function hashToUnitFloats(hash: Buffer, dims: number) {
+	// Map bytes to [-1, 1].
+	const out: number[] = []
+	for (let i = 0; i < dims; i++) {
+		const byte = hash[i % hash.length]!
+		out.push((byte / 255) * 2 - 1)
+	}
+	return out
+}
+
+function textToEmbedding(text: string, dims = DEFAULT_EMBEDDING_DIMS) {
+	const hash = createHash('sha256').update(text, 'utf8').digest()
+	return hashToUnitFloats(hash, dims)
+}
+
+function getIndexKey(accountId: string, indexName: string) {
+	return `${accountId}:${indexName}`
+}
+
+function getOrCreateIndexStore(accountId: string, indexName: string): VectorizeIndexStore {
+	const key = getIndexKey(accountId, indexName)
+	let store = vectorizeIndexes.get(key)
+	if (!store) {
+		store = new Map()
+		vectorizeIndexes.set(key, store)
+	}
+	return store
+}
+
+function allVectors(store: VectorizeIndexStore, namespace?: string) {
+	if (typeof namespace === 'string') {
+		const ns = store.get(namespace)
+		return ns ? Array.from(ns.values()) : []
+	}
+	return Array.from(store.values()).flatMap((ns) => Array.from(ns.values()))
+}
+
+function ensureSeededIndex(accountId: string, indexName: string) {
+	const store = getOrCreateIndexStore(accountId, indexName)
+	if (allVectors(store).length > 0) return
+
+	// Seed a few deterministic "documents" so semantic search is usable in mocks.
+	const seedDocs: Array<{
+		id: string
+		title: string
+		type: string
+		url: string
+		snippet: string
+	}> = [
+		{
+			id: '/search',
+			title: 'Search',
+			type: 'page',
+			url: 'https://kentcdodds.com/search',
+			snippet: 'Semantic search across posts, pages, podcasts, talks, and more.',
+		},
+		{
+			id: '/blog',
+			title: 'Blog',
+			type: 'page',
+			url: 'https://kentcdodds.com/blog',
+			snippet: 'Articles about React, testing, and modern web development.',
+		},
+		{
+			id: '/workshops',
+			title: 'Workshops',
+			type: 'page',
+			url: 'https://kentcdodds.com/workshops',
+			snippet: 'Hands-on training on React, testing, TypeScript, and more.',
+		},
+		{
+			id: '/call-kent',
+			title: 'Call Kent Podcast',
+			type: 'podcast',
+			url: 'https://kentcdodds.com/call-kent',
+			snippet: 'Short, practical audio answers about React and software engineering.',
+		},
+		{
+			id: '/contact',
+			title: 'Contact',
+			type: 'page',
+			url: 'https://kentcdodds.com/contact',
+			snippet: 'Get in touch.',
+		},
+	]
+
+	const namespace = 'default'
+	const nsStore = new Map<string, VectorizeStoredVector>()
+	for (const doc of seedDocs) {
+		const values = textToEmbedding(`${doc.title}\n${doc.snippet}`)
+		nsStore.set(doc.id, {
+			id: doc.id,
+			values,
+			metadata: {
+				type: doc.type,
+				title: doc.title,
+				url: doc.url,
+				snippet: doc.snippet,
+			},
+			namespace,
+		})
+	}
+	store.set(namespace, nsStore)
+}
+
+async function parseVectorizeNdjsonVectors(request: Request) {
+	const contentType = request.headers.get('content-type') ?? ''
+	if (!contentType.toLowerCase().includes('multipart/form-data')) {
+		return { ok: false as const, error: 'Expected multipart/form-data request.' }
+	}
+
+	const form = await request.formData()
+	const vectorsPart = form.get('vectors')
+	if (!vectorsPart) {
+		return { ok: false as const, error: 'Missing "vectors" form field.' }
+	}
+
+	let ndjson = ''
+	if (typeof vectorsPart === 'string') {
+		ndjson = vectorsPart
+	} else if (vectorsPart instanceof Blob) {
+		ndjson = await vectorsPart.text()
+	} else {
+		return { ok: false as const, error: 'Unsupported "vectors" form field type.' }
+	}
+
+	const vectors: VectorizeStoredVector[] = []
+	const lines = ndjson.split('\n').filter(Boolean)
+	for (const line of lines) {
+		let parsed: any
+		try {
+			parsed = JSON.parse(line)
+		} catch (e) {
+			return {
+				ok: false as const,
+				error: `Invalid NDJSON line: ${String(e)}`,
+			}
+		}
+
+		const id = typeof parsed?.id === 'string' ? parsed.id : null
+		const values = Array.isArray(parsed?.values)
+			? (parsed.values as unknown[])
+					.filter((v): v is number => typeof v === 'number')
+			: null
+		if (!id || !values || values.length === 0) {
+			return {
+				ok: false as const,
+				error: 'Each vector must include { id: string, values: number[] }.',
+			}
+		}
+
+		const namespace =
+			typeof parsed?.namespace === 'string' && parsed.namespace
+				? parsed.namespace
+				: 'default'
+		const metadata =
+			parsed?.metadata && typeof parsed.metadata === 'object'
+				? (parsed.metadata as Record<string, unknown>)
+				: {}
+
+		vectors.push({ id, values, namespace, metadata })
+	}
+
+	return { ok: true as const, vectors }
+}
+
+function modelFromAiRunPathname(pathname: string) {
+	const marker = '/ai/run/'
+	const idx = pathname.indexOf(marker)
+	if (idx === -1) return null
+	const raw = pathname.slice(idx + marker.length)
+	if (!raw) return null
+
+	// `raw` may include slashes (e.g. @cf/google/embeddinggemma-300m) or be a
+	// single encoded segment (e.g. %40cf%2Fopenai%2Fwhisper).
+	return decodeURIComponent(raw)
+}
+
+export const cloudflareHandlers: Array<HttpHandler> = [
+	// Workers AI (REST): https://api.cloudflare.com/client/v4/accounts/:accountId/ai/run/<model>
+	// Model names commonly contain `/`, so use a regex instead of path params.
+	http.post<any, DefaultBodyType>(
+		/https:\/\/api\.cloudflare\.com\/client\/v4\/accounts\/[^/]+\/ai\/run\/.+/,
+		async ({ request }) => {
+			requiredHeader(request.headers, 'authorization')
+
+			const url = new URL(request.url)
+			const model = modelFromAiRunPathname(url.pathname) ?? 'unknown-model'
+			const contentType = (request.headers.get('content-type') ?? '').toLowerCase()
+
+			// Transcription requests in-app are raw MP3 bytes (`audio/mpeg`).
+			if (contentType.includes('audio/')) {
+				// Return a short, realistic-enough snippet; callers only need `.text`.
+				return jsonOk({
+					text: `Mock transcription (${model}): hello from Workers AI.`,
+				})
+			}
+
+			// Embeddings: { text: string[] }
+			let body: any = null
+			try {
+				body = await request.json()
+			} catch {
+				// ignore
+			}
+
+			const textsRaw = body?.text
+			const texts =
+				Array.isArray(textsRaw) ? textsRaw.filter((t: any) => typeof t === 'string') : []
+
+			if (!texts.length) {
+				return jsonError(
+					400,
+					`Mock Workers AI expected JSON body { text: string[] } (model: ${model}).`,
+					10001,
+				)
+			}
+
+			const data = texts.map((t: string) => textToEmbedding(t))
+			return jsonOk({
+				shape: [texts.length, DEFAULT_EMBEDDING_DIMS],
+				data,
+			})
+		},
+	),
+
+	// Vectorize query (v2)
+	http.post<any, DefaultBodyType>(
+		`${CLOUDFLARE_API_BASE}/accounts/:accountId/vectorize/v2/indexes/:indexName/query`,
+		async ({ request, params }) => {
+			requiredHeader(request.headers, 'authorization')
+			const accountId = String(params.accountId)
+			const indexName = String(params.indexName)
+
+			let body: any
+			try {
+				body = await request.json()
+			} catch {
+				return jsonError(400, 'Invalid JSON body for Vectorize query.', 10002)
+			}
+
+			const vector = Array.isArray(body?.vector)
+				? (body.vector as unknown[]).filter((v): v is number => typeof v === 'number')
+				: null
+			const topK = Number.isFinite(body?.topK) ? Number(body.topK) : 10
+			const namespace = typeof body?.namespace === 'string' ? body.namespace : undefined
+
+			if (!vector || vector.length === 0) {
+				return jsonError(
+					400,
+					'Mock Vectorize expected JSON body { vector: number[], topK?: number }.',
+					10003,
+				)
+			}
+
+			ensureSeededIndex(accountId, indexName)
+			const store = getOrCreateIndexStore(accountId, indexName)
+			const candidates = allVectors(store, namespace)
+
+			const matches = candidates
+				.map((v) => ({
+					id: v.id,
+					score: scoreFromSimilarity(cosineSimilarity(vector, v.values)),
+					metadata: v.metadata,
+				}))
+				.sort((a, b) => b.score - a.score)
+				.slice(0, clamp(Math.trunc(topK), 1, 100))
+
+			return jsonOk({
+				count: matches.length,
+				matches,
+			})
+		},
+	),
+
+	// Vectorize query (legacy)
+	http.post<any, DefaultBodyType>(
+		`${CLOUDFLARE_API_BASE}/accounts/:accountId/vectorize/indexes/:indexName/query`,
+		async ({ request, params }) => {
+			// Same response shape as v2 in our mock.
+			requiredHeader(request.headers, 'authorization')
+			const accountId = String(params.accountId)
+			const indexName = String(params.indexName)
+
+			let body: any
+			try {
+				body = await request.json()
+			} catch {
+				return jsonError(400, 'Invalid JSON body for Vectorize query.', 10002)
+			}
+
+			const vector = Array.isArray(body?.vector)
+				? (body.vector as unknown[]).filter((v): v is number => typeof v === 'number')
+				: null
+			const topK = Number.isFinite(body?.topK) ? Number(body.topK) : 10
+			const namespace = typeof body?.namespace === 'string' ? body.namespace : undefined
+
+			if (!vector || vector.length === 0) {
+				return jsonError(
+					400,
+					'Mock Vectorize expected JSON body { vector: number[], topK?: number }.',
+					10003,
+				)
+			}
+
+			ensureSeededIndex(accountId, indexName)
+			const store = getOrCreateIndexStore(accountId, indexName)
+			const candidates = allVectors(store, namespace)
+
+			const matches = candidates
+				.map((v) => ({
+					id: v.id,
+					score: scoreFromSimilarity(cosineSimilarity(vector, v.values)),
+					metadata: v.metadata,
+				}))
+				.sort((a, b) => b.score - a.score)
+				.slice(0, clamp(Math.trunc(topK), 1, 100))
+
+			return jsonOk({
+				count: matches.length,
+				matches,
+			})
+		},
+	),
+
+	// Vectorize write operations (v2): insert/upsert
+	http.post<any, DefaultRequestMultipartBody>(
+		`${CLOUDFLARE_API_BASE}/accounts/:accountId/vectorize/v2/indexes/:indexName/:operation`,
+		async ({ request, params }) => {
+			requiredHeader(request.headers, 'authorization')
+			const operation = String(params.operation)
+			if (operation !== 'insert' && operation !== 'upsert') {
+				return jsonError(404, `Unknown Vectorize operation: ${operation}`, 10004)
+			}
+
+			const accountId = String(params.accountId)
+			const indexName = String(params.indexName)
+			const parsed = await parseVectorizeNdjsonVectors(request)
+			if (!parsed.ok) return jsonError(400, parsed.error, 10005)
+
+			const store = getOrCreateIndexStore(accountId, indexName)
+			let updated = 0
+			for (const v of parsed.vectors) {
+				let ns = store.get(v.namespace)
+				if (!ns) {
+					ns = new Map()
+					store.set(v.namespace, ns)
+				}
+				ns.set(v.id, v)
+				updated++
+			}
+
+			return jsonOk({
+				operation,
+				updated,
+			})
+		},
+	),
+
+	// Vectorize write operations (legacy): insert/upsert
+	http.post<any, DefaultRequestMultipartBody>(
+		`${CLOUDFLARE_API_BASE}/accounts/:accountId/vectorize/indexes/:indexName/:operation`,
+		async ({ request, params }) => {
+			requiredHeader(request.headers, 'authorization')
+			const operation = String(params.operation)
+			if (operation !== 'insert' && operation !== 'upsert') {
+				return jsonError(404, `Unknown Vectorize operation: ${operation}`, 10004)
+			}
+
+			const accountId = String(params.accountId)
+			const indexName = String(params.indexName)
+			const parsed = await parseVectorizeNdjsonVectors(request)
+			if (!parsed.ok) return jsonError(400, parsed.error, 10005)
+
+			const store = getOrCreateIndexStore(accountId, indexName)
+			let updated = 0
+			for (const v of parsed.vectors) {
+				let ns = store.get(v.namespace)
+				if (!ns) {
+					ns = new Map()
+					store.set(v.namespace, ns)
+				}
+				ns.set(v.id, v)
+				updated++
+			}
+
+			return jsonOk({
+				operation,
+				updated,
+			})
+		},
+	),
+
+	// Vectorize delete_by_ids (v2)
+	http.post<any, DefaultBodyType>(
+		`${CLOUDFLARE_API_BASE}/accounts/:accountId/vectorize/v2/indexes/:indexName/delete_by_ids`,
+		async ({ request, params }) => {
+			requiredHeader(request.headers, 'authorization')
+			const accountId = String(params.accountId)
+			const indexName = String(params.indexName)
+
+			let body: any
+			try {
+				body = await request.json()
+			} catch {
+				return jsonError(400, 'Invalid JSON body for delete_by_ids.', 10006)
+			}
+
+			const ids = Array.isArray(body?.ids)
+				? (body.ids as unknown[]).filter((id): id is string => typeof id === 'string')
+				: null
+			if (!ids?.length) {
+				return jsonError(400, 'Mock delete_by_ids expected { ids: string[] }.', 10007)
+			}
+
+			const store = getOrCreateIndexStore(accountId, indexName)
+			let deleted = 0
+			for (const ns of store.values()) {
+				for (const id of ids) {
+					if (ns.delete(id)) deleted++
+				}
+			}
+
+			return jsonOk({ deleted })
+		},
+	),
+
+	// Vectorize delete_by_ids (legacy)
+	http.post<any, DefaultBodyType>(
+		`${CLOUDFLARE_API_BASE}/accounts/:accountId/vectorize/indexes/:indexName/delete_by_ids`,
+		async ({ request, params }) => {
+			requiredHeader(request.headers, 'authorization')
+			const accountId = String(params.accountId)
+			const indexName = String(params.indexName)
+
+			let body: any
+			try {
+				body = await request.json()
+			} catch {
+				return jsonError(400, 'Invalid JSON body for delete_by_ids.', 10006)
+			}
+
+			const ids = Array.isArray(body?.ids)
+				? (body.ids as unknown[]).filter((id): id is string => typeof id === 'string')
+				: null
+			if (!ids?.length) {
+				return jsonError(400, 'Mock delete_by_ids expected { ids: string[] }.', 10007)
+			}
+
+			const store = getOrCreateIndexStore(accountId, indexName)
+			let deleted = 0
+			for (const ns of store.values()) {
+				for (const id of ids) {
+					if (ns.delete(id)) deleted++
+				}
+			}
+
+			return jsonOk({ deleted })
+		},
+	),
+]
+

--- a/mocks/cloudflare.ts
+++ b/mocks/cloudflare.ts
@@ -585,7 +585,12 @@ function modelFromAiRunPathname(pathname: string) {
 	return decodeURIComponent(raw)
 }
 
-const handleVectorizeQuery = async ({ request, params }) => {
+type VectorizeHandlerArgs = {
+	request: Request
+	params: { accountId: string; indexName: string } & Record<string, string>
+}
+
+const handleVectorizeQuery = async ({ request, params }: VectorizeHandlerArgs) => {
 	requiredHeader(request.headers, 'authorization')
 	const accountId = String(params.accountId)
 	const indexName = String(params.indexName)
@@ -679,7 +684,7 @@ const handleVectorizeQuery = async ({ request, params }) => {
 	})
 }
 
-const handleVectorizeInsert = async ({ request, params }) => {
+const handleVectorizeInsert = async ({ request, params }: VectorizeHandlerArgs) => {
 	requiredHeader(request.headers, 'authorization')
 	const accountId = String(params.accountId)
 	const indexName = String(params.indexName)
@@ -701,7 +706,7 @@ const handleVectorizeInsert = async ({ request, params }) => {
 	return jsonOk({ operation: 'insert', updated })
 }
 
-const handleVectorizeUpsert = async ({ request, params }) => {
+const handleVectorizeUpsert = async ({ request, params }: VectorizeHandlerArgs) => {
 	requiredHeader(request.headers, 'authorization')
 	const accountId = String(params.accountId)
 	const indexName = String(params.indexName)
@@ -723,7 +728,7 @@ const handleVectorizeUpsert = async ({ request, params }) => {
 	return jsonOk({ operation: 'upsert', updated })
 }
 
-const handleVectorizeDeleteByIds = async ({ request, params }) => {
+const handleVectorizeDeleteByIds = async ({ request, params }: VectorizeHandlerArgs) => {
 	requiredHeader(request.headers, 'authorization')
 	const accountId = String(params.accountId)
 	const indexName = String(params.indexName)

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,5 +1,6 @@
 import { http, passthrough, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { cloudflareHandlers } from './cloudflare.ts'
 import { discordHandlers } from './discord.ts'
 import { githubHandlers } from './github.ts'
 import { kitHandlers } from './kit.ts'
@@ -79,6 +80,7 @@ const server = setupServer(
 	...discordHandlers,
 	...kitHandlers,
 	...simplecastHandlers,
+	...cloudflareHandlers,
 	...miscHandlers,
 )
 

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -191,4 +191,4 @@ const transistorHandlers: Array<HttpHandler> = [
 	),
 ]
 
-export { transistorHandlers }
+export { transistorHandlers, episodes as mockTransistorEpisodes }


### PR DESCRIPTION
Add MSW mocks for Cloudflare Workers AI and Vectorize APIs to enable local development and testing.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-87f42ba3-93d0-4765-8df8-1c87f0cc3be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87f42ba3-93d0-4765-8df8-1c87f0cc3be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a sizeable new mock implementation and hooks it into the global MSW server, which could change test/local-dev network behavior if the handlers match unexpected requests. Production logic change is minimal (a type-cast on the transcription request body).
> 
> **Overview**
> Adds **new MSW mocks** for Cloudflare’s `Workers AI` and `Vectorize` APIs (`mocks/cloudflare.ts`) to support local development/testing, including embedding generation, audio transcription responses, and Vectorize `query`/`insert`/`upsert`/`delete_by_ids` flows with seeded/searchable mock data.
> 
> Wires these handlers into the existing mock server (`mocks/index.ts`), adds a focused Vitest suite covering embeddings/transcription and Vectorize write/query/delete behaviors, and updates `transcribeMp3WithWorkersAi` to accept broader `Uint8Array` inputs by casting the request body to satisfy stricter fetch typings.
> 
> Exports `episodes` as `mockTransistorEpisodes` from `mocks/transistor.ts` to seed the mock search corpus used by the Vectorize mock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffae634cc082655e0fa87831d63cbf554708c372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for Cloudflare-style AI endpoints: embeddings, transcription, vectorize queries, upsert/query/delete flows.

* **Chores**
  * Added a local Cloudflare API mock with seeded sample data to support AI run, embeddings, transcription, and vector insert/query/delete scenarios.
  * Improved request handling compatibility for transcription payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->