### PR TITLE
Blog page sorting

### DIFF
--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -377,16 +377,24 @@ function BlogHome() {
 	}
 
 	const isSearching = query.length > 0 || userReadsState !== 'unset'
+	const showFeatured =
+		!isSearching && Boolean(data.recommended) && effectiveSort === 'newest'
+	const shouldOmitRecommendedFromGrid = showFeatured && Boolean(data.recommended)
 
 	const posts = isSearching
 		? matchingPosts.slice(0, indexToShow)
-		: matchingPosts
-				.filter((p) => p.slug !== data.recommended?.slug)
-				.slice(0, indexToShow)
+		: (shouldOmitRecommendedFromGrid
+				? matchingPosts.filter((p) => p.slug !== data.recommended?.slug)
+				: matchingPosts
+			).slice(0, indexToShow)
+
+	const nonSearchingPostsCount = shouldOmitRecommendedFromGrid
+		? Math.max(0, matchingPosts.length - 1)
+		: matchingPosts.length
 
 	const hasMorePosts = isSearching
 		? indexToShow < matchingPosts.length
-		: indexToShow < matchingPosts.length - 1
+		: indexToShow < nonSearchingPostsCount
 
 	const visibleTags = isSearching
 		? new Set(
@@ -606,7 +614,7 @@ function BlogHome() {
 
 			{/* this is a remix bug */}
 			{}
-			{!isSearching && data.recommended ? (
+			{showFeatured && data.recommended ? (
 				<div className="mb-10">
 					<FeaturedSection
 						subTitle={[

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -382,20 +382,17 @@ function BlogHome() {
 	const showFeatured =
 		!isSearching && Boolean(data.recommended) && effectiveSort === 'newest'
 
+	const nonSearchingPosts = showFeatured
+		? matchingPosts.filter((p) => p.slug !== data.recommended?.slug)
+		: matchingPosts
+
 	const posts = isSearching
 		? matchingPosts.slice(0, indexToShow)
-		: (showFeatured
-				? matchingPosts.filter((p) => p.slug !== data.recommended?.slug)
-				: matchingPosts
-			).slice(0, indexToShow)
-
-	const nonSearchingPostsCount = showFeatured
-		? Math.max(0, matchingPosts.length - 1)
-		: matchingPosts.length
+		: nonSearchingPosts.slice(0, indexToShow)
 
 	const hasMorePosts = isSearching
 		? indexToShow < matchingPosts.length
-		: indexToShow < nonSearchingPostsCount
+		: indexToShow < nonSearchingPosts.length
 
 	const visibleTags = isSearching
 		? new Set(

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -344,7 +344,7 @@ function BlogHome() {
 	// when the query changes, we want to reset the index
 	React.useEffect(() => {
 		setIndexToShow(initialIndexToShow)
-	}, [query, sortState, userReadsState])
+	}, [query, effectiveSort, userReadsState])
 
 	// this bit is very similar to what's on the blogs page.
 	// Next time we need to do work in here, let's make an abstraction for them
@@ -379,16 +379,15 @@ function BlogHome() {
 	const isSearching = query.length > 0 || userReadsState !== 'unset'
 	const showFeatured =
 		!isSearching && Boolean(data.recommended) && effectiveSort === 'newest'
-	const shouldOmitRecommendedFromGrid = showFeatured && Boolean(data.recommended)
 
 	const posts = isSearching
 		? matchingPosts.slice(0, indexToShow)
-		: (shouldOmitRecommendedFromGrid
+		: (showFeatured
 				? matchingPosts.filter((p) => p.slug !== data.recommended?.slug)
 				: matchingPosts
 			).slice(0, indexToShow)
 
-	const nonSearchingPostsCount = shouldOmitRecommendedFromGrid
+	const nonSearchingPostsCount = showFeatured
 		? Math.max(0, matchingPosts.length - 1)
 		: matchingPosts.length
 

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -614,92 +614,99 @@ function BlogHome() {
 
 			{/* this is a remix bug */}
 			{}
-			{showFeatured && data.recommended ? (
-				<div className="mb-10">
-					<FeaturedSection
-						subTitle={[
-							data.recommended.dateDisplay,
-							data.recommended.readTime?.text ?? 'quick read',
-						]
-							.filter(Boolean)
-							.join(' — ')}
-						title={data.recommended.frontmatter.title}
-						blurDataUrl={data.recommended.frontmatter.bannerBlurDataUrl}
-						imageBuilder={
-							data.recommended.frontmatter.bannerCloudinaryId
-								? getImageBuilder(
-										data.recommended.frontmatter.bannerCloudinaryId,
-										getBannerAltProp(data.recommended.frontmatter),
-									)
-								: undefined
-						}
-						caption="Featured article"
-						cta="Read full article"
-						slug={data.recommended.slug}
-						permalink={recommendedPermalink}
-						leadingTeam={getLeadingTeamForSlug(data.recommended.slug)}
-					/>
-				</div>
-			) : null}
-
-			<Grid className="mb-64" ref={resultsRef}>
-				<div className="col-span-full mb-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-					<H6 as="div" className="m-0">
-						Articles
-					</H6>
-					<label className="flex items-center gap-3 text-sm font-medium text-slate-500">
-						<span>Sort by</span>
-						<select
-							value={
-								regularQuery === '' && sortState === 'newest' ? 'auto' : sortState
-							}
-							onChange={(e) => setSortState(e.currentTarget.value as SortState)}
-							className="text-primary bg-primary border-secondary focus:bg-secondary rounded-full border px-5 py-2 hover:border-team-current focus:border-team-current focus:outline-none"
-						>
-							<option value="auto">
-								{regularQuery ? 'Relevance' : 'Newest'}
-							</option>
-							{regularQuery ? <option value="newest">Newest</option> : null}
-							<option value="popular">Most popular</option>
-							<option value="oldest">Oldest</option>
-						</select>
-					</label>
-				</div>
-				{posts.length === 0 ? (
-					<div className="col-span-full flex flex-col items-center">
-						<img
-							{...getImgProps(images.bustedOnewheel, {
-								className: 'mt-24 h-auto w-full max-w-lg',
-								widths: [350, 512, 1024, 1536],
-								sizes: ['(max-width: 639px) 80vw', '512px'],
-							})}
-						/>
-						<H3 as="p" variant="secondary" className="mt-24 max-w-lg">
-							{`Couldn't find anything to match your criteria. Sorry.`}
-						</H3>
+			<div ref={resultsRef}>
+				<Grid className={showFeatured ? 'mb-6' : 'mb-10'}>
+					<div className="col-span-full flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<H6 as="div" className="m-0">
+							Articles
+						</H6>
+						<label className="flex items-center gap-3 text-sm font-medium text-slate-500">
+							<span>Sort by</span>
+							<select
+								value={
+									regularQuery === '' && sortState === 'newest'
+										? 'auto'
+										: sortState
+								}
+								onChange={(e) => setSortState(e.currentTarget.value as SortState)}
+								className="text-primary bg-primary border-secondary focus:bg-secondary rounded-full border px-5 py-2 hover:border-team-current focus:border-team-current focus:outline-none"
+							>
+								<option value="auto">
+									{regularQuery ? 'Relevance' : 'Newest'}
+								</option>
+								{regularQuery ? <option value="newest">Newest</option> : null}
+								<option value="popular">Most popular</option>
+								<option value="oldest">Oldest</option>
+							</select>
+						</label>
 					</div>
-				) : (
-					posts.map((article) => (
-						<div key={article.slug} className="col-span-4 mb-10">
-							<ArticleCard
-								article={article}
-								leadingTeam={getLeadingTeamForSlug(article.slug)}
-							/>
-						</div>
-					))
-				)}
-			</Grid>
+				</Grid>
 
-			{hasMorePosts ? (
-				<div className="mb-64 flex w-full justify-center">
-					<Button
-						variant="secondary"
-						onClick={() => setIndexToShow((i) => i + PAGE_SIZE)}
-					>
-						<span>Load more articles</span> <PlusIcon />
-					</Button>
-				</div>
-			) : null}
+				{showFeatured && data.recommended ? (
+					<div className="mb-10">
+						<FeaturedSection
+							subTitle={[
+								data.recommended.dateDisplay,
+								data.recommended.readTime?.text ?? 'quick read',
+							]
+								.filter(Boolean)
+								.join(' — ')}
+							title={data.recommended.frontmatter.title}
+							blurDataUrl={data.recommended.frontmatter.bannerBlurDataUrl}
+							imageBuilder={
+								data.recommended.frontmatter.bannerCloudinaryId
+									? getImageBuilder(
+											data.recommended.frontmatter.bannerCloudinaryId,
+											getBannerAltProp(data.recommended.frontmatter),
+										)
+									: undefined
+							}
+							caption="Featured article"
+							cta="Read full article"
+							slug={data.recommended.slug}
+							permalink={recommendedPermalink}
+							leadingTeam={getLeadingTeamForSlug(data.recommended.slug)}
+						/>
+					</div>
+				) : null}
+
+				<Grid className="mb-64">
+					{posts.length === 0 ? (
+						<div className="col-span-full flex flex-col items-center">
+							<img
+								{...getImgProps(images.bustedOnewheel, {
+									className: 'mt-24 h-auto w-full max-w-lg',
+									widths: [350, 512, 1024, 1536],
+									sizes: ['(max-width: 639px) 80vw', '512px'],
+								})}
+							/>
+							<H3 as="p" variant="secondary" className="mt-24 max-w-lg">
+								{`Couldn't find anything to match your criteria. Sorry.`}
+							</H3>
+						</div>
+					) : (
+						posts.map((article) => (
+							<div key={article.slug} className="col-span-4 mb-10">
+								<ArticleCard
+									article={article}
+									leadingTeam={getLeadingTeamForSlug(article.slug)}
+								/>
+							</div>
+						))
+					)}
+				</Grid>
+
+				{hasMorePosts ? (
+					<div className="mb-64 flex w-full justify-center">
+						<Button
+							variant="secondary"
+							onClick={() => setIndexToShow((i) => i + PAGE_SIZE)}
+						>
+							<span>Load more articles</span> <PlusIcon />
+						</Button>
+					</div>
+				) : null}
+			</div>
 
 			<Grid>
 				<div className="col-span-full lg:col-span-5">

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -197,11 +197,14 @@ function BlogHome() {
 		return getSortStateFromParam(searchParams.get('sort'))
 	})
 	const query = queryValue.trim()
+	const regularQuery = query.replace(specialQueryRegex, '').trim()
 
 	useUpdateQueryStringValueWithoutNavigation('q', query)
 	useUpdateQueryStringValueWithoutNavigation(
 		'sort',
-		sortState === 'auto' ? '' : sortState,
+		sortState === 'auto' || (sortState === 'newest' && regularQuery === '')
+			? ''
+			: sortState,
 	)
 
 	const data = useLoaderData<typeof loader>()
@@ -214,7 +217,6 @@ function BlogHome() {
 		[data.allPostReadRankings],
 	)
 
-	const regularQuery = query.replace(specialQueryRegex, '').trim()
 	const effectiveSort =
 		sortState === 'auto'
 			? regularQuery

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -284,9 +284,10 @@ function BlogHome() {
 			return value
 		}
 
-		const compareByNewest = (
+		const compareByDate = (
 			a: (typeof searchedPosts)[number],
 			b: (typeof searchedPosts)[number],
+			direction: 'asc' | 'desc',
 		) => {
 			const aTime = getPostDateTime(a)
 			const bTime = getPostDateTime(b)
@@ -294,21 +295,18 @@ function BlogHome() {
 			if (aTime === null) return 1
 			if (bTime === null) return -1
 			if (aTime === bTime) return a.slug.localeCompare(b.slug)
-			return bTime - aTime
+			return direction === 'desc' ? bTime - aTime : aTime - bTime
 		}
+
+		const compareByNewest = (
+			a: (typeof searchedPosts)[number],
+			b: (typeof searchedPosts)[number],
+		) => compareByDate(a, b, 'desc')
 
 		const compareByOldest = (
 			a: (typeof searchedPosts)[number],
 			b: (typeof searchedPosts)[number],
-		) => {
-			const aTime = getPostDateTime(a)
-			const bTime = getPostDateTime(b)
-			if (aTime === null && bTime === null) return a.slug.localeCompare(b.slug)
-			if (aTime === null) return 1
-			if (bTime === null) return -1
-			if (aTime === bTime) return a.slug.localeCompare(b.slug)
-			return aTime - bTime
-		}
+		) => compareByDate(a, b, 'asc')
 
 		const compareByPopular = (
 			a: (typeof searchedPosts)[number],
@@ -328,8 +326,13 @@ function BlogHome() {
 				return postsToSort.sort(compareByOldest)
 			case 'popular':
 				return postsToSort.sort(compareByPopular)
-			default:
+			default: {
+				// If TypeScript ever flags this, a new SortState value was added
+				// without a corresponding sort branch.
+				const _exhaustiveCheck: never = effectiveSort
+				void _exhaustiveCheck
 				return searchedPosts
+			}
 		}
 	}, [
 		allPosts,
@@ -626,7 +629,9 @@ function BlogHome() {
 										? 'auto'
 										: sortState
 								}
-								onChange={(e) => setSortState(e.currentTarget.value as SortState)}
+								onChange={(e) =>
+									setSortState(getSortStateFromParam(e.currentTarget.value))
+								}
 								className="text-primary bg-primary border-secondary focus:bg-secondary rounded-full border px-5 py-2 hover:border-team-current focus:border-team-current focus:outline-none"
 							>
 								<option value="auto">

--- a/app/routes/resources+/promotification.tsx
+++ b/app/routes/resources+/promotification.tsx
@@ -2,7 +2,7 @@
 // which the user can dismiss for a period of time.
 import { type ActionFunctionArgs, json } from '@remix-run/node'
 import { useFetcher } from '@remix-run/react'
-import { parse, serialize } from 'cookie'
+import * as cookie from 'cookie'
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
@@ -20,7 +20,7 @@ export function getPromoCookieValue({
 	promoName: string
 	request: Request
 }) {
-	const cookies = parse(request.headers.get('Cookie') || '')
+	const cookies = cookie.parse(request.headers.get('Cookie') || '')
 	return cookies[promoName]
 }
 
@@ -30,7 +30,7 @@ export async function action({ request }: ActionFunctionArgs) {
 	const promoName = formData.get('promoName')
 	invariant(typeof promoName === 'string', 'promoName must be a string')
 
-	const cookieHeader = serialize(promoName, 'hidden', {
+	const cookieHeader = cookie.serialize(promoName, 'hidden', {
 		httpOnly: true,
 		secure: true,
 		sameSite: 'lax',

--- a/app/routes/resources+/promotification.tsx
+++ b/app/routes/resources+/promotification.tsx
@@ -2,7 +2,7 @@
 // which the user can dismiss for a period of time.
 import { type ActionFunctionArgs, json } from '@remix-run/node'
 import { useFetcher } from '@remix-run/react'
-import cookie from 'cookie'
+import { parse, serialize } from 'cookie'
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
@@ -20,7 +20,7 @@ export function getPromoCookieValue({
 	promoName: string
 	request: Request
 }) {
-	const cookies = cookie.parse(request.headers.get('Cookie') || '')
+	const cookies = parse(request.headers.get('Cookie') || '')
 	return cookies[promoName]
 }
 
@@ -30,7 +30,7 @@ export async function action({ request }: ActionFunctionArgs) {
 	const promoName = formData.get('promoName')
 	invariant(typeof promoName === 'string', 'promoName must be a string')
 
-	const cookieHeader = cookie.serialize(promoName, 'hidden', {
+	const cookieHeader = serialize(promoName, 'hidden', {
 		httpOnly: true,
 		secure: true,
 		sameSite: 'lax',

--- a/app/utils/blog.server.ts
+++ b/app/utils/blog.server.ts
@@ -160,10 +160,15 @@ async function promiseWithTimeout<T>(
 	promise: Promise<T>,
 	timeoutMs: number,
 ): Promise<T> {
+	let timeoutHandle: ReturnType<typeof setTimeout> | null = null
 	const timeoutPromise = new Promise<never>((_, reject) => {
-		setTimeout(() => reject(new Error('Timeout')), timeoutMs)
+		timeoutHandle = setTimeout(() => reject(new Error('Timeout')), timeoutMs)
 	})
-	return Promise.race([promise, timeoutPromise])
+	try {
+		return await Promise.race([promise, timeoutPromise])
+	} finally {
+		if (timeoutHandle) clearTimeout(timeoutHandle)
+	}
 }
 
 async function getBlogPostReadCounts({

--- a/app/utils/blog.server.ts
+++ b/app/utils/blog.server.ts
@@ -171,7 +171,7 @@ export async function getMostPopularPostSlugs({
 		.slice(0, limit)
 }
 
-export async function getBlogPostReadCounts({
+async function getBlogPostReadCounts({
 	request,
 	timings,
 }: {


### PR DESCRIPTION
Add a sort control to the `/blog` page, allowing users to sort posts by "Newest", "Most popular", or "Oldest".

The "Featured article" is now only displayed when sorting by "Newest" to ensure that the "Most popular" view presents a complete, popularity-ordered grid, making the sorting change more obvious and intuitive.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1b79fde2-5e0c-4e09-83c2-c0da265c1324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b79fde2-5e0c-4e09-83c2-c0da265c1324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sort-by control (Auto → relevance when searching, Newest, Oldest, Popular) that stays in sync with the URL.
  * Popular sort now uses consistent read-counts data so “Popular” ranking is more reliable.
  * Sorting UI block added above results and featured-article placement adapts to sorting and search.

* **Bug Fixes / Improvements**
  * Featured article shown only when appropriate and excluded from grid counts so pagination and “Load more” remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches blog data fetching/caching and adds new sorting logic that affects what content users see; also adjusts core server middleware flow, so regressions could impact page ordering or request handling.
> 
> **Overview**
> Adds a **Sort by** control to `/blog` and persists it via the `sort` query param, with *auto* mapping to **relevance** when searching and **newest** otherwise.
> 
> Implements deterministic client-side ordering for **newest/oldest/popular** (popular uses per-slug read counts), updates pagination/featured-article behavior so the featured card only shows when not searching and sorting by newest, and adjusts the loader to fetch `postReadCounts`.
> 
> Refactors blog popularity data fetching by introducing cached `getBlogPostReadCounts` (map of slug→count) with timeouts/fallbacks and reuses it for `getMostPopularPostSlugs`; also fixes `cookie` import style in `promotification` and makes the server header middleware non-`async` with explicit promise error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd909f385e4d89400fe935036a0a1463530b9433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->