### PR TITLE
Search results auto-load

### DIFF
--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -128,7 +128,6 @@ export default function SearchPage() {
 
 	React.useEffect(() => {
 		// Clear results immediately when the input is cleared.
-		if (!trimmedQuery) return
 		debouncedRequestSearch(trimmedQuery)
 	}, [debouncedRequestSearch, trimmedQuery])
 

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -98,6 +98,11 @@ export default function SearchPage() {
 	}, 250)
 
 	React.useEffect(() => {
+		setQuery(loaderData.q)
+		setDebouncedQuery(loaderData.q)
+	}, [loaderData.q])
+
+	React.useEffect(() => {
 		if (trimmedQuery === debouncedQuery) return
 		// Clear results immediately when the input is cleared.
 		if (!trimmedQuery) {

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -108,6 +108,7 @@ export default function SearchPage() {
 	React.useEffect(() => {
 		setQuery(loaderData.q)
 		setRequestedQuery(loaderData.q)
+		setResolved(null)
 	}, [loaderData.q])
 
 	React.useEffect(() => {
@@ -118,6 +119,7 @@ export default function SearchPage() {
 	}, [trimmedQuery])
 
 	const debouncedRequestSearch = useDebounce((nextQuery: string) => {
+		if (nextQuery === requestedQuery) return
 		setRequestedQuery(nextQuery)
 		if (!loaderData.configured) return
 		if (!nextQuery) return
@@ -162,7 +164,20 @@ export default function SearchPage() {
 				subtitle="Semantic search across posts, pages, podcasts, talks, resume, credits, and testimonials."
 				imageBuilder={images.kodyProfileGray}
 				action={
-					<fetcher.Form method="get" action="/search" className="w-full">
+					<fetcher.Form
+						method="get"
+						action="/search"
+						className="w-full"
+						onSubmit={(event) => {
+							event.preventDefault()
+							if (!loaderData.configured) return
+							if (!trimmedQuery) return
+							if (trimmedQuery === requestedQuery) return
+							setRequestedQuery(trimmedQuery)
+							if (trimmedQuery === loaderData.q) return
+							load(`/search?q=${encodeURIComponent(trimmedQuery)}`)
+						}}
+					>
 						<div className="relative">
 							<Input
 								ref={inputRef}

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -162,7 +162,7 @@ export default function SearchPage() {
 				subtitle="Semantic search across posts, pages, podcasts, talks, resume, credits, and testimonials."
 				imageBuilder={images.kodyProfileGray}
 				action={
-					<div className="w-full">
+					<fetcher.Form method="get" action="/search" className="w-full">
 						<div className="relative">
 							<Input
 								ref={inputRef}
@@ -174,7 +174,7 @@ export default function SearchPage() {
 								onChange={(event) => setQuery(event.currentTarget.value)}
 							/>
 						</div>
-					</div>
+					</fetcher.Form>
 				}
 			/>
 

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -82,6 +82,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export default function SearchPage() {
 	const loaderData = useLoaderData<typeof loader>()
 	const fetcher = useFetcher<typeof loader>({ key: 'search-page-results' })
+	const { load } = fetcher
 	const inputRef = React.useRef<HTMLInputElement>(null)
 
 	const [query, setQuery] = React.useState(loaderData.q)
@@ -133,8 +134,8 @@ export default function SearchPage() {
 		if (!debouncedQuery) return
 		// If the loader already fetched this query (e.g. initial page load), reuse it.
 		if (debouncedQuery === loaderData.q) return
-		fetcher.load(`/search?q=${encodeURIComponent(debouncedQuery)}`)
-	}, [debouncedQuery, fetcher.load, loaderData.configured, loaderData.q])
+		load(`/search?q=${encodeURIComponent(debouncedQuery)}`)
+	}, [debouncedQuery, load, loaderData.configured, loaderData.q])
 
 	const isQueryPending = trimmedQuery !== debouncedQuery
 

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -135,10 +135,10 @@ export default function SearchPage() {
 	const isQueryPending = trimmedQuery !== requestedQuery
 
 	const activeData =
-		requestedQuery && fetcher.data?.q === requestedQuery
-			? fetcher.data
-			: loaderData.q === requestedQuery
-				? loaderData
+		requestedQuery && loaderData.q === requestedQuery
+			? loaderData
+			: fetcher.data?.q === requestedQuery
+				? fetcher.data
 				: null
 
 	const error =

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -140,10 +140,10 @@ export default function SearchPage() {
 	const isQueryPending = trimmedQuery !== debouncedQuery
 
 	const activeData =
-		debouncedQuery && fetcher.data?.q === debouncedQuery
-			? fetcher.data
-			: loaderData.q === debouncedQuery
-				? loaderData
+		debouncedQuery && loaderData.q === debouncedQuery
+			? loaderData
+			: fetcher.data?.q === debouncedQuery
+				? fetcher.data
 				: null
 
 	const error =

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -134,7 +134,7 @@ export default function SearchPage() {
 		// If the loader already fetched this query (e.g. initial page load), reuse it.
 		if (debouncedQuery === loaderData.q) return
 		fetcher.load(`/search?q=${encodeURIComponent(debouncedQuery)}`)
-	}, [debouncedQuery, fetcher, loaderData.configured, loaderData.q])
+	}, [debouncedQuery, fetcher.load, loaderData.configured, loaderData.q])
 
 	const isQueryPending = trimmedQuery !== debouncedQuery
 


### PR DESCRIPTION
Auto-load search results as the user types using a debounced `fetcher.load()` and update the URL with `replaceState`.

This changes the search page from a `Form` submission to an auto-loading experience, as it's not a true navigation. The controlled input also syncs with `loaderData.q` for external navigations.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-56b65009-b33d-4214-8dca-364480cf997c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56b65009-b33d-4214-8dca-364480cf997c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX refactor of the search flow with new client-side state and async coordination; risk is mainly regressions in result freshness/loading/error states rather than data/security concerns.
> 
> **Overview**
> Updates the search page to a typeahead-style experience: the input is now controlled, results are fetched via a debounced `useFetcher().load()` rather than full `GET` form navigations, and the `q` param is kept shareable via `replaceState` without rerunning the loader on every keypress.
> 
> Adds client-side state to coordinate *requested vs resolved* queries, reuse initial loader results when possible, and provide smoother UX with a reusable loading skeleton, pending opacity transitions, and a centralized “semantic search not configured” error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3e92da326fb445e94bf424927348ef6cb676ec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search input is now client-controlled and debounced to reduce requests while typing
  * Query syncs to the URL without triggering full-page reloads
  * Initial results are reused and subsequent fetches are staged to avoid jarring reloads
  * Loading skeleton shown during result fetches for smoother feedback
  * Clearer, user-friendly message when semantic search isn’t configured
<!-- end of auto-generated comment: release notes by coderabbit.ai -->