### PR TITLE
YouTube playlist video error

### DIFF
--- a/app/routes/youtube.tsx
+++ b/app/routes/youtube.tsx
@@ -94,7 +94,9 @@ export default function YouTubePage() {
 							params={new URLSearchParams({
 								rel: '0',
 								modestbranding: '1',
-								list: playlistId,
+								// Do not include the configured playlist when deep-linking to a
+								// specific video. If the video is not in the playlist, YouTube will
+								// fall back to playing the first playlist entry instead.
 								...(startSeconds ? { start: String(startSeconds) } : {}),
 							}).toString()}
 						/>


### PR DESCRIPTION
Fix deep-linked YouTube embeds to play the specified video, not the first video in the playlist.

Previously, when a `video` query parameter was present, the YouTube embed URL still included the `list` parameter for the configured playlist. If the requested video was not part of that playlist, YouTube would default to playing the first video from the playlist instead of the intended specific video. This change ensures that when a specific `video` is requested, only that video is embedded.

---
<p><a href="https://cursor.com/agents?id=bc-95353aa9-7c59-43a9-a14f-0362fedc27be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95353aa9-7c59-43a9-a14f-0362fedc27be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to client-side embed URL parameters with minimal blast radius; risk is limited to how YouTube interprets the updated query string.
> 
> **Overview**
> When a specific `video` is selected via query params, the YouTube embed no longer includes the configured playlist `list` parameter, preventing YouTube from falling back to the first playlist item if the requested video is outside the playlist.
> 
> This preserves optional start time (`t`) behavior and adds an inline comment clarifying the rationale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 561f8e5483fb34e4f499a3615ef1e0bd7783a664. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YouTube video embedding to correctly omit playlist parameters when a specific video is selected, ensuring only the selected video plays without displaying the full playlist alongside it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->