### PR TITLE
JSX page content indexing

### DIFF
--- a/.github/workflows/index-semantic-content.yml
+++ b/.github/workflows/index-semantic-content.yml
@@ -8,6 +8,12 @@ on:
       - 'content/blog/**'
       - 'content/pages/**'
       - 'content/data/**'
+      - 'app/routes/**'
+      - 'app/components/**'
+      - 'app/root.tsx'
+      - 'app/other-routes.server.ts'
+      - 'app/utils/sitemap.server.ts'
+      - 'other/semantic-search/**'
 
 jobs:
   index:

--- a/other/semantic-search/__tests__/chunk-utils.test.ts
+++ b/other/semantic-search/__tests__/chunk-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
 	chunkText,
 	chunkTextRaw,
+	mapWithConcurrency,
 	normalizeText,
 	sha256,
 } from '../chunk-utils.ts'
@@ -26,6 +27,15 @@ describe('semantic-search chunk utils', () => {
 	test('sha256 is stable', () => {
 		expect(sha256('abc')).toBe(sha256('abc'))
 		expect(sha256('abc')).not.toBe(sha256('abcd'))
+	})
+
+	test('mapWithConcurrency rejects when mapper throws undefined', async () => {
+		await expect(
+			mapWithConcurrency([1, 2, 3], 1, async (item) => {
+				if (item === 2) throw undefined
+				return item
+			}),
+		).rejects.toBeUndefined()
 	})
 
 	test('chunkTextRaw does not split surrogate pairs', () => {

--- a/other/semantic-search/__tests__/jsx-page-content.test.ts
+++ b/other/semantic-search/__tests__/jsx-page-content.test.ts
@@ -102,6 +102,32 @@ describe('jsx page content utils', () => {
 		expect(extracted.text).not.toContain('window.foo')
 	})
 
+	test('extractRenderedPageContent keeps block sections newline separated', () => {
+		const html = `
+      <html>
+        <head><title>Courses</title></head>
+        <body>
+          <main>
+            <h1>Level up as a developer.</h1>
+            <h2>Invest in yourself with a premium dev course.</h2>
+            <h3>Reasons to invest in yourself</h3>
+            <h4>Become a more confident developer</h4>
+          </main>
+        </body>
+      </html>
+    `
+
+		const extracted = extractRenderedPageContent(html)
+		expect(extracted.text).toContain(
+			[
+				'Level up as a developer.',
+				'Invest in yourself with a premium dev course.',
+				'Reasons to invest in yourself',
+				'Become a more confident developer',
+			].join('\n'),
+		)
+	})
+
 	test('extractRenderedPageContent excludes aria-hidden content', () => {
 		const html = `
       <html>

--- a/other/semantic-search/__tests__/jsx-page-content.test.ts
+++ b/other/semantic-search/__tests__/jsx-page-content.test.ts
@@ -40,7 +40,13 @@ describe('jsx page content utils', () => {
 			shouldIndexJsxSitemapPath({ pathname: '/calls/season-1', mdxRoutes }),
 		).toBe(false)
 		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/chats/episode-1', mdxRoutes }),
+		).toBe(false)
+		expect(
 			shouldIndexJsxSitemapPath({ pathname: '/sitemap.xml', mdxRoutes }),
+		).toBe(false)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/feed.json', mdxRoutes }),
 		).toBe(false)
 	})
 
@@ -84,5 +90,27 @@ describe('jsx page content utils', () => {
 		expect(extracted.text).not.toContain('Home Blog Search')
 		expect(extracted.text).not.toContain('Footer links and legal')
 		expect(extracted.text).not.toContain('window.foo')
+	})
+
+	test('extractRenderedPageContent excludes aria-hidden content', () => {
+		const html = `
+      <html>
+        <head><title>Hidden bits</title></head>
+        <body>
+          <main>
+            <h1>Visible heading</h1>
+            <p aria-hidden="true">This text should be excluded</p>
+            <p aria-hidden="TRUE">Also excluded text</p>
+            <p>This should remain visible.</p>
+          </main>
+        </body>
+      </html>
+    `
+
+		const extracted = extractRenderedPageContent(html)
+		expect(extracted.text).toContain('Visible heading')
+		expect(extracted.text).toContain('This should remain visible.')
+		expect(extracted.text).not.toContain('This text should be excluded')
+		expect(extracted.text).not.toContain('Also excluded text')
 	})
 })

--- a/other/semantic-search/__tests__/jsx-page-content.test.ts
+++ b/other/semantic-search/__tests__/jsx-page-content.test.ts
@@ -33,6 +33,10 @@ describe('jsx page content utils', () => {
 		expect(
 			shouldIndexJsxSitemapPath({ pathname: '/about', mdxRoutes }),
 		).toBe(true)
+		// SKIPPED_PREFIX_ROUTES uses '/blog/' so bare '/blog' remains indexable.
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/blog', mdxRoutes }),
+		).toBe(true)
 		expect(
 			shouldIndexJsxSitemapPath({ pathname: '/uses', mdxRoutes }),
 		).toBe(false)
@@ -158,7 +162,9 @@ describe('jsx page content utils', () => {
 		}
 	})
 
-	test('loadJsxPageItemsFromRunningSite follows one same-origin redirect', async () => {
+	test(
+		'loadJsxPageItemsFromRunningSite follows one same-origin redirect',
+		async () => {
 		const server = http.createServer((req, res) => {
 			const host = req.headers.host ?? '127.0.0.1'
 			if (req.url === '/sitemap.xml') {
@@ -209,5 +215,7 @@ describe('jsx page content utils', () => {
 		} finally {
 			await new Promise<void>((resolve) => server.close(() => resolve()))
 		}
-	})
+		},
+		10_000,
+	)
 })

--- a/other/semantic-search/__tests__/jsx-page-content.test.ts
+++ b/other/semantic-search/__tests__/jsx-page-content.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'vitest'
+import {
+	JSX_HOME_SLUG,
+	extractRenderedPageContent,
+	getJsxPagePathFromSlug,
+	getJsxPageSlugFromPath,
+	parseSitemapPathnames,
+	shouldIndexJsxSitemapPath,
+} from '../jsx-page-content.ts'
+
+describe('jsx page content utils', () => {
+	test('parseSitemapPathnames extracts and normalizes loc entries', () => {
+		const xml = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset>
+        <url><loc>https://kentcdodds.com/about</loc></url>
+        <url><loc>https://kentcdodds.com/about/</loc></url>
+        <url><loc>https://kentcdodds.com/blog?source=sitemap</loc></url>
+        <url><loc>/search</loc></url>
+      </urlset>
+    `
+		expect(parseSitemapPathnames(xml)).toEqual(['/about', '/blog', '/search'])
+	})
+
+	test('shouldIndexJsxSitemapPath excludes non-jsx and already-indexed routes', () => {
+		const mdxRoutes = new Set(['/uses', '/appearances'])
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/about', mdxRoutes }),
+		).toBe(true)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/uses', mdxRoutes }),
+		).toBe(false)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/blog/test-post', mdxRoutes }),
+		).toBe(false)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/talks/react', mdxRoutes }),
+		).toBe(false)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/calls/season-1', mdxRoutes }),
+		).toBe(false)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/sitemap.xml', mdxRoutes }),
+		).toBe(false)
+	})
+
+	test('getJsxPageSlugFromPath and getJsxPagePathFromSlug are reversible', () => {
+		expect(getJsxPageSlugFromPath('/')).toBe(JSX_HOME_SLUG)
+		expect(getJsxPagePathFromSlug(JSX_HOME_SLUG)).toBe('/')
+		expect(getJsxPageSlugFromPath('/workshops')).toBe('workshops')
+		expect(getJsxPagePathFromSlug('workshops')).toBe('/workshops')
+	})
+
+	test('extractRenderedPageContent removes nav/footer/script noise', () => {
+		const html = `
+      <html>
+        <head>
+          <title>About Kent</title>
+          <script>window.foo = "bar"</script>
+        </head>
+        <body>
+          <nav>
+            Home Blog Search
+          </nav>
+          <section>
+            <h1>About Kent</h1>
+            <p>Kent writes and teaches about quality software.</p>
+          </section>
+          <main>
+            <h2>Main content</h2>
+            <p>This should stay in the extracted page content.</p>
+          </main>
+          <footer>
+            Footer links and legal.
+          </footer>
+        </body>
+      </html>
+    `
+
+		const extracted = extractRenderedPageContent(html)
+		expect(extracted.title).toBe('About Kent')
+		expect(extracted.text).toContain('About Kent')
+		expect(extracted.text).toContain('Main content')
+		expect(extracted.text).not.toContain('Home Blog Search')
+		expect(extracted.text).not.toContain('Footer links and legal')
+		expect(extracted.text).not.toContain('window.foo')
+	})
+})

--- a/other/semantic-search/index-repo-content.ts
+++ b/other/semantic-search/index-repo-content.ts
@@ -508,6 +508,7 @@ async function getDocsFromChangedPaths({
 		(p) =>
 			p.startsWith('app/') ||
 			p.startsWith('content/data/') ||
+			p.startsWith('content/pages/') ||
 			p.startsWith('other/semantic-search/'),
 	)
 
@@ -800,23 +801,17 @@ async function main() {
 
 		// Index raw MDX for MDX-backed docs, and cleaned rendered text for JSX pages.
 		const chunkBodies =
-			type === 'blog' || type === 'page'
-				? chunkTextRaw(source, {
+			type === 'jsx-page'
+				? chunkText(source, {
+						targetChars: 3500,
+						overlapChars: 450,
+						maxChunkChars: 5000,
+					})
+				: chunkTextRaw(source, {
 						targetChars: 2500,
 						overlapChars: 250,
 						maxChunkChars: 3500,
 					})
-				: type === 'jsx-page'
-					? chunkText(source, {
-							targetChars: 3500,
-							overlapChars: 450,
-							maxChunkChars: 5000,
-						})
-					: chunkTextRaw(source, {
-							targetChars: 2500,
-							overlapChars: 250,
-							maxChunkChars: 3500,
-						})
 		const chunkCount = chunkBodies.length
 
 		const chunks: ManifestChunk[] = []

--- a/other/semantic-search/index-repo-content.ts
+++ b/other/semantic-search/index-repo-content.ts
@@ -504,13 +504,7 @@ async function getDocsFromChangedPaths({
 	const allChanged = [...addedOrModified, ...deleted].map((p) =>
 		p.replace(/\\/g, '/'),
 	)
-	const jsxPagesChanged = allChanged.some(
-		(p) =>
-			p.startsWith('app/') ||
-			p.startsWith('content/data/') ||
-			p.startsWith('content/pages/') ||
-			p.startsWith('other/semantic-search/'),
-	)
+	const jsxPagesChanged = allChanged.some((p) => p.startsWith('app/'))
 
 	const talksFile = 'content/data/talks.yml'
 	const resumeFile = 'content/data/resume.yml'

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -1,0 +1,339 @@
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { toString as hastToString } from 'hast-util-to-string'
+import getPort, { portNumbers } from 'get-port'
+import rehypeParse from 'rehype-parse'
+import { unified } from 'unified'
+import { normalizeText } from './chunk-utils.ts'
+
+export const JSX_HOME_SLUG = '__home__'
+
+const SKIPPED_TAG_NAMES = new Set([
+	'nav',
+	'footer',
+	'script',
+	'style',
+	'noscript',
+	'svg',
+	'template',
+	'iframe',
+])
+
+const SKIPPED_CLASS_NAMES = new Set([
+	'sr-only',
+	'visually-hidden',
+	'skip-link',
+	'notification-message',
+])
+
+const SKIPPED_ROLES = new Set(['dialog', 'alert', 'status', 'navigation'])
+const SKIPPED_STATIC_ROUTES = new Set([
+	'/credits',
+	'/resume',
+	'/sitemap.xml',
+	'/testimonials',
+])
+const SKIPPED_PREFIX_ROUTES = ['/blog/', '/calls/', '/chats/', '/talks/']
+const NON_HTML_EXTENSION_PATTERN = /\.[a-z0-9]+$/i
+
+export type JsxPageIndexItem = {
+	slug: string
+	title: string
+	url: string
+	source: string
+}
+
+function getClassList(value: unknown) {
+	if (Array.isArray(value)) {
+		return value.flatMap((v) =>
+			typeof v === 'string' ? v.split(/\s+/).filter(Boolean) : [],
+		)
+	}
+	if (typeof value === 'string') return value.split(/\s+/).filter(Boolean)
+	return []
+}
+
+function hasSkippedClass(value: unknown) {
+	const classList = getClassList(value)
+	return classList.some((className) => SKIPPED_CLASS_NAMES.has(className))
+}
+
+function shouldSkipElement(node: any) {
+	if (!node || node.type !== 'element') return false
+	const tagName = String(node.tagName ?? '').toLowerCase()
+	if (SKIPPED_TAG_NAMES.has(tagName)) return true
+
+	const properties = (node.properties ?? {}) as Record<string, unknown>
+	const role = String(properties.role ?? '').toLowerCase()
+	if (role && SKIPPED_ROLES.has(role)) return true
+	if (properties.hidden === true) return true
+	if (String(properties['aria-hidden'] ?? '').toLowerCase() === 'true') return true
+	if (hasSkippedClass(properties.className)) return true
+
+	return false
+}
+
+function pruneNode(node: any): any | null {
+	if (!node || typeof node !== 'object') return node
+	if (shouldSkipElement(node)) return null
+
+	const children = Array.isArray(node.children)
+		? node.children
+				.map((child: any) => pruneNode(child))
+				.filter((child: any) => child != null)
+		: undefined
+
+	if (!children) return node
+	return { ...node, children }
+}
+
+function findFirstElementByTagName(node: any, tagName: string): any | null {
+	if (!node || typeof node !== 'object') return null
+	if (node.type === 'element' && String(node.tagName ?? '').toLowerCase() === tagName)
+		return node
+	if (!Array.isArray(node.children)) return null
+	for (const child of node.children) {
+		const found = findFirstElementByTagName(child, tagName)
+		if (found) return found
+	}
+	return null
+}
+
+export function normalizePathname(pathname: string) {
+	const withoutQueryOrFragment = pathname.split(/[?#]/)[0] ?? ''
+	if (!withoutQueryOrFragment.trim()) return '/'
+	if (withoutQueryOrFragment === '/') return '/'
+	return withoutQueryOrFragment.replace(/\/+$/, '') || '/'
+}
+
+export function parseSitemapPathnames(sitemapXml: string) {
+	const pathnames: string[] = []
+	const seen = new Set<string>()
+	for (const match of sitemapXml.matchAll(/<loc>(?<loc>[^<]+)<\/loc>/g)) {
+		const rawLoc = (match.groups?.loc ?? '').trim()
+		if (!rawLoc) continue
+		const decodedLoc = rawLoc.replace(/&amp;/g, '&')
+		let pathname = decodedLoc
+		try {
+			pathname = new URL(decodedLoc).pathname
+		} catch {
+			// ignore invalid sitemap entries
+		}
+		const normalizedPathname = normalizePathname(pathname)
+		if (seen.has(normalizedPathname)) continue
+		seen.add(normalizedPathname)
+		pathnames.push(normalizedPathname)
+	}
+	return pathnames
+}
+
+export async function getMdxPageRoutes(repoRoot = process.cwd()) {
+	const pagesDir = path.join(repoRoot, 'content', 'pages')
+	const files = await fs.readdir(pagesDir).catch(() => [])
+	const routes = new Set<string>()
+	for (const file of files) {
+		if (!file.endsWith('.mdx')) continue
+		routes.add(`/${file.replace(/\.mdx$/, '')}`)
+	}
+	return routes
+}
+
+export function shouldIndexJsxSitemapPath({
+	pathname,
+	mdxRoutes,
+}: {
+	pathname: string
+	mdxRoutes: ReadonlySet<string>
+}) {
+	const normalizedPathname = normalizePathname(pathname)
+	if (!normalizedPathname.startsWith('/')) return false
+	if (NON_HTML_EXTENSION_PATTERN.test(normalizedPathname)) return false
+	if (mdxRoutes.has(normalizedPathname)) return false
+	if (SKIPPED_STATIC_ROUTES.has(normalizedPathname)) return false
+	if (
+		SKIPPED_PREFIX_ROUTES.some((prefix) => normalizedPathname.startsWith(prefix))
+	) {
+		return false
+	}
+	return true
+}
+
+export function getJsxPageSlugFromPath(pathname: string) {
+	const normalizedPathname = normalizePathname(pathname)
+	if (normalizedPathname === '/') return JSX_HOME_SLUG
+	return normalizedPathname.slice(1)
+}
+
+export function getJsxPagePathFromSlug(slug: string) {
+	if (slug === JSX_HOME_SLUG) return '/'
+	return `/${slug.replace(/^\/+/, '')}`
+}
+
+export function extractRenderedPageContent(html: string) {
+	const tree = unified().use(rehypeParse).parse(html)
+	const titleNode = findFirstElementByTagName(tree, 'title')
+	const title = normalizeText(titleNode ? hastToString(titleNode) : '')
+
+	const pruned = pruneNode(tree)
+	const bodyNode = findFirstElementByTagName(pruned, 'body')
+	const text = normalizeText(hastToString(bodyNode ?? pruned))
+
+	return { title, text }
+}
+
+type RunningDevServer = {
+	origin: string
+	close: () => Promise<void>
+}
+
+async function waitForSitemap({
+	origin,
+	logs,
+	timeoutMs,
+}: {
+	origin: string
+	logs: () => string
+	timeoutMs: number
+}) {
+	const start = Date.now()
+	while (Date.now() - start < timeoutMs) {
+		try {
+			const res = await fetch(`${origin}/sitemap.xml`, {
+				headers: { Accept: 'application/xml' },
+			})
+			if (res.ok) return
+		} catch {
+			// still starting
+		}
+		await sleep(750)
+	}
+	throw new Error(
+		`Timed out waiting for local dev server at ${origin}. Recent logs:\n${logs()}`,
+	)
+}
+
+export async function startLocalDevServerForSitemap({
+	startupTimeoutMs = 180_000,
+}: {
+	startupTimeoutMs?: number
+} = {}): Promise<RunningDevServer> {
+	const port = await getPort({ port: portNumbers(3200, 3999) })
+	const origin = `http://127.0.0.1:${port}`
+	const child = spawn('npm', ['run', 'dev'], {
+		cwd: process.cwd(),
+		env: {
+			...process.env,
+			PORT: String(port),
+			MOCKS: process.env.MOCKS ?? 'true',
+			STARTUP_SHORTCUTS: 'false',
+			FORCE_COLOR: '0',
+		},
+		stdio: ['ignore', 'pipe', 'pipe'],
+	})
+
+	let outputLog = ''
+	const appendOutput = (chunk: Buffer | string) => {
+		outputLog += chunk.toString()
+		if (outputLog.length > 200_000) {
+			outputLog = outputLog.slice(-200_000)
+		}
+	}
+	child.stdout?.on('data', appendOutput)
+	child.stderr?.on('data', appendOutput)
+
+	let settled = false
+	const close = async () => {
+		if (settled) return
+		settled = true
+		if (child.exitCode != null) return
+		child.kill('SIGTERM')
+		const deadline = Date.now() + 10_000
+		while (child.exitCode == null && Date.now() < deadline) {
+			await sleep(100)
+		}
+		if (child.exitCode == null) {
+			child.kill('SIGKILL')
+		}
+	}
+
+	try {
+		await waitForSitemap({
+			origin,
+			logs: () => outputLog,
+			timeoutMs: startupTimeoutMs,
+		})
+		return { origin, close }
+	} catch (error) {
+		await close()
+		throw error
+	}
+}
+
+async function fetchHtml(pathname: string, origin: string) {
+	const res = await fetch(`${origin}${pathname}`, {
+		redirect: 'manual',
+		headers: { Accept: 'text/html,application/xhtml+xml' },
+	})
+	if (res.status >= 300 && res.status < 400) return null
+	if (!res.ok) return null
+	const contentType = res.headers.get('content-type') ?? ''
+	if (!contentType.includes('text/html')) return null
+	return await res.text()
+}
+
+export async function loadJsxPageItemsFromRunningSite({
+	origin,
+	mdxRoutes,
+	minimumTextLength = 80,
+}: {
+	origin: string
+	mdxRoutes: ReadonlySet<string>
+	minimumTextLength?: number
+}) {
+	const sitemapRes = await fetch(`${origin}/sitemap.xml`, {
+		headers: { Accept: 'application/xml' },
+	})
+	if (!sitemapRes.ok) {
+		throw new Error(
+			`Failed to fetch sitemap.xml from ${origin}: ${sitemapRes.status}`,
+		)
+	}
+
+	const sitemapXml = await sitemapRes.text()
+	const allPathnames = parseSitemapPathnames(sitemapXml)
+	const pathnamesToIndex = allPathnames.filter((pathname) =>
+		shouldIndexJsxSitemapPath({ pathname, mdxRoutes }),
+	)
+
+	const items: JsxPageIndexItem[] = []
+	for (const pathname of pathnamesToIndex) {
+		const html = await fetchHtml(pathname, origin)
+		if (!html) continue
+		const { title, text } = extractRenderedPageContent(html)
+		if (text.length < minimumTextLength) continue
+		const slug = getJsxPageSlugFromPath(pathname)
+		items.push({
+			slug,
+			url: pathname,
+			title: title || (pathname === '/' ? 'Home' : pathname),
+			source: text,
+		})
+	}
+
+	return items
+}
+
+export async function loadJsxPageItemsFromLocalApp() {
+	const mdxRoutes = await getMdxPageRoutes()
+	const server = await startLocalDevServerForSitemap()
+	try {
+		return await loadJsxPageItemsFromRunningSite({
+			origin: server.origin,
+			mdxRoutes,
+		})
+	} finally {
+		await server.close()
+	}
+}

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -270,7 +270,10 @@ export function extractRenderedPageContent(html: string) {
 
 	const pruned = pruneNode(tree)
 	const bodyNode = findFirstElementByTagName(pruned, 'body')
-	const text = normalizeText(extractReadableText(bodyNode ?? pruned))
+	const text = normalizeText(extractReadableText(bodyNode ?? pruned)).replace(
+		/\n{2,}/g,
+		'\n',
+	)
 
 	return { title, text }
 }

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -69,9 +69,15 @@ function shouldSkipElement(node: any) {
 
 	const properties = (node.properties ?? {}) as Record<string, unknown>
 	const role = String(properties.role ?? '').toLowerCase()
+	const ariaHidden = properties.ariaHidden
 	if (role && SKIPPED_ROLES.has(role)) return true
 	if (properties.hidden === true) return true
-	if (String(properties['aria-hidden'] ?? '').toLowerCase() === 'true') return true
+	if (
+		ariaHidden === true ||
+		String(ariaHidden ?? '').toLowerCase() === 'true'
+	) {
+		return true
+	}
 	if (hasSkippedClass(properties.className)) return true
 
 	return false
@@ -219,6 +225,7 @@ async function requestTextDocument({
 				res.on('data', (chunk) => {
 					chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
 				})
+				res.on('error', reject)
 				res.on('end', () => {
 					resolve({
 						statusCode: res.statusCode ?? 0,
@@ -352,7 +359,6 @@ async function fetchHtml(pathname: string, origin: string) {
 		url: `${origin}${pathname}`,
 		accept: 'text/html,application/xhtml+xml',
 	})
-	if (res.statusCode >= 300 && res.statusCode < 400) return null
 	if (res.statusCode < 200 || res.statusCode >= 300) return null
 	const contentType = String(res.headers['content-type'] ?? '')
 	if (!contentType.includes('text/html')) return null

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -119,7 +119,9 @@ function extractReadableText(node: any): string {
 	}
 
 	const children = Array.isArray(node.children) ? node.children : []
-	const childText = children.map((child) => extractReadableText(child)).join('')
+	const childText = children
+		.map((child: unknown) => extractReadableText(child))
+		.join('')
 	if (!childText) return ''
 
 	if (node.type !== 'element') return childText

--- a/other/semantic-search/readme.md
+++ b/other/semantic-search/readme.md
@@ -45,6 +45,8 @@ Indexed sources (via `index-repo-content.ts`):
 
 - `content/blog/**` (blog posts)
 - `content/pages/**` (MDX pages)
+- Rendered JSX pages discovered from `/sitemap.xml` (excluding MDX-backed pages
+  and docs handled by podcast/YAML indexers)
 - `content/data/talks.yml` (each talk is indexed as its own doc)
 - `content/data/resume.yml` (resume page)
 - `content/data/credits.yml` (each person is indexed as its own doc)


### PR DESCRIPTION
Add indexing for non-MDX JSX pages to ensure all relevant content is discoverable via semantic search.

---
<p><a href="https://cursor.com/agents?id=bc-6bcda597-6427-4b1a-bcfe-662b04b918d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bcda597-6427-4b1a-bcfe-662b04b918d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new indexing path that spins up a local dev server and fetches sitemap/HTML, which can increase CI/runtime flakiness and affect search index contents; changes are scoped to the semantic-search tooling.
> 
> **Overview**
> Adds **semantic search indexing for non-MDX JSX routes** by discovering indexable paths from `/sitemap.xml`, fetching rendered HTML, extracting readable text (skipping nav/footer/scripts/hidden content), and storing them as a new `jsx-page` doc type in `index-repo-content.ts`.
> 
> Refactors shared concurrency mapping into `chunk-utils.ts` (with improved error propagation), updates indexing behavior/metadata (including different chunking strategy for JSX pages), and expands the GitHub Action path filters so app/semantic-search changes trigger reindexing. Includes new/updated Vitest coverage and updates the semantic-search README to document JSX page indexing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac527fcf8b401a471e73a963f83090fbc4c876c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rendered JSX pages discovered from sitemap are now included as first‑class searchable documents with improved text chunking/embedding for better relevance.

* **Tests**
  * Added tests for sitemap parsing, path↔slug conversions, indexing filters, and rendered content extraction.

* **Documentation**
  * Documented rendered JSX pages as a new indexed source.

* **Chores**
  * CI watch list expanded to site routes, components, root, and semantic‑search areas to trigger reindexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->