### PR TITLE
Global navigation hotkeys

### DIFF
--- a/app/components/app-hotkeys.tsx
+++ b/app/components/app-hotkeys.tsx
@@ -4,11 +4,17 @@ import { useLocation, useNavigate } from 'react-router';
 import {
 	HOTKEY_GOTO_ABOUT,
 	HOTKEY_GOTO_BLOG,
+	HOTKEY_GOTO_CALLS,
+	HOTKEY_GOTO_CHATS,
 	HOTKEY_GOTO_COURSES,
 	HOTKEY_GOTO_DISCORD,
 	HOTKEY_GOTO_HOME,
+	HOTKEY_GOTO_KODY,
+	HOTKEY_GOTO_RESUME,
 	HOTKEY_GOTO_SEARCH,
+	HOTKEY_GOTO_TESTIMONY,
 	HOTKEY_GOTO_TALKS,
+	HOTKEY_GOTO_TRANSPARENCY,
 	HOTKEY_GOTO_WORKSHOPS,
 	HOTKEY_TOGGLE_HOTKEYS_DIALOG,
 	HOTKEYS_HELP_GROUPS,
@@ -62,6 +68,24 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
+		HOTKEY_GOTO_CHATS,
+		() => {
+			setDialogOpen(false)
+			navigate('/chats')
+		},
+		navSequenceOptions,
+	)
+
+	useHotkeySequence(
+		HOTKEY_GOTO_CALLS,
+		() => {
+			setDialogOpen(false)
+			navigate('/calls')
+		},
+		navSequenceOptions,
+	)
+
+	useHotkeySequence(
 		HOTKEY_GOTO_COURSES,
 		() => {
 			setDialogOpen(false)
@@ -102,6 +126,42 @@ function AppHotkeys() {
 		() => {
 			setDialogOpen(false)
 			void navigate('/talks')
+		},
+		navSequenceOptions,
+	)
+
+	useHotkeySequence(
+		HOTKEY_GOTO_TESTIMONY,
+		() => {
+			setDialogOpen(false)
+			navigate('/testimony')
+		},
+		navSequenceOptions,
+	)
+
+	useHotkeySequence(
+		HOTKEY_GOTO_TRANSPARENCY,
+		() => {
+			setDialogOpen(false)
+			navigate('/transparency')
+		},
+		navSequenceOptions,
+	)
+
+	useHotkeySequence(
+		HOTKEY_GOTO_RESUME,
+		() => {
+			setDialogOpen(false)
+			navigate('/resume')
+		},
+		navSequenceOptions,
+	)
+
+	useHotkeySequence(
+		HOTKEY_GOTO_KODY,
+		() => {
+			setDialogOpen(false)
+			navigate('/kody')
 		},
 		navSequenceOptions,
 	)

--- a/app/components/app-hotkeys.tsx
+++ b/app/components/app-hotkeys.tsx
@@ -1,24 +1,7 @@
 import { useHotkey, useHotkeySequence } from '@tanstack/react-hotkeys'
 import * as React from 'react'
-import { useLocation, useNavigate } from 'react-router';
-import {
-	HOTKEY_GOTO_ABOUT,
-	HOTKEY_GOTO_BLOG,
-	HOTKEY_GOTO_CALLS,
-	HOTKEY_GOTO_CHATS,
-	HOTKEY_GOTO_COURSES,
-	HOTKEY_GOTO_DISCORD,
-	HOTKEY_GOTO_HOME,
-	HOTKEY_GOTO_KODY,
-	HOTKEY_GOTO_RESUME,
-	HOTKEY_GOTO_SEARCH,
-	HOTKEY_GOTO_TESTIMONY,
-	HOTKEY_GOTO_TALKS,
-	HOTKEY_GOTO_TRANSPARENCY,
-	HOTKEY_GOTO_WORKSHOPS,
-	HOTKEY_TOGGLE_HOTKEYS_DIALOG,
-	HOTKEYS_HELP_GROUPS,
-} from '#app/utils/hotkeys.ts'
+import { useLocation, useNavigate } from 'react-router'
+import * as hk from '#app/utils/hotkeys.ts'
 import { HotkeysHelpDialog } from './hotkeys-help-dialog.tsx'
 
 const navSequenceOptions = {
@@ -39,7 +22,7 @@ function AppHotkeys() {
 	}, [location.pathname])
 
 	useHotkey(
-		HOTKEY_TOGGLE_HOTKEYS_DIALOG,
+		hk.HOTKEY_TOGGLE_HOTKEYS_DIALOG,
 		() => setDialogOpen((o) => !o),
 		{
 			ignoreInputs: true,
@@ -50,7 +33,7 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_HOME,
+		hk.HOTKEY_GOTO_HOME,
 		() => {
 			setDialogOpen(false)
 			void navigate('/')
@@ -59,7 +42,7 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_BLOG,
+		hk.HOTKEY_GOTO_BLOG,
 		() => {
 			setDialogOpen(false)
 			void navigate('/blog')
@@ -68,25 +51,25 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_CHATS,
+		hk.HOTKEY_GOTO_CHATS,
 		() => {
 			setDialogOpen(false)
-			navigate('/chats')
+			void navigate('/chats')
 		},
 		navSequenceOptions,
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_CALLS,
+		hk.HOTKEY_GOTO_CALLS,
 		() => {
 			setDialogOpen(false)
-			navigate('/calls')
+			void navigate('/calls')
 		},
 		navSequenceOptions,
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_COURSES,
+		hk.HOTKEY_GOTO_COURSES,
 		() => {
 			setDialogOpen(false)
 			void navigate('/courses')
@@ -95,7 +78,7 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_DISCORD,
+		hk.HOTKEY_GOTO_DISCORD,
 		() => {
 			setDialogOpen(false)
 			void navigate('/discord')
@@ -104,7 +87,7 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_WORKSHOPS,
+		hk.HOTKEY_GOTO_WORKSHOPS,
 		() => {
 			setDialogOpen(false)
 			void navigate('/workshops')
@@ -113,7 +96,7 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_ABOUT,
+		hk.HOTKEY_GOTO_ABOUT,
 		() => {
 			setDialogOpen(false)
 			void navigate('/about')
@@ -122,7 +105,7 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_TALKS,
+		hk.HOTKEY_GOTO_TALKS,
 		() => {
 			setDialogOpen(false)
 			void navigate('/talks')
@@ -131,43 +114,43 @@ function AppHotkeys() {
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_TESTIMONY,
+		hk.HOTKEY_GOTO_TESTIMONY,
 		() => {
 			setDialogOpen(false)
-			navigate('/testimony')
+			void navigate('/testimony')
 		},
 		navSequenceOptions,
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_TRANSPARENCY,
+		hk.HOTKEY_GOTO_TRANSPARENCY,
 		() => {
 			setDialogOpen(false)
-			navigate('/transparency')
+			void navigate('/transparency')
 		},
 		navSequenceOptions,
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_RESUME,
+		hk.HOTKEY_GOTO_RESUME,
 		() => {
 			setDialogOpen(false)
-			navigate('/resume')
+			void navigate('/resume')
 		},
 		navSequenceOptions,
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_KODY,
+		hk.HOTKEY_GOTO_KODY,
 		() => {
 			setDialogOpen(false)
-			navigate('/kody')
+			void navigate('/kody')
 		},
 		navSequenceOptions,
 	)
 
 	useHotkeySequence(
-		HOTKEY_GOTO_SEARCH,
+		hk.HOTKEY_GOTO_SEARCH,
 		() => {
 			setDialogOpen(false)
 			void navigate('/search')
@@ -179,7 +162,7 @@ function AppHotkeys() {
 		<HotkeysHelpDialog
 			isOpen={dialogOpen}
 			onDismiss={() => setDialogOpen(false)}
-			groups={HOTKEYS_HELP_GROUPS}
+			groups={hk.HOTKEYS_HELP_GROUPS}
 		/>
 	)
 }

--- a/app/components/app-hotkeys.tsx
+++ b/app/components/app-hotkeys.tsx
@@ -1,4 +1,4 @@
-import { useHotkey, useHotkeySequence } from '@tanstack/react-hotkeys'
+import { getSequenceManager, useHotkey } from '@tanstack/react-hotkeys'
 import * as React from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import * as hk from '#app/utils/hotkeys.ts'
@@ -11,10 +11,34 @@ const navSequenceOptions = {
 	timeout: 800,
 }
 
+const NAVIGATION_HOTKEY_ROUTES = [
+	{ sequence: hk.HOTKEY_GOTO_HOME, path: '/' },
+	{ sequence: hk.HOTKEY_GOTO_BLOG, path: '/blog' },
+	{ sequence: hk.HOTKEY_GOTO_CHATS, path: '/chats' },
+	{ sequence: hk.HOTKEY_GOTO_CALLS, path: '/calls' },
+	{ sequence: hk.HOTKEY_GOTO_COURSES, path: '/courses' },
+	{ sequence: hk.HOTKEY_GOTO_DISCORD, path: '/discord' },
+	{ sequence: hk.HOTKEY_GOTO_WORKSHOPS, path: '/workshops' },
+	{ sequence: hk.HOTKEY_GOTO_ABOUT, path: '/about' },
+	{ sequence: hk.HOTKEY_GOTO_TALKS, path: '/talks' },
+	{ sequence: hk.HOTKEY_GOTO_TESTIMONY, path: '/testimony' },
+	{ sequence: hk.HOTKEY_GOTO_TRANSPARENCY, path: '/transparency' },
+	{ sequence: hk.HOTKEY_GOTO_RESUME, path: '/resume' },
+	{ sequence: hk.HOTKEY_GOTO_KODY, path: '/kody' },
+	{ sequence: hk.HOTKEY_GOTO_SEARCH, path: '/search' },
+] as const
+
 function AppHotkeys() {
 	const navigate = useNavigate()
 	const location = useLocation()
 	const [dialogOpen, setDialogOpen] = React.useState(false)
+	const navigateToPath = React.useCallback(
+		(path: string) => {
+			setDialogOpen(false)
+			void navigate(path)
+		},
+		[navigate],
+	)
 
 	// Close the dialog when navigation happens (mouse/touch or hotkeys).
 	React.useEffect(() => {
@@ -32,131 +56,16 @@ function AppHotkeys() {
 		},
 	)
 
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_HOME,
-		() => {
-			setDialogOpen(false)
-			void navigate('/')
-		},
-		navSequenceOptions,
-	)
+	React.useEffect(() => {
+		const sequenceManager = getSequenceManager()
+		const unregisterCallbacks = NAVIGATION_HOTKEY_ROUTES.map(({ sequence, path }) =>
+			sequenceManager.register([...sequence], () => navigateToPath(path), navSequenceOptions),
+		)
 
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_BLOG,
-		() => {
-			setDialogOpen(false)
-			void navigate('/blog')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_CHATS,
-		() => {
-			setDialogOpen(false)
-			void navigate('/chats')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_CALLS,
-		() => {
-			setDialogOpen(false)
-			void navigate('/calls')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_COURSES,
-		() => {
-			setDialogOpen(false)
-			void navigate('/courses')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_DISCORD,
-		() => {
-			setDialogOpen(false)
-			void navigate('/discord')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_WORKSHOPS,
-		() => {
-			setDialogOpen(false)
-			void navigate('/workshops')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_ABOUT,
-		() => {
-			setDialogOpen(false)
-			void navigate('/about')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_TALKS,
-		() => {
-			setDialogOpen(false)
-			void navigate('/talks')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_TESTIMONY,
-		() => {
-			setDialogOpen(false)
-			void navigate('/testimony')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_TRANSPARENCY,
-		() => {
-			setDialogOpen(false)
-			void navigate('/transparency')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_RESUME,
-		() => {
-			setDialogOpen(false)
-			void navigate('/resume')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_KODY,
-		() => {
-			setDialogOpen(false)
-			void navigate('/kody')
-		},
-		navSequenceOptions,
-	)
-
-	useHotkeySequence(
-		hk.HOTKEY_GOTO_SEARCH,
-		() => {
-			setDialogOpen(false)
-			void navigate('/search')
-		},
-		navSequenceOptions,
-	)
+		return () => {
+			for (const unregister of unregisterCallbacks) unregister()
+		}
+	}, [navigateToPath])
 
 	return (
 		<HotkeysHelpDialog

--- a/app/components/hotkeys-help-dialog.tsx
+++ b/app/components/hotkeys-help-dialog.tsx
@@ -114,7 +114,7 @@ function HotkeysHelpDialog({
 			<DialogContent
 				aria-label="Keyboard shortcuts"
 				data-animation-state={animationState}
-				className="hotkeys-help-dialog-content bg-primary text-primary !w-11/12 !max-w-3xl rounded-xl border-2 border-black px-6 py-6 shadow-xl sm:px-8 sm:py-8 dark:border-white dark:!bg-gray-900"
+				className="hotkeys-help-dialog-content bg-primary text-primary !my-[10vh] !flex !h-[80vh] !w-11/12 !max-w-3xl !flex-col overflow-hidden rounded-xl border-2 border-black px-6 py-6 shadow-xl sm:px-8 sm:py-8 dark:border-white dark:!bg-gray-900"
 				style={animationDurationStyle}
 			>
 				<div className="flex items-start justify-between gap-6">
@@ -134,38 +134,47 @@ function HotkeysHelpDialog({
 					</button>
 				</div>
 
-				<div className="mt-8 space-y-8">
-					{groups.map((group) => (
-						<section key={group.title}>
-							<div className="text-secondary mb-3 text-xs font-semibold tracking-widest uppercase">
-								{group.title}
-							</div>
-							<ul className="space-y-4">
-								{group.items.map((item) => (
-									<li
-										key={`${group.title}-${item.description}`}
-										className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
-									>
-										<div className="flex flex-wrap items-center gap-2">
-											{item.combos.map((combo, index) => (
-												<React.Fragment key={index}>
-													{index === 0 ? null : (
-														<span className="text-secondary px-1 text-sm">
-															or
-														</span>
-													)}
-													{renderCombo(combo)}
-												</React.Fragment>
-											))}
-										</div>
-										<div className="text-secondary text-sm sm:text-base">
-											{item.description}
-										</div>
-									</li>
-								))}
-							</ul>
-						</section>
-					))}
+				<div className="mt-8 min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
+					<div className="space-y-8">
+						{groups.map((group) => (
+							<section key={group.title}>
+								<div className="text-secondary mb-3 text-xs font-semibold tracking-widest uppercase">
+									{group.title}
+								</div>
+								<ul className="space-y-4">
+									{group.items.map((item) => (
+										<li
+											key={`${group.title}-${item.description}`}
+											className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+										>
+											<div className="flex flex-wrap items-center gap-2">
+												{item.combos.map((combo, index) => {
+													const comboKey =
+														combo.kind === 'hotkey'
+															? `hotkey:${combo.hotkey}`
+															: `sequence:${combo.keys.join('-')}`
+
+													return (
+														<React.Fragment key={comboKey}>
+															{index === 0 ? null : (
+																<span className="text-secondary px-1 text-sm">
+																	or
+																</span>
+															)}
+															{renderCombo(combo)}
+														</React.Fragment>
+													)
+												})}
+											</div>
+											<div className="text-secondary text-sm sm:text-base">
+												{item.description}
+											</div>
+										</li>
+									))}
+								</ul>
+							</section>
+						))}
+					</div>
 				</div>
 			</DialogContent>
 		</DialogOverlay>

--- a/app/components/hotkeys-help-dialog.tsx
+++ b/app/components/hotkeys-help-dialog.tsx
@@ -134,7 +134,12 @@ function HotkeysHelpDialog({
 					</button>
 				</div>
 
-				<div className="mt-8 min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
+				<div
+					tabIndex={0}
+					role="region"
+					aria-label="Keyboard shortcuts list"
+					className="focus-ring mt-8 min-h-0 flex-1 overflow-y-auto overscroll-contain rounded-md pr-1 focus:outline-none"
+				>
 					<div className="space-y-8">
 						{groups.map((group) => (
 							<section key={group.title}>

--- a/app/components/hotkeys-help-dialog.tsx
+++ b/app/components/hotkeys-help-dialog.tsx
@@ -22,8 +22,8 @@ function renderCombo(combo: HotkeysHelpCombo) {
 	if (combo.kind === 'sequence') {
 		return (
 			<span className="inline-flex flex-wrap items-center gap-1">
-				{combo.keys.map((k) => (
-					<Kbd key={k}>{k}</Kbd>
+				{combo.keys.map((k, i) => (
+					<Kbd key={`${k}-${i}`}>{k}</Kbd>
 				))}
 			</span>
 		)

--- a/app/components/hotkeys-help-dialog.tsx
+++ b/app/components/hotkeys-help-dialog.tsx
@@ -114,7 +114,7 @@ function HotkeysHelpDialog({
 			<DialogContent
 				aria-label="Keyboard shortcuts"
 				data-animation-state={animationState}
-				className="hotkeys-help-dialog-content bg-primary text-primary !my-[10vh] !flex !h-[80vh] !w-11/12 !max-w-3xl !flex-col overflow-hidden rounded-xl border-2 border-black px-6 py-6 shadow-xl sm:px-8 sm:py-8 dark:border-white dark:!bg-gray-900"
+				className="hotkeys-help-dialog-content bg-primary text-primary !my-[10svh] !flex !h-[80svh] !w-11/12 !max-w-3xl !flex-col overflow-hidden rounded-xl border-2 border-black px-6 py-6 shadow-xl sm:px-8 sm:py-8 dark:border-white dark:!bg-gray-900"
 				style={animationDurationStyle}
 			>
 				<div className="flex items-start justify-between gap-6">

--- a/app/utils/__tests__/hotkeys.test.ts
+++ b/app/utils/__tests__/hotkeys.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { assert, describe, expect, test } from 'vitest'
 import {
 	HOTKEY_GOTO_CALLS,
 	HOTKEY_GOTO_CHATS,
@@ -25,10 +25,10 @@ describe('hotkeys navigation mappings', () => {
 		const navigationGroup = HOTKEYS_HELP_GROUPS.find(
 			(group) => group.title === 'Navigation',
 		)
-		expect(navigationGroup).toBeDefined()
+		assert(navigationGroup, 'Expected Navigation hotkeys group to exist')
 
 		const itemByDescription = new Map(
-			navigationGroup!.items.map((item) => [item.description, item]),
+			navigationGroup.items.map((item) => [item.description, item]),
 		)
 
 		expect(itemByDescription.get('Go to Chats with Kent podcast')).toMatchObject({

--- a/app/utils/__tests__/hotkeys.test.ts
+++ b/app/utils/__tests__/hotkeys.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest'
+import {
+	HOTKEY_GOTO_CALLS,
+	HOTKEY_GOTO_CHATS,
+	HOTKEY_GOTO_COURSES,
+	HOTKEY_GOTO_KODY,
+	HOTKEY_GOTO_RESUME,
+	HOTKEY_GOTO_TESTIMONY,
+	HOTKEY_GOTO_TRANSPARENCY,
+	HOTKEYS_HELP_GROUPS,
+} from '../hotkeys.ts'
+
+describe('hotkeys navigation mappings', () => {
+	test('matches the expected key sequences', () => {
+		expect(HOTKEY_GOTO_CHATS).toEqual(['G', 'C'])
+		expect(HOTKEY_GOTO_CALLS).toEqual(['G', 'P'])
+		expect(HOTKEY_GOTO_COURSES).toEqual(['G', 'U'])
+		expect(HOTKEY_GOTO_TESTIMONY).toEqual(['G', 'F'])
+		expect(HOTKEY_GOTO_TRANSPARENCY).toEqual(['G', 'M'])
+		expect(HOTKEY_GOTO_RESUME).toEqual(['G', 'R'])
+		expect(HOTKEY_GOTO_KODY).toEqual(['G', 'K'])
+	})
+
+	test('shows the new bindings in keyboard shortcuts help', () => {
+		const navigationGroup = HOTKEYS_HELP_GROUPS.find(
+			(group) => group.title === 'Navigation',
+		)
+		expect(navigationGroup).toBeDefined()
+
+		const itemByDescription = new Map(
+			navigationGroup!.items.map((item) => [item.description, item]),
+		)
+
+		expect(itemByDescription.get('Go to Chats with Kent podcast')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'c'] }],
+		})
+		expect(itemByDescription.get('Go to Call Kent podcast')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'p'] }],
+		})
+		expect(itemByDescription.get('Go to courses')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'u'] }],
+		})
+		expect(itemByDescription.get('Go to testimony')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'f'] }],
+		})
+		expect(itemByDescription.get('Go to transparency')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'm'] }],
+		})
+		expect(itemByDescription.get('Go to resume')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'r'] }],
+		})
+		expect(itemByDescription.get('Go to kody')).toMatchObject({
+			combos: [{ kind: 'sequence', keys: ['g', 'k'] }],
+		})
+	})
+})

--- a/app/utils/__tests__/hotkeys.test.ts
+++ b/app/utils/__tests__/hotkeys.test.ts
@@ -49,7 +49,7 @@ describe('hotkeys navigation mappings', () => {
 		expect(itemByDescription.get('Go to resume')).toMatchObject({
 			combos: [{ kind: 'sequence', keys: ['g', 'r'] }],
 		})
-		expect(itemByDescription.get('Go to kody')).toMatchObject({
+		expect(itemByDescription.get('Go to Kody')).toMatchObject({
 			combos: [{ kind: 'sequence', keys: ['g', 'k'] }],
 		})
 	})

--- a/app/utils/hotkeys.ts
+++ b/app/utils/hotkeys.ts
@@ -15,11 +15,17 @@ export const HOTKEY_OPEN_SEARCH = {
 
 export const HOTKEY_GOTO_HOME = ['G', 'H'] as const satisfies HotkeySequence
 export const HOTKEY_GOTO_BLOG = ['G', 'B'] as const satisfies HotkeySequence
-export const HOTKEY_GOTO_COURSES = ['G', 'C'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_CHATS = ['G', 'C'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_CALLS = ['G', 'P'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_COURSES = ['G', 'U'] as const satisfies HotkeySequence
 export const HOTKEY_GOTO_DISCORD = ['G', 'D'] as const satisfies HotkeySequence
 export const HOTKEY_GOTO_WORKSHOPS = ['G', 'W'] as const satisfies HotkeySequence
 export const HOTKEY_GOTO_ABOUT = ['G', 'A'] as const satisfies HotkeySequence
 export const HOTKEY_GOTO_TALKS = ['G', 'T'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_TESTIMONY = ['G', 'F'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_TRANSPARENCY = ['G', 'M'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_RESUME = ['G', 'R'] as const satisfies HotkeySequence
+export const HOTKEY_GOTO_KODY = ['G', 'K'] as const satisfies HotkeySequence
 export const HOTKEY_GOTO_SEARCH = ['G', 'S'] as const satisfies HotkeySequence
 
 export type HotkeysHelpCombo =
@@ -78,6 +84,14 @@ export const HOTKEYS_HELP_GROUPS = [
 				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_BLOG) }],
 			},
 			{
+				description: 'Go to Chats with Kent podcast',
+				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_CHATS) }],
+			},
+			{
+				description: 'Go to Call Kent podcast',
+				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_CALLS) }],
+			},
+			{
 				description: 'Go to courses',
 				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_COURSES) }],
 			},
@@ -96,6 +110,24 @@ export const HOTKEYS_HELP_GROUPS = [
 			{
 				description: 'Go to talks',
 				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_TALKS) }],
+			},
+			{
+				description: 'Go to testimony',
+				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_TESTIMONY) }],
+			},
+			{
+				description: 'Go to transparency',
+				combos: [
+					{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_TRANSPARENCY) },
+				],
+			},
+			{
+				description: 'Go to resume',
+				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_RESUME) }],
+			},
+			{
+				description: 'Go to kody',
+				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_KODY) }],
 			},
 			{
 				description: 'Go to search page',

--- a/app/utils/hotkeys.ts
+++ b/app/utils/hotkeys.ts
@@ -126,7 +126,7 @@ export const HOTKEYS_HELP_GROUPS = [
 				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_RESUME) }],
 			},
 			{
-				description: 'Go to kody',
+				description: 'Go to Kody',
 				combos: [{ kind: 'sequence', keys: getSequenceDisplayKeys(HOTKEY_GOTO_KODY) }],
 			},
 			{


### PR DESCRIPTION
Adds global navigation hotkeys for chats, call kent podcasts, testimony, transparency, resume, and kody, and remaps courses to `g u`.

---
<p><a href="https://cursor.com/agents?id=bc-b54cf528-ec62-4e9d-8d2e-57b4e172cb1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b54cf528-ec62-4e9d-8d2e-57b4e172cb1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes global keyboard shortcut registration and key mappings, which can impact navigation behavior across the app; coverage is improved with new unit tests.
> 
> **Overview**
> Adds new global navigation hotkey sequences for Chats, Calls, Testimony, Transparency, Resume, and Kody, and remaps Courses from `g c` to `g u` (with corresponding updates to `HOTKEYS_HELP_GROUPS`).
> 
> Refactors `AppHotkeys` to register navigation sequences via `getSequenceManager()` using a single `NAVIGATION_HOTKEY_ROUTES` mapping (instead of multiple `useHotkeySequence` calls), and updates the hotkeys help dialog to be scrollable/flex-height with more stable React keys for combo rendering.
> 
> Adds a Vitest suite (`app/utils/__tests__/hotkeys.test.ts`) asserting the new sequence constants and that the help dialog’s Navigation group includes the expected bindings/descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dd009cdab685c7a4c3beadf3bd85e49974407d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for Chats, Calls, Testimony, Transparency, Resume, and Kody; updated the Courses shortcut.

* **Style**
  * Redesigned the keyboard shortcuts help dialog with a scrollable, flexible layout, improved focus behavior, and more stable shortcut rendering for smoother browsing.

* **Tests**
  * Added unit tests validating navigation shortcuts and ensuring the help dialog shows correct shortcut combos and descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->