### PR TITLE
Downshift getMenuProps call

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -329,6 +329,23 @@ function NavSearch({
 	)
 
 	const showForm = isOpen || alwaysExpanded
+	const shouldShowSuggestions = inputValue.trim().length >= 2
+	const menuProps = getMenuProps(
+		{
+			'aria-label': 'Search suggestions',
+			className: clsx(
+				'rounded-2xl',
+				shouldShowSuggestions && suggestions.length
+					? 'bg-primary border-secondary max-h-96 overflow-x-hidden overflow-y-auto border shadow-lg'
+					: 'overflow-hidden border-0',
+			),
+		},
+		{
+			// When the compact icon-only state is rendered there is no menu element.
+			// We still call getMenuProps to satisfy Downshift without requiring a ref.
+			suppressRefError: !showForm,
+		},
+	)
 
 	return (
 		<div
@@ -518,18 +535,8 @@ function NavSearch({
 								{fetchError}
 							</div>
 						) : null}
-						<ul
-							{...getMenuProps({
-								'aria-label': 'Search suggestions',
-								className: clsx(
-									'rounded-2xl',
-									inputValue.trim().length >= 2 && suggestions.length
-										? 'bg-primary border-secondary max-h-96 overflow-x-hidden overflow-y-auto border shadow-lg'
-										: 'overflow-hidden border-0',
-								),
-							})}
-						>
-							{inputValue.trim().length >= 2 ? (
+						<ul {...menuProps}>
+							{shouldShowSuggestions ? (
 								<>
 									{isMenuOpen &&
 										suggestions.map((s, index) => (

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -329,6 +329,32 @@ function NavSearch({
 	)
 
 	const showForm = isOpen || alwaysExpanded
+	const labelProps = getLabelProps()
+	const searchInputProps = getInputProps(
+		{
+			ref: inputRef,
+			type: 'text',
+			name: 'q',
+			'data-nav-search-input': 'true',
+			autoComplete: 'off',
+			placeholder: 'Semantic search...',
+			className:
+				'text-primary bg-transparent h-14 w-full py-0 pr-14 pl-3 text-lg font-medium focus:outline-none placeholder:text-secondary',
+			onBlur: alwaysExpanded ? undefined : handleBlurReset,
+			onKeyDown: (event: React.KeyboardEvent) => {
+				if (event.key === 'Escape') {
+					event.preventDefault()
+					if (alwaysExpanded) onOpenChange(false)
+					else close()
+				}
+			},
+		},
+		{
+			// The input is absent in compact icon-only mode, but Downshift still expects
+			// getInputProps to be called each render.
+			suppressRefError: !showForm,
+		},
+	)
 	const shouldShowSuggestions = inputValue.trim().length >= 2
 	const menuProps = getMenuProps(
 		{
@@ -372,7 +398,7 @@ function NavSearch({
 				>
 					{alwaysExpanded ? (
 						<div className="bg-primary pointer-events-auto flex min-h-14 w-full overflow-hidden rounded-full shadow-[inset_0_0_0_2px_var(--border-secondary)] transition-shadow focus-within:shadow-[inset_0_0_0_2px_var(--color-team-current)] hover:shadow-[inset_0_0_0_2px_var(--color-team-current)]">
-							<label {...getLabelProps()} className="sr-only">
+							<label {...labelProps} className="sr-only">
 								Search
 							</label>
 							<Link
@@ -396,26 +422,7 @@ function NavSearch({
 								<SearchIcon />
 							</Link>
 							<div className="relative flex min-w-0 flex-1">
-								<input
-									{...getInputProps({
-										ref: inputRef,
-										type: 'text',
-										name: 'q',
-										'data-nav-search-input': 'true',
-										autoComplete: 'off',
-										placeholder: 'Semantic search...',
-										className:
-											'text-primary bg-transparent h-14 w-full py-0 pr-14 pl-3 text-lg font-medium focus:outline-none placeholder:text-secondary',
-										onBlur: alwaysExpanded ? undefined : handleBlurReset,
-										onKeyDown: (event: React.KeyboardEvent) => {
-											if (event.key === 'Escape') {
-												event.preventDefault()
-												if (alwaysExpanded) onOpenChange(false)
-												else close()
-											}
-										},
-									})}
-								/>
+								<input {...searchInputProps} />
 								<div className="pointer-events-auto absolute top-1/2 right-4 z-10 flex h-8 w-8 -translate-y-1/2 items-center justify-center">
 									{fetcher.state !== 'idle' ? (
 										<SpinnerIcon size={18} className="animate-spin" />
@@ -459,7 +466,7 @@ function NavSearch({
 								}
 							}}
 						>
-							<label {...getLabelProps()} className="sr-only">
+							<label {...labelProps} className="sr-only">
 								Search
 							</label>
 							<Link
@@ -482,25 +489,7 @@ function NavSearch({
 								<SearchIcon />
 							</Link>
 							<div className="relative flex min-w-0 flex-1">
-								<input
-									{...getInputProps({
-										ref: inputRef,
-										type: 'text',
-										name: 'q',
-										'data-nav-search-input': 'true',
-										autoComplete: 'off',
-										placeholder: 'Semantic search...',
-										className:
-											'text-primary bg-transparent h-14 w-full py-0 pr-14 pl-3 text-lg font-medium focus:outline-none placeholder:text-secondary',
-										onBlur: handleBlurReset,
-										onKeyDown: (event: React.KeyboardEvent) => {
-											if (event.key === 'Escape') {
-												event.preventDefault()
-												close()
-											}
-										},
-									})}
-								/>
+								<input {...searchInputProps} />
 								<div className="pointer-events-auto absolute top-1/2 right-4 z-10 flex h-8 w-8 -translate-y-1/2 items-center justify-center">
 									{fetcher.state !== 'idle' ? (
 										<SpinnerIcon size={18} className="animate-spin" />


### PR DESCRIPTION
Call Downshift `getInputProps` and `getMenuProps` on every render in `NavSearch` to resolve console warnings.

The `downshift` library issued warnings on the homepage because `getInputProps` and `getMenuProps` were not called when the search form was collapsed. This fix ensures these getter functions are always invoked, using `suppressRefError` when the corresponding elements are not rendered.

---
<p><a href="https://cursor.com/agents?id=bc-dcc1d2c3-3961-4506-ba09-9a0526cc76dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcc1d2c3-3961-4506-ba09-9a0526cc76dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to navbar search UI wiring; main risk is minor regressions in search focus/keyboard handling or suggestion menu rendering.
> 
> **Overview**
> Fixes Downshift console warnings in `NavSearch` by ensuring `getInputProps`, `getMenuProps`, and `getLabelProps` are invoked on every render, even when the compact icon-only search UI is not mounted.
> 
> Refactors the search input/menu prop construction into memoized variables, adds `suppressRefError` when the form/menu elements aren’t rendered, and centralizes the “show suggestions after 2+ chars” condition for consistent dropdown styling/visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 611f438dcc7c6eabc0aebf12e08d14f25daf9340. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized navbar component's internal search functionality handling for improved code maintainability and consistency. No changes to user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->