### PR TITLE
TanStack hotkeys input bug

### DIFF
--- a/app/components/app-hotkeys.tsx
+++ b/app/components/app-hotkeys.tsx
@@ -80,7 +80,7 @@ function AppHotkeys() {
 		// TanStack Hotkeys SequenceManager (currently) does not honor `ignoreInputs`,
 		// so sequences can progress while typing and complete on the final key.
 		// Work around by resetting sequence progress for key events from inputs.
-		// Upstream issue: https://github.com/TanStack/hotkeys/issues (see repo issue for details)
+		// Upstream issue: https://github.com/TanStack/hotkeys/issues/34
 		const resetSequencesIfTyping = (event: Event) => {
 			if (isInputLikeElement(event.target)) {
 				sequenceManager.resetAll()


### PR DESCRIPTION
Add a workaround to prevent TanStack hotkey sequences from firing in input fields.

TanStack's `SequenceManager` (v0.1.3) does not implement `ignoreInputs`, causing hotkey sequences to trigger while typing in input fields, leading to unintended navigation. This workaround resets sequence progress when key events originate from inputs.

---
<p><a href="https://cursor.com/agents?id=bc-3ec03ecf-65a6-4b04-9e84-b4b6eb7da04d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ec03ecf-65a6-4b04-9e84-b4b6eb7da04d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated client-side hotkey behavior change; risk is limited to potential over-resetting of sequences outside intended editable elements.
> 
> **Overview**
> Prevents TanStack hotkey *sequences* from completing while the user is typing in editable fields.
> 
> `AppHotkeys` now detects input-like targets (`input`/`textarea`/`select`/`contenteditable`) and, due to an upstream `ignoreInputs` bug in `SequenceManager`, resets all sequence progress on `keydown` and `focusout` events (with proper cleanup) before registering navigation sequences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18103d3d6190cde371c7ce9086e22a21da41cf65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where keyboard shortcuts would interfere with typing in input fields and text areas. Hotkey sequences are now properly ignored when you're actively typing or editing content, ensuring a more seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->