### PR TITLE
Content cache refresh error

### DIFF
--- a/other/__tests__/refresh-changed-content.test.js
+++ b/other/__tests__/refresh-changed-content.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test, vi } from 'vitest'
+import { refreshChangedContent } from '../refresh-changed-content.js'
+
+function createLogger() {
+	return {
+		log: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}
+}
+
+describe('refreshChangedContent', () => {
+	test('skips refresh when no content files changed', async () => {
+		const fetchJsonImpl = vi.fn(async () => ({ sha: 'compare-sha' }))
+		const getChangedFilesImpl = vi.fn(async () => [
+			{ changeType: 'modified', filename: 'app/routes/index.tsx' },
+		])
+		const postRefreshCacheImpl = vi.fn()
+		const log = createLogger()
+
+		const result = await refreshChangedContent({
+			currentCommitSha: 'current-sha',
+			fetchJsonImpl,
+			getChangedFilesImpl,
+			postRefreshCacheImpl,
+			log,
+		})
+
+		expect(result).toEqual({ status: 'no-content-changes' })
+		expect(postRefreshCacheImpl).not.toHaveBeenCalled()
+	})
+
+	test('retries refresh request and eventually succeeds', async () => {
+		const fetchJsonImpl = vi.fn(async () => ({ sha: 'compare-sha' }))
+		const getChangedFilesImpl = vi.fn(async () => [
+			{
+				changeType: 'modified',
+				filename: 'content/blog/some-post.mdx',
+			},
+		])
+		const postRefreshCacheImpl = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('Unexpected Server Error'))
+			.mockResolvedValueOnce({ ok: true })
+		const log = createLogger()
+
+		const result = await refreshChangedContent({
+			currentCommitSha: 'current-sha',
+			fetchJsonImpl,
+			getChangedFilesImpl,
+			postRefreshCacheImpl,
+			log,
+			maxRefreshAttempts: 3,
+			retryDelayMs: 1,
+		})
+
+		expect(result).toEqual({ status: 'refreshed', attempts: 2 })
+		expect(postRefreshCacheImpl).toHaveBeenCalledTimes(2)
+		expect(postRefreshCacheImpl).toHaveBeenLastCalledWith({
+			postData: {
+				contentPaths: ['blog/some-post.mdx'],
+				commitSha: 'current-sha',
+			},
+		})
+		expect(log.warn).toHaveBeenCalledTimes(1)
+	})
+
+	test('returns refresh-failed after exhausting retries without throwing', async () => {
+		const fetchJsonImpl = vi.fn(async () => ({ sha: 'compare-sha' }))
+		const getChangedFilesImpl = vi.fn(async () => [
+			{
+				changeType: 'modified',
+				filename: 'content/blog/some-post.mdx',
+			},
+		])
+		const postRefreshCacheImpl = vi
+			.fn()
+			.mockRejectedValue('Unexpected Server Error')
+		const log = createLogger()
+
+		const result = await refreshChangedContent({
+			currentCommitSha: 'current-sha',
+			fetchJsonImpl,
+			getChangedFilesImpl,
+			postRefreshCacheImpl,
+			log,
+			maxRefreshAttempts: 2,
+			retryDelayMs: 1,
+		})
+
+		expect(result).toEqual({ status: 'refresh-failed', attempts: 2 })
+		expect(postRefreshCacheImpl).toHaveBeenCalledTimes(2)
+		expect(log.warn).toHaveBeenCalledTimes(2)
+	})
+})

--- a/other/get-changed-files.js
+++ b/other/get-changed-files.js
@@ -2,7 +2,20 @@
 import { execSync } from 'child_process'
 import https from 'https'
 
+let warnedTimoutTime = false
+
 export function fetchJson(url, { timeoutTime, timoutTime } = {}) {
+	if (
+		typeof timeoutTime === 'undefined' &&
+		typeof timoutTime !== 'undefined' &&
+		!warnedTimoutTime
+	) {
+		warnedTimoutTime = true
+		console.warn(
+			'[fetchJson] `timoutTime` is deprecated; use `timeoutTime` instead.',
+		)
+	}
+
 	return new Promise((resolve, reject) => {
 		const request = https
 			.get(url, (res) => {

--- a/other/get-changed-files.js
+++ b/other/get-changed-files.js
@@ -2,7 +2,7 @@
 import { execSync } from 'child_process'
 import https from 'https'
 
-export function fetchJson(url, { timoutTime } = {}) {
+export function fetchJson(url, { timeoutTime, timoutTime } = {}) {
 	return new Promise((resolve, reject) => {
 		const request = https
 			.get(url, (res) => {
@@ -22,10 +22,11 @@ export function fetchJson(url, { timoutTime } = {}) {
 			.on('error', (e) => {
 				reject(e)
 			})
-		if (timoutTime) {
+		const effectiveTimeoutTime = timeoutTime ?? timoutTime
+		if (effectiveTimeoutTime) {
 			setTimeout(() => {
 				request.destroy(new Error('Request timed out'))
-			}, timoutTime)
+			}, effectiveTimeoutTime)
 		}
 	})
 }

--- a/other/refresh-changed-content.js
+++ b/other/refresh-changed-content.js
@@ -1,54 +1,161 @@
 // try to keep this dep-free so we don't have to install deps
+import { pathToFileURL } from 'url'
 import { getChangedFiles, fetchJson } from './get-changed-files.js'
 import { postRefreshCache } from './utils.js'
 
-const [currentCommitSha] = process.argv.slice(2)
-
-const baseUrl =
+const defaultBaseUrl =
 	process.env.GITHUB_REF_NAME === 'dev'
 		? 'https://kcd-staging.fly.dev'
 		: 'https://kentcdodds.com'
 
-async function go() {
-	const shaInfo = await fetchJson(`${baseUrl}/refresh-commit-sha.json`, {
-		timeoutTime: 10_000,
-	})
-	let compareSha = shaInfo?.sha
-	if (!compareSha) {
-		const buildInfo = await fetchJson(`${baseUrl}/build/info.json`, {
-			timeoutTime: 10_000,
-		})
-		compareSha = buildInfo.commit.sha
-		console.log(
-			`No compare sha found, using build sha: ${buildInfo.commit.sha}`,
-		)
-	}
-	if (typeof compareSha !== 'string') {
-		console.log('🤷‍♂️ No sha to compare to. Unsure what to refresh.')
-		return
-	}
+const defaultTimeoutMs = 10_000
 
-	const changedFiles =
-		(await getChangedFiles(currentCommitSha, compareSha)) ?? []
-	const contentPaths = changedFiles
-		.filter((f) => f.filename.startsWith('content'))
-		.map((f) => f.filename.replace(/^content\//, ''))
-	if (contentPaths.length) {
-		console.log(`⚡️ Content changed. Requesting the cache be refreshed.`, {
-			currentCommitSha,
-			compareSha,
-			contentPaths,
-		})
-		const response = await postRefreshCache({
-			postData: {
-				contentPaths,
-				commitSha: currentCommitSha,
-			},
-		})
-		console.log(`Content change request finished.`, { response })
-	} else {
-		console.log('🆗 Not refreshing changed content because no content changed.')
+const defaultRefreshRetryOptions = {
+	maxAttempts: 3,
+	baseDelayMs: 2_000,
+}
+
+function getErrorMessage(error) {
+	if (error instanceof Error) {
+		return error.message
+	}
+	if (typeof error === 'string') {
+		return error
+	}
+	try {
+		return JSON.stringify(error)
+	} catch {
+		return String(error)
 	}
 }
 
-void go()
+const sleep = (durationMs) =>
+	new Promise((resolve) => setTimeout(resolve, durationMs))
+
+async function postRefreshCacheWithRetry({
+	postRefreshCacheImpl,
+	postData,
+	log,
+	maxAttempts = defaultRefreshRetryOptions.maxAttempts,
+	baseDelayMs = defaultRefreshRetryOptions.baseDelayMs,
+}) {
+	let lastError = null
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			const response = await postRefreshCacheImpl({ postData })
+			return { ok: true, attempts: attempt, response }
+		} catch (error) {
+			lastError = error
+			if (attempt === maxAttempts) {
+				break
+			}
+			const retryDelayMs = baseDelayMs * attempt
+			log.warn(
+				`Refresh cache request failed on attempt ${attempt}/${maxAttempts}. Retrying in ${retryDelayMs}ms.`,
+				{ error: getErrorMessage(error) },
+			)
+			await sleep(retryDelayMs)
+		}
+	}
+
+	return {
+		ok: false,
+		attempts: maxAttempts,
+		error: lastError,
+	}
+}
+
+export async function refreshChangedContent({
+	currentCommitSha,
+	baseUrl = defaultBaseUrl,
+	fetchJsonImpl = fetchJson,
+	getChangedFilesImpl = getChangedFiles,
+	postRefreshCacheImpl = postRefreshCache,
+	log = console,
+	maxRefreshAttempts = defaultRefreshRetryOptions.maxAttempts,
+	retryDelayMs = defaultRefreshRetryOptions.baseDelayMs,
+} = {}) {
+	if (!currentCommitSha) {
+		throw new Error('currentCommitSha is required')
+	}
+
+	const shaInfo = await fetchJsonImpl(`${baseUrl}/refresh-commit-sha.json`, {
+		timeoutTime: defaultTimeoutMs,
+	})
+	let compareSha = shaInfo?.sha
+	if (!compareSha) {
+		const buildInfo = await fetchJsonImpl(`${baseUrl}/build/info.json`, {
+			timeoutTime: defaultTimeoutMs,
+		})
+		compareSha = buildInfo?.commit?.sha
+		log.log(`No compare sha found, using build sha: ${compareSha}`)
+	}
+	if (typeof compareSha !== 'string') {
+		log.log('🤷‍♂️ No sha to compare to. Unsure what to refresh.')
+		return { status: 'no-compare-sha' }
+	}
+
+	const changedFiles = (await getChangedFilesImpl(currentCommitSha, compareSha)) ?? []
+	const contentPaths = changedFiles
+		.filter((f) => f.filename.startsWith('content'))
+		.map((f) => f.filename.replace(/^content\//, ''))
+	if (!contentPaths.length) {
+		log.log('🆗 Not refreshing changed content because no content changed.')
+		return { status: 'no-content-changes' }
+	}
+
+	log.log(`⚡️ Content changed. Requesting the cache be refreshed.`, {
+		currentCommitSha,
+		compareSha,
+		contentPaths,
+	})
+	const refreshResult = await postRefreshCacheWithRetry({
+		postRefreshCacheImpl,
+		postData: {
+			contentPaths,
+			commitSha: currentCommitSha,
+		},
+		log,
+		maxAttempts: maxRefreshAttempts,
+		baseDelayMs: retryDelayMs,
+	})
+
+	if (refreshResult.ok) {
+		log.log(`Content change request finished.`, {
+			response: refreshResult.response,
+			attempts: refreshResult.attempts,
+		})
+		return {
+			status: 'refreshed',
+			attempts: refreshResult.attempts,
+		}
+	}
+
+	log.warn(
+		'⚠️ Content changed but cache refresh failed. Continuing without failing this workflow run.',
+		{
+			currentCommitSha,
+			compareSha,
+			contentPaths,
+			attempts: refreshResult.attempts,
+			error: getErrorMessage(refreshResult.error),
+		},
+	)
+	return {
+		status: 'refresh-failed',
+		attempts: refreshResult.attempts,
+	}
+}
+
+const isMainModule =
+	process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMainModule) {
+	const [currentCommitSha] = process.argv.slice(2)
+	void refreshChangedContent({ currentCommitSha }).catch((error) => {
+		console.error('Unexpected error while refreshing changed content.', {
+			error: getErrorMessage(error),
+		})
+		process.exitCode = 1
+	})
+}

--- a/other/utils.js
+++ b/other/utils.js
@@ -19,7 +19,7 @@ function withStatusMessage(statusCode, body) {
 export async function postRefreshCache({
 	http,
 	postData,
-	options: { headers: headersOverrides, ...optionsOverrides } = {},
+	options: { headers: headersOverrides, timeout: timeoutOverride, ...optionsOverrides } = {},
 }) {
 	if (!http) {
 		http = await import('https')
@@ -77,8 +77,8 @@ export async function postRefreshCache({
 				})
 				.on('error', reject)
 			const timeoutMs =
-				typeof options.timeout === 'number'
-					? options.timeout
+				typeof timeoutOverride === 'number'
+					? timeoutOverride
 					: defaultTimeoutMs
 			req.setTimeout(timeoutMs, () => {
 				req.destroy(


### PR DESCRIPTION
Fix `UnhandledPromiseRejection` in `refresh-changed-content.js` by adding retry logic and robust error handling for cache refresh failures.

The original issue was an `UnhandledPromiseRejection` when the `postRefreshCache` API call failed, causing CI jobs to exit with code 1. This PR ensures the script handles API failures gracefully with retries and converts them into warnings, preventing crashes and providing better diagnostic information.

---
<p><a href="https://cursor.com/agents?id=bc-ff7f23c2-6e9d-44ee-9e87-ac1ba88d6852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff7f23c2-6e9d-44ee-9e87-ac1ba88d6852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/workflow automation and HTTP request behavior (timeouts, retry logic, and error parsing), which could change when/if cache refreshes occur or mask real failures if misconfigured.
> 
> **Overview**
> Prevents `refresh-changed-content.js` from failing CI on cache-refresh errors by refactoring it into an exported `refreshChangedContent` function with **retry/backoff**, structured status returns (`no-compare-sha`, `no-content-changes`, `refreshed`, `refresh-failed`), and normalized error logging via `getErrorMessage`.
> 
> Hardens HTTP helpers: `postRefreshCache` now enforces a request timeout and treats non-2xx responses as errors with better messages, and `fetchJson` supports the corrected `timeoutTime` option while warning once on deprecated `timoutTime` usage. Adds Vitest coverage for the new retry and edge-case behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ff7061a87131aecca075a33dea152148af5693. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry-enabled content refresh with configurable attempts and delays.
  * Explicit outcome statuses for refresh flows (e.g., skipped when no compare SHA or no changed content).

* **Improvements**
  * Flexible timeout handling with a one-time deprecation warning for legacy usage.
  * Normalized error messages and clearer logging for operations and failures.
  * More robust response parsing with status-aware error handling.

* **Tests**
  * Added tests covering retry behavior, skip conditions, and error-normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->