### PR TITLE
LiteFS directory variable

### DIFF
--- a/app/utils/litefs-js.server.ts
+++ b/app/utils/litefs-js.server.ts
@@ -1,3 +1,11 @@
+// `litefs-js` throws if `LITEFS_DIR` is missing, but many scripts (like the
+// semantic-search indexers) intentionally start the dev server without loading a
+// local `.env`. Default to the same value as `.env.example` so non-LiteFS
+// environments can still boot and treat the current instance as primary.
+if (!process.env.LITEFS_DIR) {
+	process.env.LITEFS_DIR = './prisma'
+}
+
 export {
 	getInstanceInfo,
 	getInstanceInfoSync,

--- a/app/utils/litefs-js.server.ts
+++ b/app/utils/litefs-js.server.ts
@@ -1,9 +1,90 @@
+import {
+	getInstanceInfo as baseGetInstanceInfo,
+	getInstanceInfoSync as baseGetInstanceInfoSync,
+	TXID_NUM_COOKIE_NAME,
+	waitForUpToDateTxNumber as baseWaitForUpToDateTxNumber,
+	getTxNumber as baseGetTxNumber,
+	getTxSetCookieHeader,
+	checkCookieForTransactionalConsistency as baseCheckCookieForTransactionalConsistency,
+	getInternalInstanceDomain,
+	getAllInstances,
+} from 'litefs-js'
+
+import {
+	ensurePrimary as baseEnsurePrimary,
+	ensureInstance as baseEnsureInstance,
+	getReplayResponse,
+	handleTransactionalConsistency as baseHandleTransactionalConsistency,
+	appendTxNumberCookie as baseAppendTxNumberCookie,
+} from 'litefs-js/remix'
+
 // `litefs-js` throws if `LITEFS_DIR` is missing, but many scripts (like the
 // semantic-search indexers) intentionally start the dev server without loading a
-// local `.env`. Default to the same value as `.env.example` so non-LiteFS
-// environments can still boot and treat the current instance as primary.
-if (!process.env.LITEFS_DIR) {
-	process.env.LITEFS_DIR = './prisma'
+// local `.env`. Default to the same value as `.env.example` when the value is
+// actually needed so dotenv can still override if it loads later.
+const defaultLitefsDir = './prisma'
+
+function ensureLitefsDir() {
+	if (!process.env.LITEFS_DIR) {
+		process.env.LITEFS_DIR = defaultLitefsDir
+	}
+}
+
+const getInstanceInfo: typeof baseGetInstanceInfo = (...args) => {
+	if (!args[0]) {
+		ensureLitefsDir()
+	}
+	return baseGetInstanceInfo(...args)
+}
+
+const getInstanceInfoSync: typeof baseGetInstanceInfoSync = (...args) => {
+	if (!args[0]) {
+		ensureLitefsDir()
+	}
+	return baseGetInstanceInfoSync(...args)
+}
+
+const waitForUpToDateTxNumber: typeof baseWaitForUpToDateTxNumber = (
+	...args
+) => {
+	if (!args[1]?.litefsDir) {
+		ensureLitefsDir()
+	}
+	return baseWaitForUpToDateTxNumber(...args)
+}
+
+const getTxNumber: typeof baseGetTxNumber = (...args) => {
+	if (!args[0]) {
+		ensureLitefsDir()
+	}
+	return baseGetTxNumber(...args)
+}
+
+const checkCookieForTransactionalConsistency: typeof baseCheckCookieForTransactionalConsistency =
+	(...args) => {
+		ensureLitefsDir()
+		return baseCheckCookieForTransactionalConsistency(...args)
+	}
+
+const ensurePrimary: typeof baseEnsurePrimary = (...args) => {
+	ensureLitefsDir()
+	return baseEnsurePrimary(...args)
+}
+
+const ensureInstance: typeof baseEnsureInstance = (...args) => {
+	ensureLitefsDir()
+	return baseEnsureInstance(...args)
+}
+
+const handleTransactionalConsistency: typeof baseHandleTransactionalConsistency =
+	(...args) => {
+		ensureLitefsDir()
+		return baseHandleTransactionalConsistency(...args)
+	}
+
+const appendTxNumberCookie: typeof baseAppendTxNumberCookie = (...args) => {
+	ensureLitefsDir()
+	return baseAppendTxNumberCookie(...args)
 }
 
 export {
@@ -16,7 +97,7 @@ export {
 	checkCookieForTransactionalConsistency,
 	getInternalInstanceDomain,
 	getAllInstances,
-} from 'litefs-js'
+}
 
 export {
 	ensurePrimary,
@@ -24,4 +105,4 @@ export {
 	getReplayResponse,
 	handleTransactionalConsistency,
 	appendTxNumberCookie,
-} from 'litefs-js/remix'
+}


### PR DESCRIPTION
Default `LITEFS_DIR` to `./prisma` to fix semantic search job failures in CI.

The semantic search content indexing job failed because the local dev server, which it starts to fetch sitemap content, could not boot. This was due to `litefs-js` requiring `LITEFS_DIR` to be set, which it isn't in the CI environment for this specific job. Providing a default allows the server to start without error.

---
<p><a href="https://cursor.com/agents?id=bc-c0adcf35-476c-454c-b21b-21c296d8c12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0adcf35-476c-454c-b21b-21c296d8c12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App runs when LiteFS environment vars are missing by using a sensible default and temporarily applying a resolved environment during related operations.

* **New Features**
  * Exposes additional public utilities for transactional consistency, transaction cookie handling, replay/instance management, and primary/instance checks, consolidating these APIs for easier integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-wide environment handling with async locking; mistakes could cause cross-request interference or incorrect LiteFS directory usage under concurrency.
> 
> **Overview**
> Prevents startup/runtime failures when `LITEFS_DIR` is unset by defaulting the LiteFS directory to `./prisma` and routing all LiteFS helper calls through that resolver.
> 
> Adds a small, serialized env-override helper (`withLitefsDirEnv`) that temporarily sets `process.env.LITEFS_DIR` around `litefs-js` operations (e.g., `waitForUpToDateTxNumber`, `ensurePrimary`, transactional consistency/cookie helpers) to satisfy libraries that read the env var at call time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870b3cb831a350bad67d0a066f8678334d5169e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->