### PR TITLE
Deployment workflow error

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -216,16 +216,17 @@ jobs:
       - name: 🚀 Deploy Staging
         if: ${{ github.ref == 'refs/heads/dev' }}
         run:
-          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{
-          github.sha }} --app ${{ steps.app_name.outputs.value }}-staging
+          bash ./other/flyctl-deploy-with-retry.sh --depot --remote-only
+          --build-arg COMMIT_SHA=${{ github.sha }} --app ${{
+          steps.app_name.outputs.value }}-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
         run:
-          flyctl deploy --depot --remote-only --build-arg COMMIT_SHA=${{
-          github.sha }} --build-secret SENTRY_AUTH_TOKEN=${{
-          secrets.SENTRY_AUTH_TOKEN }}
+          bash ./other/flyctl-deploy-with-retry.sh --depot --remote-only
+          --build-arg COMMIT_SHA=${{ github.sha }} --build-secret
+          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/other/flyctl-deploy-with-retry.sh
+++ b/other/flyctl-deploy-with-retry.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+max_attempts="${FLY_DEPLOY_MAX_ATTEMPTS:-3}"
+base_backoff_seconds="${FLY_DEPLOY_BASE_BACKOFF_SECONDS:-8}"
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <flyctl deploy args...>" >&2
+  exit 2
+fi
+
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "FLY_DEPLOY_MAX_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+
+if ! [[ "$base_backoff_seconds" =~ ^[0-9]+$ ]]; then
+  echo "FLY_DEPLOY_BASE_BACKOFF_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+
+is_transient_deploy_error() {
+  local log_file="$1"
+  grep -E -q \
+    'error releasing builder: deadline_exceeded|failed to receive status: rpc error: code = Unavailable|error reading from server: EOF|graceful_stop' \
+    "$log_file"
+}
+
+attempt=1
+while [ "$attempt" -le "$max_attempts" ]; do
+  log_file="$(mktemp)"
+  echo "Running flyctl deploy attempt ${attempt}/${max_attempts}..."
+
+  set +e
+  flyctl deploy "$@" 2>&1 | tee "$log_file"
+  exit_code="${PIPESTATUS[0]}"
+  set -e
+
+  if [ "$exit_code" -eq 0 ]; then
+    rm -f "$log_file"
+    exit 0
+  fi
+
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "Deploy failed after ${attempt} attempts."
+    rm -f "$log_file"
+    exit "$exit_code"
+  fi
+
+  if is_transient_deploy_error "$log_file"; then
+    sleep_seconds=$((base_backoff_seconds * attempt))
+    echo "Transient Fly/Depot builder transport error detected."
+    echo "Retrying in ${sleep_seconds}s..."
+    rm -f "$log_file"
+    sleep "$sleep_seconds"
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  echo "Non-retryable flyctl deploy failure encountered."
+  rm -f "$log_file"
+  exit "$exit_code"
+done


### PR DESCRIPTION
Add a retry mechanism to `flyctl deploy` to handle transient builder transport errors.

Deployment workflows were failing intermittently with `deadline_exceeded` and `EOF` errors during the Docker build step, indicating transient disconnections with the Fly/Depot builder. This change introduces a script that retries `flyctl deploy` specifically for these known transient errors, ensuring that real build failures still fail fast.

---
<p><a href="https://cursor.com/agents?id=bc-66b43c9b-e343-4a3f-bd62-210c9d96615c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66b43c9b-e343-4a3f-bd62-210c9d96615c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

