### PR TITLE
X post truncation

### DIFF
--- a/app/utils/__tests__/x-server.test.ts
+++ b/app/utils/__tests__/x-server.test.ts
@@ -1,0 +1,117 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { getTweetEmbedHTML } from '../x.server.ts'
+import { type Tweet } from '../twitter/types/index.ts'
+
+const truncatedTweetId = '2024575351259877487'
+const fullNoteTweetId = '2024575351259877488'
+
+function makeTweet(overrides: Partial<Tweet>): Tweet {
+	return {
+		__typename: 'Tweet',
+		lang: 'en',
+		favorite_count: 111,
+		created_at: '2026-02-19T20:02:33.000Z',
+		display_text_range: [0, 277],
+		entities: {
+			hashtags: [],
+			urls: [],
+			user_mentions: [],
+			symbols: [],
+		},
+		id_str: overrides.id_str ?? truncatedTweetId,
+		text: "I don't know about you...\n\nIt's not",
+		user: {
+			id_str: '389681470',
+			name: 'Kent C. Dodds',
+			screen_name: 'kentcdodds',
+			profile_image_url_https:
+				'https://pbs.twimg.com/profile_images/example_normal.jpg',
+			verified: false,
+			verified_type: 'none',
+			is_blue_verified: true,
+		},
+		edit_control: {
+			edit_tweet_ids: [overrides.id_str ?? truncatedTweetId],
+			editable_until_msecs: '1771534953000',
+			is_edit_eligible: true,
+			edits_remaining: '5',
+		},
+		conversation_count: 27,
+		news_action_type: 'conversation',
+		isEdited: false,
+		isStaleEdit: false,
+		...overrides,
+	}
+}
+
+const tweetById = new Map<string, Tweet>([
+	[
+		truncatedTweetId,
+		makeTweet({
+			id_str: truncatedTweetId,
+			text: "I don't know about you, but recently my days have been extremely chaotic.\n\nIt's not",
+			note_tweet: {
+				id: 'Tm90ZVR3ZWV0UmVzdWx0czoyMDI0NTc1MzUxMTg4NDkyMjg4',
+			},
+		}),
+	],
+	[
+		fullNoteTweetId,
+		makeTweet({
+			id_str: fullNoteTweetId,
+			text: "I don't know about you, but recently my days have been extremely chaotic.\n\nIt's not",
+			note_tweet: {
+				id: 'Tm90ZVR3ZWV0UmVzdWx0czoyMDI0NTc1MzUxMTg4NDkyMjk5',
+				note_tweet_results: {
+					result: {
+						text: "I don't know about you, but recently my days have been extremely chaotic.\n\nIt's not bad. I'm making progress and doing good work, but it's just utter chaos. I kinda like it.",
+					},
+				},
+			},
+		}),
+	],
+])
+
+const server = setupServer(
+	http.get('https://cdn.syndication.twimg.com/tweet-result', ({ request }) => {
+		const id = new URL(request.url).searchParams.get('id')
+		const tweet = id ? tweetById.get(id) : undefined
+		if (!tweet) return HttpResponse.json({}, { status: 404 })
+		return HttpResponse.json(tweet)
+	}),
+)
+
+beforeAll(() => {
+	server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterAll(() => {
+	server.close()
+})
+
+describe('getTweetEmbedHTML', () => {
+	test('adds linked ellipsis when longform content is truncated', async () => {
+		const html = await getTweetEmbedHTML(
+			`https://x.com/kentcdodds/status/${truncatedTweetId}`,
+		)
+
+		expect(html).toContain("It's not <a class=\"tweet-read-more\"")
+		expect(html).toContain(
+			`href="https://x.com/kentcdodds/status/${truncatedTweetId}"`,
+		)
+		expect(html).not.toContain('I kinda like it.')
+	})
+
+	test('prefers full note tweet text when available', async () => {
+		const html = await getTweetEmbedHTML(
+			`https://x.com/kentcdodds/status/${fullNoteTweetId}`,
+		)
+
+		expect(html).toContain(
+			"It's not bad. I'm making progress and doing good work, but it's just utter chaos. I kinda like it.",
+		)
+		expect(html).not.toContain('class="tweet-read-more"')
+	})
+})

--- a/app/utils/__tests__/x-server.test.ts
+++ b/app/utils/__tests__/x-server.test.ts
@@ -1,8 +1,22 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import { getTweetEmbedHTML } from '../x.server.ts'
 import { type Tweet } from '../twitter/types/index.ts'
+
+vi.mock('../cache.server.ts', () => ({
+	cache: {
+		name: 'test-cache',
+		get: () => null,
+		set: async () => {},
+		delete: async () => {},
+	},
+	lruCache: {
+		get: () => undefined,
+		set: () => undefined,
+		delete: () => undefined,
+	},
+}))
 
 const truncatedTweetId = '2024575351259877487'
 const fullNoteTweetId = '2024575351259877488'

--- a/app/utils/__tests__/x-server.test.ts
+++ b/app/utils/__tests__/x-server.test.ts
@@ -1,8 +1,8 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
-import { getTweetEmbedHTML } from '../x.server.ts'
 import { type Tweet } from '../twitter/types/index.ts'
+import { getTweetEmbedHTML } from '../x.server.ts'
 
 vi.mock('../cache.server.ts', () => ({
 	cache: {

--- a/app/utils/twitter/types/tweet.ts
+++ b/app/utils/twitter/types/tweet.ts
@@ -18,6 +18,17 @@ interface TweetBase {
 	isStaleEdit: boolean
 }
 
+interface NoteTweetResult {
+	text?: string
+}
+
+interface NoteTweet {
+	id: string
+	note_tweet_results?: {
+		result?: NoteTweetResult
+	}
+}
+
 export interface Tweet extends TweetBase {
 	__typename: 'Tweet'
 	favorite_count: number
@@ -32,6 +43,7 @@ export interface Tweet extends TweetBase {
 	in_reply_to_user_id_str?: string
 	parent?: TweetParent
 	possibly_sensitive?: boolean
+	note_tweet?: NoteTweet
 }
 
 export interface TweetParent extends TweetBase {


### PR DESCRIPTION
Add linked ellipsis for truncated X (Twitter) embeds and support for full longform text.

The X API often provides only truncated text for long posts, along with an ID indicating it's a long post. This change ensures that such truncated embeds now explicitly show a "..." linked to the original post, improving user experience by indicating more content is available. It also supports rendering the full text if the API ever provides it directly.

---
<p><a href="https://cursor.com/agents?id=bc-3ab92e6f-0fa8-4f2f-9f41-c49c31450812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ab92e6f-0fa8-4f2f-9f41-c49c31450812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to HTML generation and tweet typing, with new tests covering the main longform/truncation cases.
> 
> **Overview**
> Improves X embed rendering for longform posts by preferring `note_tweet.note_tweet_results.result.text` when present, otherwise detecting truncated longform posts via `note_tweet.id` and appending a linked `...` (“read more”) to the blockquote.
> 
> Extends the `Tweet` type to include `note_tweet` fields and adds MSW-backed Vitest coverage to verify both the linked-ellipsis truncation behavior and the full-note-text rendering path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00b935ca3c46efa4285463e338206409f2dd5496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for extended tweets with improved content display, including read-more links for truncated content and full display of extended tweet notes.

* **Tests**
  * Added test coverage for extended tweet embedding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->