### PR TITLE
Semantic search data admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,16 @@ CLOUDFLARE_AI_EMBEDDING_MODEL=
 # Used to auto-generate Transistor `transcript_text` for Call Kent episodes.
 CLOUDFLARE_AI_TRANSCRIPTION_MODEL=
 
+# Feature: /search/admin (semantic search manifests + ignore list)
+# Mocked: yes (fixture manifests) when MOCKS=true and R2 creds are not set.
+# Note: R2 object access uses the S3-compatible API (access key + secret).
+R2_BUCKET=
+R2_ENDPOINT=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+# Optional: override ignore list object key
+SEMANTIC_SEARCH_IGNORE_LIST_KEY=manifests/ignore-list.json
+
 # Feature: YouTube playlist semantic indexing + /youtube route
 # Optional: set either playlist URL or playlist ID.
 YOUTUBE_PLAYLIST_URL=https://www.youtube.com/watch?v=wSEUlS8WcQs&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf

--- a/app/routes/search.admin.tsx
+++ b/app/routes/search.admin.tsx
@@ -487,7 +487,7 @@ export default function SearchAdminRoute() {
 										type="search"
 										name="q"
 										defaultValue={searchParams.get('q') ?? ''}
-										placeholder="Filter by title, URL, docId, or snippet…"
+										placeholder="Filter by title, URL, docId, or snippet..."
 										className={inputClassName}
 									/>
 								)}

--- a/app/routes/search.admin.tsx
+++ b/app/routes/search.admin.tsx
@@ -12,11 +12,10 @@ import invariant from 'tiny-invariant'
 import { Button } from '#app/components/button.tsx'
 import {
 	ErrorPanel,
-	Field,
+	FieldContainer,
 	inputClassName,
 } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
-import { Spacer } from '#app/components/spacer.tsx'
 import { H2, H3, H4, Paragraph } from '#app/components/typography.tsx'
 import { type KCDHandle } from '#app/types.ts'
 import {
@@ -54,6 +53,9 @@ type DocRow = {
 	chunks: Array<{ id: string; snippet: string; hash: string }>
 	ignored: boolean
 }
+
+const cardClassName =
+	'rounded-2xl bg-gray-100 p-6 ring-1 ring-inset ring-[rgba(0,0,0,0.05)] dark:bg-gray-850 dark:ring-[rgba(255,255,255,0.05)]'
 
 function asPositiveInt(value: string | null, fallback: number) {
 	if (!value) return fallback
@@ -409,7 +411,7 @@ export default function SearchAdminRoute() {
 
 	return (
 		<main className="mt-12 mb-24 lg:mt-24 lg:mb-48">
-			<Grid>
+			<Grid rowGap>
 				<div className="col-span-full">
 					<H2>Semantic Search Admin</H2>
 					<Paragraph textColorClassName="text-secondary">
@@ -418,194 +420,240 @@ export default function SearchAdminRoute() {
 					</Paragraph>
 				</div>
 
-				<Spacer size="2xs" className="col-span-full" />
-
 				{data.message ? (
 					<div className="col-span-full">
-						<ErrorPanel>{data.message}</ErrorPanel>
+						{data.configured ? (
+							<InfoPanel>{data.message}</InfoPanel>
+						) : (
+							<ErrorPanel>{data.message}</ErrorPanel>
+						)}
 					</div>
 				) : null}
 
 				{data.store ? (
 					<div className="col-span-full">
-						<Paragraph textColorClassName="text-secondary">
-							Store: {data.store.source} • Bucket: {data.store.bucket} • Ignore
-							list key: {data.store.ignoreListKey}
-						</Paragraph>
+						<InfoPanel>
+							<div className="flex flex-wrap gap-x-3 gap-y-1">
+								<span>
+									Store: <code>{data.store.source}</code>
+								</span>
+								<span>
+									Bucket: <code>{data.store.bucket}</code>
+								</span>
+								<span>
+									Ignore list key: <code>{data.store.ignoreListKey}</code>
+								</span>
+							</div>
+						</InfoPanel>
 					</div>
 				) : null}
 
-				<Spacer size="2xs" className="col-span-full" />
-
 				<div className="col-span-full">
-					<H3>Browse</H3>
-					<Form
-						method="get"
-						className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-12"
-						onChange={(e) => syncGetForm(e.currentTarget)}
-					>
-						<div className="md:col-span-4">
-							<label className="block text-sm font-medium">Manifest</label>
-							<select
-								name="manifest"
-								defaultValue={data.selectedManifest}
-								className={inputClassName}
-							>
-								<option value="all">All manifests</option>
-								{data.manifestKeys.map((k) => (
-									<option key={k} value={k}>
-										{k}
-									</option>
-								))}
-							</select>
-						</div>
-
-						<div className="md:col-span-4">
-							<Field
-								label="Query"
-								name="q"
-								defaultValue={searchParams.get('q') ?? ''}
-								placeholder="Filter by title/url/docId/snippet..."
-							/>
-						</div>
-
-						<div className="md:col-span-2">
-							<label className="block text-sm font-medium">Type</label>
-							<select
-								name="type"
-								defaultValue={data.type}
-								className={inputClassName}
-							>
-								<option value="">All</option>
-								{data.typeOptions.map((o: { type: string; count: number }) => (
-									<option key={o.type} value={o.type}>
-										{o.type} ({o.count})
-									</option>
-								))}
-							</select>
-						</div>
-
-						<div className="md:col-span-2">
-							<Field
-								label="Limit"
-								name="limit"
-								type="number"
-								step="1"
-								min="10"
-								max="500"
-								defaultValue={String(data.limit)}
-							/>
-						</div>
-
-						<input type="hidden" name="offset" value={String(data.offset)} />
-
-						<div className="flex items-center gap-3 md:col-span-12">
-							<label className="flex items-center gap-2 text-sm">
-								<input
-									type="checkbox"
-									name="showIgnored"
-									defaultChecked={data.showIgnored}
-									value="true"
-								/>
-								Show ignored
-							</label>
+					<div className={cardClassName}>
+						<div className="flex flex-wrap items-baseline justify-between gap-3">
+							<H3>Browse</H3>
 							<Paragraph textColorClassName="text-secondary">
 								Showing {data.docs.length} of {data.total} docs
 							</Paragraph>
 						</div>
-					</Form>
 
-					<div className="mt-4 flex items-center gap-2">
-						<Button
-							type="button"
-							disabled={!hasPrev}
-							onClick={() => {
-								const next = new URLSearchParams(searchParams)
-								next.set('offset', String(prevOffset))
-								void submit(next, { method: 'get', replace: true })
-							}}
+						<Form
+							method="get"
+							className="mt-6 grid grid-cols-1 gap-x-6 gap-y-6 lg:grid-cols-12"
+							onChange={(e) => syncGetForm(e.currentTarget)}
 						>
-							Prev
-						</Button>
-						<Button
-							type="button"
-							disabled={!hasNext}
-							onClick={() => {
-								const next = new URLSearchParams(searchParams)
-								next.set('offset', String(nextOffset))
-								void submit(next, { method: 'get', replace: true })
-							}}
-						>
-							Next
-						</Button>
+							<FieldContainer label="Manifest" className="mb-0 lg:col-span-4">
+								{({ inputProps }) => (
+									<select
+										{...inputProps}
+										name="manifest"
+										defaultValue={data.selectedManifest}
+										className={inputClassName}
+									>
+										<option value="all">All manifests</option>
+										{data.manifestKeys.map((k) => (
+											<option key={k} value={k}>
+												{k}
+											</option>
+										))}
+									</select>
+								)}
+							</FieldContainer>
+
+							<FieldContainer label="Query" className="mb-0 lg:col-span-4">
+								{({ inputProps }) => (
+									<input
+										{...inputProps}
+										type="search"
+										name="q"
+										defaultValue={searchParams.get('q') ?? ''}
+										placeholder="Filter by title, URL, docId, or snippet…"
+										className={inputClassName}
+									/>
+								)}
+							</FieldContainer>
+
+							<FieldContainer label="Type" className="mb-0 lg:col-span-2">
+								{({ inputProps }) => (
+									<select
+										{...inputProps}
+										name="type"
+										defaultValue={data.type}
+										className={inputClassName}
+									>
+										<option value="">All</option>
+										{data.typeOptions.map(
+											(o: { type: string; count: number }) => (
+												<option key={o.type} value={o.type}>
+													{o.type} ({o.count})
+												</option>
+											),
+										)}
+									</select>
+								)}
+							</FieldContainer>
+
+							<FieldContainer label="Limit" className="mb-0 lg:col-span-2">
+								{({ inputProps }) => (
+									<input
+										{...inputProps}
+										name="limit"
+										type="number"
+										step={1}
+										min={10}
+										max={500}
+										defaultValue={String(data.limit)}
+										className={inputClassName}
+									/>
+								)}
+							</FieldContainer>
+
+							{/* Reset pagination when filters change */}
+							<input type="hidden" name="offset" value="0" />
+
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between lg:col-span-12">
+								<label className="flex items-center gap-2 text-lg text-gray-500 dark:text-slate-500">
+									<input
+										type="checkbox"
+										name="showIgnored"
+										defaultChecked={data.showIgnored}
+										value="true"
+									/>
+									Show ignored
+								</label>
+
+								<div className="flex items-center gap-2">
+									<Button
+										size="medium"
+										type="button"
+										disabled={!hasPrev}
+										onClick={() => {
+											const next = new URLSearchParams(searchParams)
+											next.set('offset', String(prevOffset))
+											void submit(next, { method: 'get', replace: true })
+										}}
+									>
+										Prev
+									</Button>
+									<Button
+										size="medium"
+										type="button"
+										disabled={!hasNext}
+										onClick={() => {
+											const next = new URLSearchParams(searchParams)
+											next.set('offset', String(nextOffset))
+											void submit(next, { method: 'get', replace: true })
+										}}
+									>
+										Next
+									</Button>
+								</div>
+							</div>
+						</Form>
 					</div>
 				</div>
 
-				<Spacer size="xs" className="col-span-full" />
+				<div className="col-span-full md:col-span-3 lg:col-span-4">
+					<div className={cardClassName}>
+						<H3>Ignore list</H3>
+						<Paragraph textColorClassName="text-secondary">
+							Patterns match manifest doc IDs like{' '}
+							<code>youtube:dQw4w9WgXcQ</code>. Use a trailing <code>*</code>{' '}
+							for prefixes (ex: <code>youtube:*</code>).
+						</Paragraph>
 
-				<div className="col-span-full md:col-span-5">
-					<H3>Ignore list</H3>
-					<Paragraph textColorClassName="text-secondary">
-						Patterns match manifest doc IDs like `youtube:dQw4w9WgXcQ`. Use a
-						trailing `*` for prefixes (ex: `youtube:*`).
-					</Paragraph>
+						<ignoreAddFetcher.Form
+							method="post"
+							className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-end"
+							onSubmit={() => {
+								// Keep typing fast.
+								setTimeout(() => {
+									ignoreAddRef.current?.focus()
+								}, 0)
+							}}
+						>
+							<input type="hidden" name="intent" value="ignore-add" />
+							<div className="flex-1">
+								<FieldContainer label="Add pattern" className="mb-0">
+									{({ inputProps }) => (
+										<input
+											{...inputProps}
+											ref={ignoreAddRef}
+											name="pattern"
+											type="text"
+											placeholder="youtube:abc123 or youtube:*"
+											className={inputClassName}
+											required
+										/>
+									)}
+								</FieldContainer>
+							</div>
+							<Button
+								size="medium"
+								type="submit"
+								className="w-full sm:w-auto"
+								disabled={ignoreAddFetcher.state !== 'idle'}
+							>
+								{ignoreAddFetcher.state === 'idle' ? 'Add' : 'Adding...'}
+							</Button>
+						</ignoreAddFetcher.Form>
 
-					<ignoreAddFetcher.Form
-						method="post"
-						className="mt-3 flex items-end gap-2"
-						onSubmit={() => {
-							// Keep typing fast.
-							setTimeout(() => {
-								ignoreAddRef.current?.focus()
-							}, 0)
-						}}
-					>
-						<input type="hidden" name="intent" value="ignore-add" />
-						<div className="flex-1">
-							<label className="block text-sm font-medium" htmlFor="pattern">
-								Add pattern
-							</label>
-							<input
-								ref={ignoreAddRef}
-								id="pattern"
-								name="pattern"
-								type="text"
-								placeholder="youtube:abc123 or youtube:*"
-								className={inputClassName}
-							/>
-						</div>
-						<Button type="submit" disabled={ignoreAddFetcher.state !== 'idle'}>
-							{ignoreAddFetcher.state === 'idle' ? 'Add' : 'Adding...'}
-						</Button>
-					</ignoreAddFetcher.Form>
-
-					<ul className="mt-4 space-y-2">
-						{(data.ignoreList.patterns ?? []).length ? (
-							(data.ignoreList.patterns ?? []).map((pattern) => (
-								<IgnorePatternRow key={pattern} pattern={pattern} />
-							))
-						) : (
-							<li>
-								<Paragraph textColorClassName="text-secondary">
-									No ignore patterns yet.
-								</Paragraph>
-							</li>
-						)}
-					</ul>
+						<ul className="mt-6 space-y-3">
+							{(data.ignoreList.patterns ?? []).length ? (
+								(data.ignoreList.patterns ?? []).map((pattern) => (
+									<IgnorePatternRow key={pattern} pattern={pattern} />
+								))
+							) : (
+								<li>
+									<Paragraph textColorClassName="text-secondary">
+										No ignore patterns yet.
+									</Paragraph>
+								</li>
+							)}
+						</ul>
+					</div>
 				</div>
 
-				<div className="col-span-full md:col-span-7">
-					<H3>Docs</H3>
-					<div className="mt-3 space-y-4">
-						{data.docs.length ? (
-							data.docs.map((doc) => (
-								<DocCard key={`${doc.manifestKey}:${doc.docId}`} doc={doc} />
-							))
-						) : (
+				<div className="col-span-full md:col-span-5 lg:col-span-8">
+					<div className={cardClassName}>
+						<div className="flex flex-wrap items-baseline justify-between gap-3">
+							<H3>Docs</H3>
 							<Paragraph textColorClassName="text-secondary">
-								No docs match the current filters.
+								{data.total === 1 ? '1 doc' : `${data.total} docs`}
 							</Paragraph>
-						)}
+						</div>
+
+						<div className="mt-6 space-y-6">
+							{data.docs.length ? (
+								data.docs.map((doc) => (
+									<DocCard key={`${doc.manifestKey}:${doc.docId}`} doc={doc} />
+								))
+							) : (
+								<Paragraph textColorClassName="text-secondary">
+									No docs match the current filters.
+								</Paragraph>
+							)}
+						</div>
 					</div>
 				</div>
 			</Grid>
@@ -617,7 +665,7 @@ function IgnorePatternRow({ pattern }: { pattern: string }) {
 	const fetcher = useFetcher<typeof action>()
 	const dc = useDoubleCheck()
 	return (
-		<li className="flex items-center justify-between gap-3 rounded-lg bg-gray-100 p-3 dark:bg-gray-800">
+		<li className="flex flex-col gap-3 rounded-xl bg-white/60 p-4 sm:flex-row sm:items-center sm:justify-between dark:bg-black/20">
 			<code className="min-w-0 flex-1 truncate text-sm">{pattern}</code>
 			<fetcher.Form method="post">
 				<input type="hidden" name="intent" value="ignore-remove" />
@@ -627,6 +675,7 @@ function IgnorePatternRow({ pattern }: { pattern: string }) {
 					variant="danger"
 					{...dc.getButtonProps({ type: 'submit' })}
 					disabled={fetcher.state !== 'idle'}
+					className="w-full sm:w-auto"
 				>
 					{fetcher.state === 'idle'
 						? dc.doubleCheck
@@ -668,8 +717,8 @@ function DocCard({ doc }: { doc: DocRow }) {
 			: null
 
 	return (
-		<div className="rounded-lg bg-gray-100 p-4 dark:bg-gray-800">
-			<div className="flex flex-wrap items-start justify-between gap-3">
+		<div className="rounded-2xl bg-white/60 p-5 dark:bg-black/20">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 				<div className="min-w-0 flex-1">
 					<H4 className="truncate">
 						{doc.url ? (
@@ -696,16 +745,17 @@ function DocCard({ doc }: { doc: DocRow }) {
 					</Paragraph>
 				</div>
 
-				<div className="flex shrink-0 flex-wrap items-center gap-2">
+				<div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
 					<ignoreFetcher.Form method="post">
 						<input type="hidden" name="intent" value="ignore-add" />
 						<input type="hidden" name="pattern" value={doc.docId} />
 						<Button
-							size="small"
+							size="medium"
 							variant="secondary"
 							{...ignoreDc.getButtonProps({ type: 'submit' })}
 							disabled={isIgnoring}
 							title="Adds an exact ignore pattern for this doc ID"
+							className="w-full sm:w-auto"
 						>
 							{isIgnoring
 								? 'Ignoring...'
@@ -722,10 +772,11 @@ function DocCard({ doc }: { doc: DocRow }) {
 						<input type="hidden" name="scope" value="manifest" />
 						<input type="hidden" name="addToIgnore" value="false" />
 						<Button
-							size="small"
+							size="medium"
 							variant="danger"
 							{...deleteDc.getButtonProps({ type: 'submit' })}
 							disabled={isDeleting}
+							className="w-full sm:w-auto"
 						>
 							{isDeleting
 								? 'Deleting...'
@@ -742,11 +793,12 @@ function DocCard({ doc }: { doc: DocRow }) {
 						<input type="hidden" name="scope" value="manifest" />
 						<input type="hidden" name="addToIgnore" value="true" />
 						<Button
-							size="small"
+							size="medium"
 							variant="danger"
 							{...deleteIgnoreDc.getButtonProps({ type: 'submit' })}
 							disabled={isDeleting}
 							title="Deletes now and adds this docId to ignore list"
+							className="w-full sm:w-auto"
 						>
 							{isDeleting
 								? 'Deleting...'
@@ -805,6 +857,14 @@ export function ErrorBoundary() {
 		<div className="mx-10vw mt-10">
 			<h2>Search admin error</h2>
 			<pre className="whitespace-pre-wrap">{getErrorMessage(error)}</pre>
+		</div>
+	)
+}
+
+function InfoPanel({ children }: { children: React.ReactNode }) {
+	return (
+		<div className="rounded-xl bg-slate-100 p-5 text-base text-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+			{children}
 		</div>
 	)
 }

--- a/app/routes/search.admin.tsx
+++ b/app/routes/search.admin.tsx
@@ -1,0 +1,789 @@
+import * as React from 'react'
+import {
+	data as json,
+	Form,
+	Link,
+	useFetcher,
+	useLoaderData,
+	useSearchParams,
+	useSubmit,
+} from 'react-router'
+import invariant from 'tiny-invariant'
+import { Button } from '#app/components/button.tsx'
+import {
+	ErrorPanel,
+	Field,
+	inputClassName,
+} from '#app/components/form-elements.tsx'
+import { Grid } from '#app/components/grid.tsx'
+import { Spacer } from '#app/components/spacer.tsx'
+import { H2, H3, H4, Paragraph } from '#app/components/typography.tsx'
+import { type KCDHandle } from '#app/types.ts'
+import {
+	getErrorMessage,
+	useDebounce,
+	useDoubleCheck,
+	useCapturedRouteError,
+} from '#app/utils/misc.tsx'
+import { requireAdminUser } from '#app/utils/session.server.ts'
+import {
+	isSemanticSearchConfigured,
+	vectorizeDeleteByIds,
+} from '#app/utils/semantic-search.server.ts'
+import {
+	getSemanticSearchAdminStore,
+	isDocIdIgnored,
+	type SemanticSearchIgnoreList,
+	type SemanticSearchManifest,
+} from '#app/utils/semantic-search-admin.server.ts'
+import { type Route } from './+types/search.admin'
+
+export const handle: KCDHandle = {
+	getSitemapEntries: () => null,
+}
+
+type DocRow = {
+	docId: string
+	manifestKey: string
+	type: string
+	title: string
+	url: string
+	sourceUpdatedAt?: string
+	transcriptSource?: string
+	chunkCount: number
+	chunks: Array<{ id: string; snippet: string; hash: string }>
+	ignored: boolean
+}
+
+function asPositiveInt(value: string | null, fallback: number) {
+	if (!value) return fallback
+	const n = Number(value)
+	if (!Number.isFinite(n)) return fallback
+	return Math.max(0, Math.floor(n))
+}
+
+function containsInsensitive(haystack: string, needle: string) {
+	return haystack.toLowerCase().includes(needle.toLowerCase())
+}
+
+function filterDocs({
+	docs,
+	query,
+	type,
+	showIgnored,
+}: {
+	docs: DocRow[]
+	query: string
+	type: string
+	showIgnored: boolean
+}) {
+	const q = query.trim()
+	return docs.filter((doc) => {
+		if (!showIgnored && doc.ignored) return false
+		if (type && doc.type !== type) return false
+		if (!q) return true
+		if (
+			containsInsensitive(doc.docId, q) ||
+			containsInsensitive(doc.title, q) ||
+			containsInsensitive(doc.url, q) ||
+			containsInsensitive(doc.manifestKey, q)
+		) {
+			return true
+		}
+		return doc.chunks.some((c) => containsInsensitive(c.snippet, q))
+	})
+}
+
+function sortDocs(docs: DocRow[]) {
+	return [...docs].sort((a, b) => {
+		// Bring ignored docs to the top so they’re easy to spot.
+		if (a.ignored !== b.ignored) return a.ignored ? -1 : 1
+		const typeDiff = a.type.localeCompare(b.type)
+		if (typeDiff) return typeDiff
+		const titleDiff = a.title.localeCompare(b.title)
+		if (titleDiff) return titleDiff
+		return a.docId.localeCompare(b.docId)
+	})
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+	await requireAdminUser(request)
+	const url = new URL(request.url)
+	const sp = url.searchParams
+
+	const { store, configured, message } = getSemanticSearchAdminStore()
+	const manifestParam = sp.get('manifest') ?? 'all'
+	const query = sp.get('q') ?? ''
+	const type = sp.get('type') ?? ''
+	const showIgnored = sp.get('showIgnored') === 'true'
+	const limit = Math.min(500, Math.max(10, asPositiveInt(sp.get('limit'), 100)))
+	const offset = asPositiveInt(sp.get('offset'), 0)
+
+	if (!store || !configured) {
+		return json(
+			{
+				configured: false,
+				message:
+					message ??
+					'Semantic search admin is not configured on this environment.',
+				semanticSearchConfigured: isSemanticSearchConfigured(),
+				manifestKeys: [] as string[],
+				selectedManifest: manifestParam,
+				query,
+				type,
+				showIgnored,
+				limit,
+				offset,
+				total: 0,
+				docs: [] as DocRow[],
+				ignoreList: {
+					version: 1,
+					patterns: [],
+				} satisfies SemanticSearchIgnoreList,
+				store: null as null | {
+					source: string
+					bucket: string
+					ignoreListKey: string
+				},
+			},
+			{ headers: { 'Cache-Control': 'no-store' } },
+		)
+	}
+
+	const [manifestKeys, ignoreList] = await Promise.all([
+		store.listManifestKeys(),
+		store.getIgnoreList(),
+	])
+
+	const selectedKeys =
+		manifestParam === 'all'
+			? manifestKeys
+			: manifestKeys.includes(manifestParam)
+				? [manifestParam]
+				: manifestKeys
+
+	const manifests = await Promise.all(
+		selectedKeys.map(async (key) => {
+			const manifest = await store.getManifest(key)
+			return { key, manifest }
+		}),
+	)
+
+	const rows: DocRow[] = []
+	for (const { key: manifestKey, manifest } of manifests) {
+		const docs = (manifest as SemanticSearchManifest | null)?.docs ?? {}
+		for (const [docId, doc] of Object.entries(docs)) {
+			const chunks = Array.isArray(doc?.chunks) ? doc.chunks : []
+			rows.push({
+				docId,
+				manifestKey,
+				type: String(doc?.type ?? ''),
+				title: String(doc?.title ?? docId),
+				url: String(doc?.url ?? ''),
+				sourceUpdatedAt:
+					typeof (doc as any)?.sourceUpdatedAt === 'string'
+						? (doc as any).sourceUpdatedAt
+						: undefined,
+				transcriptSource:
+					typeof (doc as any)?.transcriptSource === 'string'
+						? (doc as any).transcriptSource
+						: undefined,
+				chunkCount: chunks.length,
+				chunks: chunks.map((c) => ({
+					id: String((c as any)?.id ?? ''),
+					hash: String((c as any)?.hash ?? ''),
+					snippet: String((c as any)?.snippet ?? ''),
+				})),
+				ignored: isDocIdIgnored({ docId, ignoreList }),
+			})
+		}
+	}
+
+	const filtered = sortDocs(
+		filterDocs({ docs: rows, query, type, showIgnored }),
+	)
+	const paged = filtered.slice(offset, offset + limit)
+
+	const types = new Map<string, number>()
+	for (const r of rows) {
+		const key = r.type || 'unknown'
+		types.set(key, (types.get(key) ?? 0) + 1)
+	}
+	const typeOptions = [...types.entries()]
+		.map(([k, count]) => ({ type: k, count }))
+		.sort((a, b) => b.count - a.count || a.type.localeCompare(b.type))
+
+	return json(
+		{
+			configured: true,
+			message,
+			semanticSearchConfigured: isSemanticSearchConfigured(),
+			manifestKeys,
+			selectedManifest: manifestParam,
+			selectedKeys,
+			query,
+			type,
+			showIgnored,
+			limit,
+			offset,
+			total: filtered.length,
+			docs: paged,
+			typeOptions,
+			ignoreList,
+			store: {
+				source: store.source,
+				bucket: store.bucket,
+				ignoreListKey: store.ignoreListKey,
+			},
+		},
+		{ headers: { 'Cache-Control': 'no-store' } },
+	)
+}
+
+function uniqPatterns(patterns: string[]) {
+	const seen = new Set<string>()
+	const result: string[] = []
+	for (const p of patterns) {
+		const trimmed = p.trim()
+		if (!trimmed) continue
+		if (seen.has(trimmed)) continue
+		seen.add(trimmed)
+		result.push(trimmed)
+	}
+	return result
+}
+
+async function deleteVectorsInBatches(ids: string[]) {
+	let deleted = 0
+	for (let i = 0; i < ids.length; i += 500) {
+		const batch = ids.slice(i, i + 500).filter(Boolean)
+		if (batch.length === 0) continue
+		const res = await vectorizeDeleteByIds({ ids: batch })
+		// Best-effort: Cloudflare returns { result: { deleted } } or { deleted } in mocks.
+		const asAny = res as any
+		const next =
+			typeof asAny?.result?.deleted === 'number'
+				? asAny.result.deleted
+				: typeof asAny?.deleted === 'number'
+					? asAny.deleted
+					: 0
+		deleted += next
+	}
+	return deleted
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	await requireAdminUser(request)
+
+	const { store, configured } = getSemanticSearchAdminStore()
+	if (!store || !configured) {
+		return json(
+			{ ok: false, error: 'R2 is not configured for /search/admin.' },
+			{ status: 503 },
+		)
+	}
+
+	const formData = await request.formData()
+	const intent = formData.get('intent')
+	invariant(typeof intent === 'string', 'intent must be a string')
+
+	if (intent === 'ignore-add') {
+		const pattern = String(formData.get('pattern') ?? '').trim()
+		if (!pattern)
+			return json({ ok: false, error: 'pattern is required' }, { status: 400 })
+
+		const ignoreList = await store.getIgnoreList()
+		const patterns = uniqPatterns([...(ignoreList.patterns ?? []), pattern])
+		await store.putIgnoreList({
+			version: 1,
+			updatedAt: new Date().toISOString(),
+			patterns,
+		})
+		return json({ ok: true })
+	}
+
+	if (intent === 'ignore-remove') {
+		const pattern = String(formData.get('pattern') ?? '').trim()
+		if (!pattern)
+			return json({ ok: false, error: 'pattern is required' }, { status: 400 })
+
+		const ignoreList = await store.getIgnoreList()
+		const patterns = (ignoreList.patterns ?? [])
+			.map((p) => p.trim())
+			.filter(Boolean)
+		await store.putIgnoreList({
+			version: 1,
+			updatedAt: new Date().toISOString(),
+			patterns: patterns.filter((p) => p !== pattern),
+		})
+		return json({ ok: true })
+	}
+
+	if (intent === 'doc-delete') {
+		const docId = String(formData.get('docId') ?? '').trim()
+		const scope = String(formData.get('scope') ?? 'manifest')
+		const manifestKey = String(formData.get('manifestKey') ?? '').trim()
+		const addToIgnore = String(formData.get('addToIgnore') ?? '') === 'true'
+		if (!docId)
+			return json({ ok: false, error: 'docId is required' }, { status: 400 })
+
+		const manifestKeys =
+			scope === 'all'
+				? await store.listManifestKeys()
+				: manifestKey
+					? [manifestKey]
+					: await store.listManifestKeys()
+
+		const vectorIdsToDelete: string[] = []
+		const updatedManifests: string[] = []
+
+		for (const key of manifestKeys) {
+			const manifest = await store.getManifest(key)
+			if (!manifest?.docs?.[docId]) continue
+			const next: SemanticSearchManifest = structuredClone(manifest)
+			const doc = next.docs[docId]
+			if (doc?.chunks?.length) {
+				for (const c of doc.chunks) {
+					if (c?.id) vectorIdsToDelete.push(String(c.id))
+				}
+			}
+			delete next.docs[docId]
+			await store.putManifest(key, next)
+			updatedManifests.push(key)
+		}
+
+		let deletedVectors = 0
+		let vectorDeleteSkipped = false
+		if (vectorIdsToDelete.length) {
+			if (!isSemanticSearchConfigured()) {
+				vectorDeleteSkipped = true
+			} else {
+				deletedVectors = await deleteVectorsInBatches(vectorIdsToDelete)
+			}
+		}
+
+		if (addToIgnore) {
+			const ignoreList = await store.getIgnoreList()
+			const patterns = uniqPatterns([...(ignoreList.patterns ?? []), docId])
+			await store.putIgnoreList({
+				version: 1,
+				updatedAt: new Date().toISOString(),
+				patterns,
+			})
+		}
+
+		return json({
+			ok: true,
+			docId,
+			updatedManifests,
+			vectorIdsRequested: vectorIdsToDelete.length,
+			deletedVectors,
+			vectorDeleteSkipped,
+		})
+	}
+
+	return json(
+		{ ok: false, error: `Unknown intent: ${intent}` },
+		{ status: 400 },
+	)
+}
+
+export default function SearchAdminRoute() {
+	const data = useLoaderData<Route.ComponentProps['loaderData']>()
+	const [searchParams] = useSearchParams()
+	const submit = useSubmit()
+
+	const syncGetForm = useDebounce((form: HTMLFormElement) => {
+		void submit(form, { replace: true })
+	}, 350)
+
+	const ignoreAddFetcher = useFetcher<typeof action>()
+	const ignoreAddRef = React.useRef<HTMLInputElement>(null)
+
+	const nextOffset = data.offset + data.limit
+	const prevOffset = Math.max(0, data.offset - data.limit)
+	const hasPrev = data.offset > 0
+	const hasNext = nextOffset < data.total
+
+	return (
+		<main className="mt-12 mb-24 lg:mt-24 lg:mb-48">
+			<Grid>
+				<div className="col-span-full">
+					<H2>Semantic Search Admin</H2>
+					<Paragraph textColorClassName="text-secondary">
+						Inspect and curate semantic-search manifests; delete docs from the
+						Vectorize index; manage an ignore list to prevent re-indexing.
+					</Paragraph>
+				</div>
+
+				<Spacer size="2xs" className="col-span-full" />
+
+				{data.message ? (
+					<div className="col-span-full">
+						<ErrorPanel>{data.message}</ErrorPanel>
+					</div>
+				) : null}
+
+				{data.store ? (
+					<div className="col-span-full">
+						<Paragraph textColorClassName="text-secondary">
+							Store: {data.store.source} • Bucket: {data.store.bucket} • Ignore
+							list key: {data.store.ignoreListKey}
+						</Paragraph>
+					</div>
+				) : null}
+
+				<Spacer size="2xs" className="col-span-full" />
+
+				<div className="col-span-full">
+					<H3>Browse</H3>
+					<Form
+						method="get"
+						className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-12"
+						onChange={(e) => syncGetForm(e.currentTarget)}
+					>
+						<div className="md:col-span-4">
+							<label className="block text-sm font-medium">Manifest</label>
+							<select
+								name="manifest"
+								defaultValue={data.selectedManifest}
+								className={inputClassName}
+							>
+								<option value="all">All manifests</option>
+								{data.manifestKeys.map((k) => (
+									<option key={k} value={k}>
+										{k}
+									</option>
+								))}
+							</select>
+						</div>
+
+						<div className="md:col-span-4">
+							<Field
+								label="Query"
+								name="q"
+								defaultValue={searchParams.get('q') ?? ''}
+								placeholder="Filter by title/url/docId/snippet..."
+							/>
+						</div>
+
+						<div className="md:col-span-2">
+							<label className="block text-sm font-medium">Type</label>
+							<select
+								name="type"
+								defaultValue={data.type}
+								className={inputClassName}
+							>
+								<option value="">All</option>
+								{data.typeOptions.map((o) => (
+									<option key={o.type} value={o.type}>
+										{o.type} ({o.count})
+									</option>
+								))}
+							</select>
+						</div>
+
+						<div className="md:col-span-2">
+							<Field
+								label="Limit"
+								name="limit"
+								type="number"
+								step="1"
+								min="10"
+								max="500"
+								defaultValue={String(data.limit)}
+							/>
+						</div>
+
+						<input type="hidden" name="offset" value={String(data.offset)} />
+
+						<div className="flex items-center gap-3 md:col-span-12">
+							<label className="flex items-center gap-2 text-sm">
+								<input
+									type="checkbox"
+									name="showIgnored"
+									defaultChecked={data.showIgnored}
+									value="true"
+								/>
+								Show ignored
+							</label>
+							<Paragraph textColorClassName="text-secondary">
+								Showing {data.docs.length} of {data.total} docs
+							</Paragraph>
+						</div>
+					</Form>
+
+					<div className="mt-4 flex items-center gap-2">
+						<Button
+							as="button"
+							type="button"
+							disabled={!hasPrev}
+							onClick={() => {
+								const next = new URLSearchParams(searchParams)
+								next.set('offset', String(prevOffset))
+								void submit(next, { method: 'get', replace: true })
+							}}
+						>
+							Prev
+						</Button>
+						<Button
+							as="button"
+							type="button"
+							disabled={!hasNext}
+							onClick={() => {
+								const next = new URLSearchParams(searchParams)
+								next.set('offset', String(nextOffset))
+								void submit(next, { method: 'get', replace: true })
+							}}
+						>
+							Next
+						</Button>
+					</div>
+				</div>
+
+				<Spacer size="xs" className="col-span-full" />
+
+				<div className="col-span-full md:col-span-5">
+					<H3>Ignore list</H3>
+					<Paragraph textColorClassName="text-secondary">
+						Patterns match manifest doc IDs like `youtube:dQw4w9WgXcQ`. Use a
+						trailing `*` for prefixes (ex: `youtube:*`).
+					</Paragraph>
+
+					<ignoreAddFetcher.Form
+						method="post"
+						className="mt-3 flex items-end gap-2"
+						onSubmit={() => {
+							// Keep typing fast.
+							setTimeout(() => {
+								ignoreAddRef.current?.focus()
+							}, 0)
+						}}
+					>
+						<input type="hidden" name="intent" value="ignore-add" />
+						<div className="flex-1">
+							<label className="block text-sm font-medium" htmlFor="pattern">
+								Add pattern
+							</label>
+							<input
+								ref={ignoreAddRef}
+								id="pattern"
+								name="pattern"
+								type="text"
+								placeholder="youtube:abc123 or youtube:*"
+								className={inputClassName}
+							/>
+						</div>
+						<Button type="submit" disabled={ignoreAddFetcher.state !== 'idle'}>
+							{ignoreAddFetcher.state === 'idle' ? 'Add' : 'Adding...'}
+						</Button>
+					</ignoreAddFetcher.Form>
+
+					<ul className="mt-4 space-y-2">
+						{(data.ignoreList.patterns ?? []).length ? (
+							(data.ignoreList.patterns ?? []).map((pattern) => (
+								<IgnorePatternRow key={pattern} pattern={pattern} />
+							))
+						) : (
+							<li>
+								<Paragraph textColorClassName="text-secondary">
+									No ignore patterns yet.
+								</Paragraph>
+							</li>
+						)}
+					</ul>
+				</div>
+
+				<div className="col-span-full md:col-span-7">
+					<H3>Docs</H3>
+					<div className="mt-3 space-y-4">
+						{data.docs.length ? (
+							data.docs.map((doc) => (
+								<DocCard key={`${doc.manifestKey}:${doc.docId}`} doc={doc} />
+							))
+						) : (
+							<Paragraph textColorClassName="text-secondary">
+								No docs match the current filters.
+							</Paragraph>
+						)}
+					</div>
+				</div>
+			</Grid>
+		</main>
+	)
+}
+
+function IgnorePatternRow({ pattern }: { pattern: string }) {
+	const fetcher = useFetcher<typeof action>()
+	const dc = useDoubleCheck()
+	return (
+		<li className="flex items-center justify-between gap-3 rounded-lg bg-gray-100 p-3 dark:bg-gray-800">
+			<code className="min-w-0 flex-1 truncate text-sm">{pattern}</code>
+			<fetcher.Form method="post">
+				<input type="hidden" name="intent" value="ignore-remove" />
+				<input type="hidden" name="pattern" value={pattern} />
+				<Button
+					size="small"
+					variant="danger"
+					{...dc.getButtonProps({ type: 'submit' })}
+					disabled={fetcher.state !== 'idle'}
+				>
+					{fetcher.state === 'idle'
+						? dc.doubleCheck
+							? 'You sure?'
+							: 'Remove'
+						: 'Removing...'}
+				</Button>
+			</fetcher.Form>
+		</li>
+	)
+}
+
+function DocCard({ doc }: { doc: DocRow }) {
+	const deleteFetcher = useFetcher<typeof action>()
+	const ignoreFetcher = useFetcher<typeof action>()
+	const deleteDc = useDoubleCheck()
+	const ignoreDc = useDoubleCheck()
+
+	const isDeleting = deleteFetcher.state !== 'idle'
+	const isIgnoring = ignoreFetcher.state !== 'idle'
+
+	return (
+		<div className="rounded-lg bg-gray-100 p-4 dark:bg-gray-800">
+			<div className="flex flex-wrap items-start justify-between gap-3">
+				<div className="min-w-0 flex-1">
+					<H4 className="truncate">
+						{doc.url ? (
+							<Link to={doc.url} className="underline">
+								{doc.title}
+							</Link>
+						) : (
+							doc.title
+						)}
+					</H4>
+					<Paragraph textColorClassName="text-secondary">
+						<code>{doc.docId}</code> • <code>{doc.type}</code> • chunks:{' '}
+						{doc.chunkCount}
+						{doc.sourceUpdatedAt
+							? ` • sourceUpdatedAt: ${doc.sourceUpdatedAt}`
+							: ''}
+						{doc.transcriptSource
+							? ` • transcript: ${doc.transcriptSource}`
+							: ''}
+					</Paragraph>
+					<Paragraph textColorClassName="text-secondary">
+						Manifest: <code>{doc.manifestKey}</code>
+						{doc.ignored ? ' • ignored' : ''}
+					</Paragraph>
+				</div>
+
+				<div className="flex shrink-0 flex-wrap items-center gap-2">
+					<ignoreFetcher.Form method="post">
+						<input type="hidden" name="intent" value="ignore-add" />
+						<input type="hidden" name="pattern" value={doc.docId} />
+						<Button
+							size="small"
+							variant="secondary"
+							{...ignoreDc.getButtonProps({ type: 'submit' })}
+							disabled={isIgnoring}
+							title="Adds an exact ignore pattern for this doc ID"
+						>
+							{isIgnoring
+								? 'Ignoring...'
+								: ignoreDc.doubleCheck
+									? 'Confirm'
+									: 'Ignore'}
+						</Button>
+					</ignoreFetcher.Form>
+
+					<deleteFetcher.Form method="post">
+						<input type="hidden" name="intent" value="doc-delete" />
+						<input type="hidden" name="docId" value={doc.docId} />
+						<input type="hidden" name="manifestKey" value={doc.manifestKey} />
+						<input type="hidden" name="scope" value="manifest" />
+						<input type="hidden" name="addToIgnore" value="false" />
+						<Button
+							size="small"
+							variant="danger"
+							{...deleteDc.getButtonProps({ type: 'submit' })}
+							disabled={isDeleting}
+						>
+							{isDeleting
+								? 'Deleting...'
+								: deleteDc.doubleCheck
+									? 'You sure?'
+									: 'Delete'}
+						</Button>
+					</deleteFetcher.Form>
+
+					<deleteFetcher.Form method="post">
+						<input type="hidden" name="intent" value="doc-delete" />
+						<input type="hidden" name="docId" value={doc.docId} />
+						<input type="hidden" name="manifestKey" value={doc.manifestKey} />
+						<input type="hidden" name="scope" value="manifest" />
+						<input type="hidden" name="addToIgnore" value="true" />
+						<Button
+							size="small"
+							variant="danger"
+							disabled={isDeleting}
+							title="Deletes now and adds this docId to ignore list"
+						>
+							Delete + ignore
+						</Button>
+					</deleteFetcher.Form>
+				</div>
+			</div>
+
+			{deleteFetcher.data?.ok === false ? (
+				<div className="mt-3">
+					<ErrorPanel>
+						{String(deleteFetcher.data.error ?? 'Delete failed')}
+					</ErrorPanel>
+				</div>
+			) : null}
+
+			{deleteFetcher.data?.ok === true ? (
+				<div className="mt-3">
+					<Paragraph textColorClassName="text-secondary">
+						Delete result: vectors requested{' '}
+						{deleteFetcher.data.vectorIdsRequested},{' '}
+						{deleteFetcher.data.vectorDeleteSkipped
+							? 'Vectorize delete skipped (semantic search env not configured)'
+							: `deleted ${deleteFetcher.data.deletedVectors}`}
+						.
+					</Paragraph>
+				</div>
+			) : null}
+
+			<details className="mt-4">
+				<summary className="cursor-pointer text-sm text-slate-600 dark:text-slate-300">
+					View chunk snippets
+				</summary>
+				<ul className="mt-3 space-y-2">
+					{doc.chunks.map((c) => (
+						<li key={c.id} className="rounded bg-white/60 p-3 dark:bg-black/20">
+							<div className="flex flex-wrap items-baseline justify-between gap-2">
+								<code className="text-xs">{c.id}</code>
+								<code className="text-xs text-slate-500">{c.hash}</code>
+							</div>
+							<p className="mt-2 text-sm whitespace-pre-wrap text-slate-700 dark:text-slate-200">
+								{c.snippet}
+							</p>
+						</li>
+					))}
+				</ul>
+			</details>
+		</div>
+	)
+}
+
+export function ErrorBoundary() {
+	const error = useCapturedRouteError()
+	console.error(error)
+	return (
+		<div className="mx-10vw mt-10">
+			<h2>Search admin error</h2>
+			<pre className="whitespace-pre-wrap">{getErrorMessage(error)}</pre>
+		</div>
+	)
+}

--- a/app/routes/search.admin.tsx
+++ b/app/routes/search.admin.tsx
@@ -643,6 +643,7 @@ function DocCard({ doc }: { doc: DocRow }) {
 	const deleteFetcher = useFetcher<typeof action>()
 	const ignoreFetcher = useFetcher<typeof action>()
 	const deleteDc = useDoubleCheck()
+	const deleteIgnoreDc = useDoubleCheck()
 	const ignoreDc = useDoubleCheck()
 
 	const isDeleting = deleteFetcher.state !== 'idle'
@@ -743,10 +744,15 @@ function DocCard({ doc }: { doc: DocRow }) {
 						<Button
 							size="small"
 							variant="danger"
+							{...deleteIgnoreDc.getButtonProps({ type: 'submit' })}
 							disabled={isDeleting}
 							title="Deletes now and adds this docId to ignore list"
 						>
-							Delete + ignore
+							{isDeleting
+								? 'Deleting...'
+								: deleteIgnoreDc.doubleCheck
+									? 'You sure?'
+									: 'Delete + ignore'}
 						</Button>
 					</deleteFetcher.Form>
 				</div>

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -52,6 +52,14 @@ const schema = z.object({
 	CLOUDFLARE_VECTORIZE_INDEX: z.string().optional(),
 	CLOUDFLARE_AI_EMBEDDING_MODEL: z.string().optional(),
 	CLOUDFLARE_AI_TRANSCRIPTION_MODEL: z.string().optional(),
+
+	// Optional: semantic search admin tooling (R2 manifests + ignore list).
+	// Used by /search/admin and by maintenance scripts; not required for the site.
+	R2_BUCKET: z.string().optional(),
+	R2_ENDPOINT: z.string().optional(),
+	R2_ACCESS_KEY_ID: z.string().optional(),
+	R2_SECRET_ACCESS_KEY: z.string().optional(),
+	SEMANTIC_SEARCH_IGNORE_LIST_KEY: z.string().optional(),
 })
 
 declare global {

--- a/app/utils/semantic-search-admin.server.ts
+++ b/app/utils/semantic-search-admin.server.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream'
 import {
 	GetObjectCommand,
 	ListObjectsV2Command,
+	type ListObjectsV2CommandOutput,
 	PutObjectCommand,
 	S3Client,
 } from '@aws-sdk/client-s3'
@@ -217,7 +218,7 @@ async function listKeysFromR2({
 	const keys: string[] = []
 	let token: string | undefined = undefined
 	for (let page = 0; page < 25; page++) {
-		const res = await client.send(
+		const res: ListObjectsV2CommandOutput = await client.send(
 			new ListObjectsV2Command({
 				Bucket: bucket,
 				Prefix: prefix,

--- a/app/utils/semantic-search-admin.server.ts
+++ b/app/utils/semantic-search-admin.server.ts
@@ -86,11 +86,6 @@ let _r2ClientConfig:
 	| { endpoint: string; accessKeyId: string; secretAccessKey: string }
 	| null = null
 
-export function invalidateR2Client() {
-	_r2Client = null
-	_r2ClientConfig = null
-}
-
 function getR2Client() {
 	const { endpoint, accessKeyId, secretAccessKey } = getR2ConfigFromEnv()
 	if (!isNonEmptyString(endpoint)) throw new Error('R2_ENDPOINT is required')

--- a/app/utils/semantic-search-admin.server.ts
+++ b/app/utils/semantic-search-admin.server.ts
@@ -1,0 +1,454 @@
+import { Readable } from 'node:stream'
+import {
+	GetObjectCommand,
+	ListObjectsV2Command,
+	PutObjectCommand,
+	S3Client,
+} from '@aws-sdk/client-s3'
+
+export type SemanticSearchManifestChunk = {
+	id: string
+	hash: string
+	snippet: string
+	chunkIndex: number
+	chunkCount: number
+}
+
+export type SemanticSearchManifestDoc = {
+	type: string
+	url: string
+	title: string
+	chunks: SemanticSearchManifestChunk[]
+	sourceUpdatedAt?: string
+	transcriptSource?: string
+}
+
+export type SemanticSearchManifest = {
+	version: number
+	docs: Record<string, SemanticSearchManifestDoc>
+}
+
+export type SemanticSearchIgnoreList = {
+	version: 1
+	updatedAt?: string
+	/**
+	 * Patterns are matched against doc IDs (ex: `youtube:dQw4w9WgXcQ`).
+	 * Supports:
+	 * - exact match: `blog:my-post`
+	 * - prefix match: `youtube:*` (wildcard is supported only at the end)
+	 */
+	patterns: string[]
+}
+
+export const DEFAULT_IGNORE_LIST_KEY = 'manifests/ignore-list.json'
+export const DEFAULT_MANIFEST_PREFIX = 'manifests/'
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.trim().length > 0
+}
+
+function normalizePattern(pattern: string) {
+	return pattern.trim()
+}
+
+export function matchesIgnorePattern(docId: string, pattern: string) {
+	const normalized = normalizePattern(pattern)
+	if (!normalized) return false
+	if (normalized.endsWith('*')) {
+		const prefix = normalized.slice(0, -1)
+		return docId.startsWith(prefix)
+	}
+	return docId === normalized
+}
+
+export function isDocIdIgnored({
+	docId,
+	ignoreList,
+}: {
+	docId: string
+	ignoreList: SemanticSearchIgnoreList
+}) {
+	return (ignoreList.patterns ?? []).some((p) => matchesIgnorePattern(docId, p))
+}
+
+export type SemanticSearchAdminStore = {
+	source: 'r2' | 'fixtures'
+	bucket: string
+	ignoreListKey: string
+	listManifestKeys: () => Promise<string[]>
+	getManifest: (key: string) => Promise<SemanticSearchManifest | null>
+	putManifest: (key: string, value: SemanticSearchManifest) => Promise<void>
+	getIgnoreList: () => Promise<SemanticSearchIgnoreList>
+	putIgnoreList: (value: SemanticSearchIgnoreList) => Promise<void>
+}
+
+function getIgnoreListKey() {
+	return process.env.SEMANTIC_SEARCH_IGNORE_LIST_KEY ?? DEFAULT_IGNORE_LIST_KEY
+}
+
+function getR2Bucket() {
+	return process.env.R2_BUCKET ?? 'kcd-semantic-search'
+}
+
+function getR2ConfigFromEnv() {
+	const endpoint = process.env.R2_ENDPOINT
+	const accessKeyId = process.env.R2_ACCESS_KEY_ID
+	const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY
+	return { endpoint, accessKeyId, secretAccessKey }
+}
+
+export function isR2S3Configured() {
+	const { endpoint, accessKeyId, secretAccessKey } = getR2ConfigFromEnv()
+	return Boolean(
+		isNonEmptyString(endpoint) &&
+		isNonEmptyString(accessKeyId) &&
+		isNonEmptyString(secretAccessKey),
+	)
+}
+
+let _r2Client: S3Client | null = null
+function getR2Client() {
+	if (_r2Client) return _r2Client
+	const { endpoint, accessKeyId, secretAccessKey } = getR2ConfigFromEnv()
+	if (!isNonEmptyString(endpoint)) throw new Error('R2_ENDPOINT is required')
+	if (!isNonEmptyString(accessKeyId))
+		throw new Error('R2_ACCESS_KEY_ID is required')
+	if (!isNonEmptyString(secretAccessKey))
+		throw new Error('R2_SECRET_ACCESS_KEY is required')
+
+	_r2Client = new S3Client({
+		region: 'auto',
+		endpoint,
+		forcePathStyle: true,
+		credentials: { accessKeyId, secretAccessKey },
+	})
+	return _r2Client
+}
+
+async function streamToString(body: unknown) {
+	if (!body) return ''
+	if (typeof body === 'string') return body
+	if (body instanceof Uint8Array) return Buffer.from(body).toString('utf8')
+	// AWS SDK v3 SdkStream mixin for Node adds transformToString.
+	if (
+		typeof body === 'object' &&
+		body !== null &&
+		'transformToString' in body &&
+		typeof (body as any).transformToString === 'function'
+	) {
+		return await (body as any).transformToString('utf-8')
+	}
+
+	if (body instanceof Readable) {
+		const chunks: Buffer[] = []
+		for await (const chunk of body) {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+		}
+		return Buffer.concat(chunks).toString('utf8')
+	}
+
+	return String(body)
+}
+
+function isNotFoundError(error: unknown) {
+	if (!error || typeof error !== 'object') return false
+	const anyErr = error as any
+	const name = typeof anyErr.name === 'string' ? anyErr.name : ''
+	const status = anyErr?.$metadata?.httpStatusCode
+	if (name === 'NoSuchKey' || name === 'NotFound') return true
+	if (status === 404) return true
+	const message = typeof anyErr.message === 'string' ? anyErr.message : ''
+	return /NoSuchKey|not found/i.test(message)
+}
+
+async function getJsonFromR2<T>({
+	client,
+	bucket,
+	key,
+}: {
+	client: S3Client
+	bucket: string
+	key: string
+}): Promise<T | null> {
+	try {
+		const res = await client.send(
+			new GetObjectCommand({ Bucket: bucket, Key: key }),
+		)
+		const text = await streamToString(res.Body)
+		if (!text.trim()) return null
+		return JSON.parse(text) as T
+	} catch (error: unknown) {
+		if (isNotFoundError(error)) return null
+		throw error
+	}
+}
+
+async function putJsonToR2({
+	client,
+	bucket,
+	key,
+	value,
+}: {
+	client: S3Client
+	bucket: string
+	key: string
+	value: unknown
+}) {
+	const body = JSON.stringify(value, null, 2)
+	await client.send(
+		new PutObjectCommand({
+			Bucket: bucket,
+			Key: key,
+			Body: body,
+			ContentType: 'application/json; charset=utf-8',
+		}),
+	)
+}
+
+async function listKeysFromR2({
+	client,
+	bucket,
+	prefix,
+}: {
+	client: S3Client
+	bucket: string
+	prefix: string
+}) {
+	const keys: string[] = []
+	let token: string | undefined = undefined
+	for (let page = 0; page < 25; page++) {
+		const res = await client.send(
+			new ListObjectsV2Command({
+				Bucket: bucket,
+				Prefix: prefix,
+				ContinuationToken: token,
+			}),
+		)
+		for (const item of res.Contents ?? []) {
+			const key = item.Key
+			if (typeof key === 'string') keys.push(key)
+		}
+		if (!res.IsTruncated) break
+		token = res.NextContinuationToken
+		if (!token) break
+	}
+	return keys
+}
+
+function getDefaultIgnoreList(): SemanticSearchIgnoreList {
+	return { version: 1, updatedAt: new Date().toISOString(), patterns: [] }
+}
+
+function createR2AdminStore(): SemanticSearchAdminStore {
+	const client = getR2Client()
+	const bucket = getR2Bucket()
+	const ignoreListKey = getIgnoreListKey()
+
+	return {
+		source: 'r2',
+		bucket,
+		ignoreListKey,
+		listManifestKeys: async () => {
+			const keys = await listKeysFromR2({
+				client,
+				bucket,
+				prefix: DEFAULT_MANIFEST_PREFIX,
+			})
+			return keys
+				.filter((k) => k.endsWith('.json'))
+				.filter((k) => k !== ignoreListKey)
+				.sort((a, b) => a.localeCompare(b))
+		},
+		getManifest: async (key) => {
+			return await getJsonFromR2<SemanticSearchManifest>({
+				client,
+				bucket,
+				key,
+			})
+		},
+		putManifest: async (key, value) => {
+			await putJsonToR2({ client, bucket, key, value })
+		},
+		getIgnoreList: async () => {
+			return (
+				(await getJsonFromR2<SemanticSearchIgnoreList>({
+					client,
+					bucket,
+					key: ignoreListKey,
+				})) ?? getDefaultIgnoreList()
+			)
+		},
+		putIgnoreList: async (value) => {
+			await putJsonToR2({ client, bucket, key: ignoreListKey, value })
+		},
+	}
+}
+
+const FIXTURE_R2_OBJECTS: Record<string, unknown> = {
+	'manifests/repo-content.json': {
+		version: 1,
+		docs: {
+			'blog:super-simple-start-to-remix': {
+				type: 'blog',
+				url: '/blog/super-simple-start-to-remix',
+				title: 'Super Simple Start to Remix',
+				chunks: [
+					{
+						id: 'blog:super-simple-start-to-remix:chunk:0',
+						hash: 'fixture-hash-blog-0',
+						snippet: 'Fixture snippet: this represents indexed blog content…',
+						chunkIndex: 0,
+						chunkCount: 2,
+					},
+					{
+						id: 'blog:super-simple-start-to-remix:chunk:1',
+						hash: 'fixture-hash-blog-1',
+						snippet: 'Fixture snippet: second chunk…',
+						chunkIndex: 1,
+						chunkCount: 2,
+					},
+				],
+			},
+			'page:uses': {
+				type: 'page',
+				url: '/uses',
+				title: 'Uses',
+				chunks: [
+					{
+						id: 'page:uses:chunk:0',
+						hash: 'fixture-hash-page-0',
+						snippet: 'Fixture snippet: page content…',
+						chunkIndex: 0,
+						chunkCount: 1,
+					},
+				],
+			},
+		},
+	},
+	'manifests/podcasts.json': {
+		version: 1,
+		docs: {
+			'ck:s01e01': {
+				type: 'ck',
+				url: '/calls/1/1',
+				title: 'Fixture Call Kent Episode',
+				sourceUpdatedAt: '2026-02-01T00:00:00.000Z',
+				chunks: [
+					{
+						id: 'ck:s01e01:chunk:0',
+						hash: 'fixture-hash-ck-0',
+						snippet: 'Fixture snippet: podcast summary…',
+						chunkIndex: 0,
+						chunkCount: 1,
+					},
+				],
+			},
+		},
+	},
+	'manifests/youtube-PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf.json': {
+		version: 1,
+		docs: {
+			'youtube:dQw4w9WgXcQ': {
+				type: 'youtube',
+				url: '/youtube?video=dQw4w9WgXcQ',
+				title: 'Fixture YouTube Video',
+				sourceUpdatedAt: '2026-02-01',
+				transcriptSource: 'manual',
+				chunks: [
+					{
+						id: 'youtube:dQw4w9WgXcQ:chunk:0',
+						hash: 'fixture-hash-yt-0',
+						snippet: 'Fixture snippet: transcript chunk…',
+						chunkIndex: 0,
+						chunkCount: 3,
+					},
+					{
+						id: 'youtube:dQw4w9WgXcQ:chunk:1',
+						hash: 'fixture-hash-yt-1',
+						snippet: 'Fixture snippet: another transcript chunk…',
+						chunkIndex: 1,
+						chunkCount: 3,
+					},
+					{
+						id: 'youtube:dQw4w9WgXcQ:chunk:2',
+						hash: 'fixture-hash-yt-2',
+						snippet: 'Fixture snippet: third transcript chunk…',
+						chunkIndex: 2,
+						chunkCount: 3,
+					},
+				],
+			},
+		},
+	},
+	[DEFAULT_IGNORE_LIST_KEY]: {
+		version: 1,
+		updatedAt: '2026-02-20T00:00:00.000Z',
+		patterns: [],
+	},
+}
+
+let _fixtureStore: SemanticSearchAdminStore | null = null
+function createFixtureAdminStore(): SemanticSearchAdminStore {
+	if (_fixtureStore) return _fixtureStore
+
+	const bucket = getR2Bucket()
+	const ignoreListKey = getIgnoreListKey()
+	const objects = new Map<string, unknown>(
+		Object.entries(FIXTURE_R2_OBJECTS).map(([k, v]) => [k, structuredClone(v)]),
+	)
+
+	_fixtureStore = {
+		source: 'fixtures',
+		bucket,
+		ignoreListKey,
+		listManifestKeys: async () => {
+			return [...objects.keys()]
+				.filter((k) => k.startsWith(DEFAULT_MANIFEST_PREFIX))
+				.filter((k) => k.endsWith('.json'))
+				.filter((k) => k !== ignoreListKey)
+				.sort((a, b) => a.localeCompare(b))
+		},
+		getManifest: async (key) => {
+			const value = objects.get(key)
+			return value ? (structuredClone(value) as SemanticSearchManifest) : null
+		},
+		putManifest: async (key, value) => {
+			objects.set(key, structuredClone(value))
+		},
+		getIgnoreList: async () => {
+			const value = objects.get(ignoreListKey)
+			return value
+				? (structuredClone(value) as SemanticSearchIgnoreList)
+				: getDefaultIgnoreList()
+		},
+		putIgnoreList: async (value) => {
+			objects.set(ignoreListKey, structuredClone(value))
+		},
+	}
+
+	return _fixtureStore
+}
+
+export function getSemanticSearchAdminStore(): {
+	store: SemanticSearchAdminStore | null
+	configured: boolean
+	message?: string
+} {
+	if (isR2S3Configured()) {
+		return { store: createR2AdminStore(), configured: true }
+	}
+	if (process.env.MOCKS === 'true') {
+		return {
+			store: createFixtureAdminStore(),
+			configured: true,
+			message:
+				'Using fixture semantic-search manifests (set R2_ENDPOINT/R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY to use real R2).',
+		}
+	}
+	return {
+		store: null,
+		configured: false,
+		message:
+			'R2 is not configured. Set R2_ENDPOINT, R2_ACCESS_KEY_ID, and R2_SECRET_ACCESS_KEY to enable /search/admin.',
+	}
+}

--- a/app/utils/semantic-search.server.ts
+++ b/app/utils/semantic-search.server.ts
@@ -245,6 +245,49 @@ async function queryVectorize({
 	}
 }
 
+export async function vectorizeDeleteByIds({
+	ids,
+}: {
+	ids: string[]
+}): Promise<unknown> {
+	const { accountId, apiToken, indexName } = getRequiredSemanticSearchEnv()
+	if (!accountId || !apiToken || !indexName) {
+		throw new Error(
+			'Semantic search is not configured. Set CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, and CLOUDFLARE_VECTORIZE_INDEX.',
+		)
+	}
+	if (!Array.isArray(ids) || ids.length === 0) {
+		return { result: { deleted: 0 } }
+	}
+
+	const body = JSON.stringify({ ids })
+	try {
+		const res = await cloudflareFetch(
+			accountId,
+			apiToken,
+			`/vectorize/v2/indexes/${indexName}/delete_by_ids`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body,
+			},
+		)
+		return (await res.json()) as unknown
+	} catch {
+		const res = await cloudflareFetch(
+			accountId,
+			apiToken,
+			`/vectorize/indexes/${indexName}/delete_by_ids`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body,
+			},
+		)
+		return (await res.json()) as unknown
+	}
+}
+
 export type SemanticSearchResult = {
 	id: string
 	score: number

--- a/other/semantic-search/__tests__/ignore-list.test.ts
+++ b/other/semantic-search/__tests__/ignore-list.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { isDocIdIgnored, matchesIgnorePattern } from '../ignore-list.ts'
+
+describe('semantic search ignore list', () => {
+	test('matches exact doc IDs', () => {
+		expect(
+			matchesIgnorePattern('youtube:dQw4w9WgXcQ', 'youtube:dQw4w9WgXcQ'),
+		).toBe(true)
+		expect(matchesIgnorePattern('youtube:dQw4w9WgXcQ', 'youtube:other')).toBe(
+			false,
+		)
+		expect(matchesIgnorePattern('blog:hello', 'blog:hello')).toBe(true)
+		expect(matchesIgnorePattern('blog:hello', 'blog:hello ')).toBe(true)
+	})
+
+	test('matches prefix patterns ending with *', () => {
+		expect(matchesIgnorePattern('youtube:dQw4w9WgXcQ', 'youtube:*')).toBe(true)
+		expect(matchesIgnorePattern('blog:react-hooks', 'blog:react*')).toBe(true)
+		expect(matchesIgnorePattern('page:uses', 'blog:*')).toBe(false)
+	})
+
+	test('isDocIdIgnored checks the ignore list patterns', () => {
+		const ignoreList = {
+			version: 1 as const,
+			updatedAt: '2026-02-20T00:00:00.000Z',
+			patterns: ['youtube:*', 'blog:secret-post'],
+		}
+
+		expect(isDocIdIgnored({ docId: 'youtube:anything', ignoreList })).toBe(true)
+		expect(isDocIdIgnored({ docId: 'blog:secret-post', ignoreList })).toBe(true)
+		expect(isDocIdIgnored({ docId: 'blog:public-post', ignoreList })).toBe(
+			false,
+		)
+	})
+})

--- a/other/semantic-search/__tests__/ignore-list.test.ts
+++ b/other/semantic-search/__tests__/ignore-list.test.ts
@@ -17,6 +17,9 @@ describe('semantic search ignore list', () => {
 		expect(matchesIgnorePattern('youtube:dQw4w9WgXcQ', 'youtube:*')).toBe(true)
 		expect(matchesIgnorePattern('blog:react-hooks', 'blog:react*')).toBe(true)
 		expect(matchesIgnorePattern('page:uses', 'blog:*')).toBe(false)
+		// A bare '*' is an empty prefix and therefore matches every doc ID.
+		expect(matchesIgnorePattern('youtube:anything', '*')).toBe(true)
+		expect(matchesIgnorePattern('blog:some-post', '*')).toBe(true)
 	})
 
 	test('isDocIdIgnored checks the ignore list patterns', () => {

--- a/other/semantic-search/ignore-list-patterns.ts
+++ b/other/semantic-search/ignore-list-patterns.ts
@@ -1,0 +1,44 @@
+export type SemanticSearchIgnoreList = {
+	version: 1
+	updatedAt?: string
+	/**
+	 * Patterns are matched against doc IDs (ex: `youtube:dQw4w9WgXcQ`).
+	 * Supports:
+	 * - exact match: `blog:my-post`
+	 * - prefix match: `youtube:*` (wildcard is supported only at the end)
+	 *
+	 * Note: a bare `*` matches every doc ID (empty prefix).
+	 */
+	patterns: string[]
+}
+
+export const DEFAULT_IGNORE_LIST_KEY = 'manifests/ignore-list.json'
+
+function normalizePattern(pattern: string) {
+	return pattern.trim()
+}
+
+export function matchesIgnorePattern(docId: string, pattern: string) {
+	const normalized = normalizePattern(pattern)
+	if (!normalized) return false
+	if (normalized.endsWith('*')) {
+		const prefix = normalized.slice(0, -1)
+		return docId.startsWith(prefix)
+	}
+	return docId === normalized
+}
+
+export function isDocIdIgnored({
+	docId,
+	ignoreList,
+}: {
+	docId: string
+	ignoreList: SemanticSearchIgnoreList
+}) {
+	return (ignoreList.patterns ?? []).some((p) => matchesIgnorePattern(docId, p))
+}
+
+export function getIgnoreListKey() {
+	return process.env.SEMANTIC_SEARCH_IGNORE_LIST_KEY ?? DEFAULT_IGNORE_LIST_KEY
+}
+

--- a/other/semantic-search/ignore-list.ts
+++ b/other/semantic-search/ignore-list.ts
@@ -1,46 +1,19 @@
 import { getJsonObject } from './r2-manifest.ts'
+import {
+	DEFAULT_IGNORE_LIST_KEY,
+	getIgnoreListKey,
+	isDocIdIgnored,
+	matchesIgnorePattern,
+	type SemanticSearchIgnoreList,
+} from './ignore-list-patterns.ts'
 
-export type SemanticSearchIgnoreList = {
-	version: 1
-	updatedAt?: string
-	/**
-	 * Patterns are matched against doc IDs (ex: `youtube:dQw4w9WgXcQ`).
-	 * Supports:
-	 * - exact match: `blog:my-post`
-	 * - prefix match: `youtube:*` (wildcard is supported only at the end)
-	 */
-	patterns: string[]
+export {
+	DEFAULT_IGNORE_LIST_KEY,
+	getIgnoreListKey,
+	isDocIdIgnored,
+	matchesIgnorePattern,
 }
-
-export const DEFAULT_IGNORE_LIST_KEY = 'manifests/ignore-list.json'
-
-function normalizePattern(pattern: string) {
-	return pattern.trim()
-}
-
-export function matchesIgnorePattern(docId: string, pattern: string) {
-	const normalized = normalizePattern(pattern)
-	if (!normalized) return false
-	if (normalized.endsWith('*')) {
-		const prefix = normalized.slice(0, -1)
-		return docId.startsWith(prefix)
-	}
-	return docId === normalized
-}
-
-export function isDocIdIgnored({
-	docId,
-	ignoreList,
-}: {
-	docId: string
-	ignoreList: SemanticSearchIgnoreList
-}) {
-	return (ignoreList.patterns ?? []).some((p) => matchesIgnorePattern(docId, p))
-}
-
-export function getIgnoreListKey() {
-	return process.env.SEMANTIC_SEARCH_IGNORE_LIST_KEY ?? DEFAULT_IGNORE_LIST_KEY
-}
+export type { SemanticSearchIgnoreList }
 
 export async function getSemanticSearchIgnoreList({
 	bucket,
@@ -52,7 +25,6 @@ export async function getSemanticSearchIgnoreList({
 	return (
 		(await getJsonObject<SemanticSearchIgnoreList>({ bucket, key })) ?? {
 			version: 1,
-			updatedAt: new Date().toISOString(),
 			patterns: [],
 		}
 	)

--- a/other/semantic-search/ignore-list.ts
+++ b/other/semantic-search/ignore-list.ts
@@ -1,0 +1,59 @@
+import { getJsonObject } from './r2-manifest.ts'
+
+export type SemanticSearchIgnoreList = {
+	version: 1
+	updatedAt?: string
+	/**
+	 * Patterns are matched against doc IDs (ex: `youtube:dQw4w9WgXcQ`).
+	 * Supports:
+	 * - exact match: `blog:my-post`
+	 * - prefix match: `youtube:*` (wildcard is supported only at the end)
+	 */
+	patterns: string[]
+}
+
+export const DEFAULT_IGNORE_LIST_KEY = 'manifests/ignore-list.json'
+
+function normalizePattern(pattern: string) {
+	return pattern.trim()
+}
+
+export function matchesIgnorePattern(docId: string, pattern: string) {
+	const normalized = normalizePattern(pattern)
+	if (!normalized) return false
+	if (normalized.endsWith('*')) {
+		const prefix = normalized.slice(0, -1)
+		return docId.startsWith(prefix)
+	}
+	return docId === normalized
+}
+
+export function isDocIdIgnored({
+	docId,
+	ignoreList,
+}: {
+	docId: string
+	ignoreList: SemanticSearchIgnoreList
+}) {
+	return (ignoreList.patterns ?? []).some((p) => matchesIgnorePattern(docId, p))
+}
+
+export function getIgnoreListKey() {
+	return process.env.SEMANTIC_SEARCH_IGNORE_LIST_KEY ?? DEFAULT_IGNORE_LIST_KEY
+}
+
+export async function getSemanticSearchIgnoreList({
+	bucket,
+	key = getIgnoreListKey(),
+}: {
+	bucket: string
+	key?: string
+}): Promise<SemanticSearchIgnoreList> {
+	return (
+		(await getJsonObject<SemanticSearchIgnoreList>({ bucket, key })) ?? {
+			version: 1,
+			updatedAt: new Date().toISOString(),
+			patterns: [],
+		}
+	)
+}

--- a/other/semantic-search/ignore-list.ts
+++ b/other/semantic-search/ignore-list.ts
@@ -1,4 +1,3 @@
-import { getJsonObject } from './r2-manifest.ts'
 import {
 	DEFAULT_IGNORE_LIST_KEY,
 	getIgnoreListKey,
@@ -6,6 +5,7 @@ import {
 	matchesIgnorePattern,
 	type SemanticSearchIgnoreList,
 } from './ignore-list-patterns.ts'
+import { getJsonObject } from './r2-manifest.ts'
 
 export {
 	DEFAULT_IGNORE_LIST_KEY,

--- a/other/semantic-search/index-repo-content.ts
+++ b/other/semantic-search/index-repo-content.ts
@@ -14,6 +14,7 @@ import {
 	getJsxPagePathFromSlug,
 	loadJsxPageItemsFromLocalApp,
 } from './jsx-page-content.ts'
+import { getSemanticSearchIgnoreList, isDocIdIgnored } from './ignore-list.ts'
 import { getJsonObject, putJsonObject } from './r2-manifest.ts'
 
 type DocType =
@@ -24,6 +25,28 @@ type DocType =
 	| 'credit'
 	| 'testimonial'
 	| 'jsx-page'
+
+function isDocType(value: string): value is DocType {
+	return (
+		value === 'blog' ||
+		value === 'page' ||
+		value === 'talk' ||
+		value === 'resume' ||
+		value === 'credit' ||
+		value === 'testimonial' ||
+		value === 'jsx-page'
+	)
+}
+
+function parseDocId(docId: string): { type: DocType; slug: string } | null {
+	const i = docId.indexOf(':')
+	if (i <= 0) return null
+	const typeRaw = docId.slice(0, i)
+	const slug = docId.slice(i + 1)
+	if (!slug) return null
+	if (!isDocType(typeRaw)) return null
+	return { type: typeRaw, slug }
+}
 
 type ManifestChunk = {
 	id: string
@@ -683,6 +706,10 @@ async function main() {
 		docs: {},
 	}
 
+	const ignoreList = await getSemanticSearchIgnoreList({ bucket: r2Bucket })
+	const isIgnoredDocId = (docId: string) =>
+		isDocIdIgnored({ docId, ignoreList })
+
 	let docsToIndex: Array<{ type: DocType; slug: string }> = []
 	let docsToDelete: Array<{ type: DocType; slug: string }> = []
 
@@ -756,6 +783,32 @@ async function main() {
 		})
 		docsToIndex = updated.docsToIndex
 		docsToDelete = updated.docsToDelete
+	}
+
+	// Apply ignore list:
+	// - never (re)index ignored docs
+	// - always delete ignored docs currently present in the manifest (even on incremental runs)
+	const beforeIgnoredFilterCount = docsToIndex.length
+	docsToIndex = docsToIndex.filter(
+		(d) => !isIgnoredDocId(getDocId(d.type, d.slug)),
+	)
+	const ignoredDocsInManifest = Object.keys(manifest.docs)
+		.filter((docId) => isIgnoredDocId(docId))
+		.map((docId) => parseDocId(docId))
+		.filter(Boolean) as Array<{ type: DocType; slug: string }>
+	if (ignoredDocsInManifest.length) {
+		docsToDelete = uniqDocRefs([...docsToDelete, ...ignoredDocsInManifest])
+	}
+
+	if (docsToIndex.length !== beforeIgnoredFilterCount) {
+		console.log(
+			`Ignore list: skipped ${beforeIgnoredFilterCount - docsToIndex.length} docs from indexing.`,
+		)
+	}
+	if (ignoredDocsInManifest.length) {
+		console.log(
+			`Ignore list: deleting ${ignoredDocsInManifest.length} docs present in manifest.`,
+		)
 	}
 
 	console.log(`Docs to index: ${docsToIndex.length}`)

--- a/other/semantic-search/index-repo-content.ts
+++ b/other/semantic-search/index-repo-content.ts
@@ -10,11 +10,11 @@ import {
 	vectorizeDeleteByIds,
 	vectorizeUpsert,
 } from './cloudflare.ts'
+import { getSemanticSearchIgnoreList, isDocIdIgnored } from './ignore-list.ts'
 import {
 	getJsxPagePathFromSlug,
 	loadJsxPageItemsFromLocalApp,
 } from './jsx-page-content.ts'
-import { getSemanticSearchIgnoreList, isDocIdIgnored } from './ignore-list.ts'
 import { getJsonObject, putJsonObject } from './r2-manifest.ts'
 
 type DocType =

--- a/other/semantic-search/index-youtube-playlist.ts
+++ b/other/semantic-search/index-youtube-playlist.ts
@@ -9,6 +9,7 @@ import {
 	vectorizeDeleteByIds,
 	vectorizeUpsert,
 } from './cloudflare.ts'
+import { getSemanticSearchIgnoreList, isDocIdIgnored } from './ignore-list.ts'
 import { getJsonObject, putJsonObject } from './r2-manifest.ts'
 
 type DocType = 'youtube'
@@ -524,9 +525,8 @@ type YouTubeBrowseConfig = {
 
 function parseSignatureTimestamp(html: string) {
 	const fromSts = html.match(/"STS":(?<sts>\d+)/)?.groups?.sts
-	const fromSignatureTimestamp = html.match(
-		/"signatureTimestamp":(?<sts>\d+)/,
-	)?.groups?.sts
+	const fromSignatureTimestamp = html.match(/"signatureTimestamp":(?<sts>\d+)/)
+		?.groups?.sts
 	const raw = fromSts ?? fromSignatureTimestamp
 	if (!raw) return null
 	const n = Number(raw)
@@ -743,7 +743,8 @@ async function fetchYouTubePlayerJson({
 		config.apiKey,
 	)}`
 	const playbackContext =
-		typeof signatureTimestamp === 'number' && Number.isFinite(signatureTimestamp)
+		typeof signatureTimestamp === 'number' &&
+		Number.isFinite(signatureTimestamp)
 			? {
 					contentPlaybackContext: {
 						// YouTube now often requires STS for a playable response (and captionTracks).
@@ -1302,6 +1303,32 @@ async function main() {
 		docs: {},
 	}
 
+	const ignoreList = await getSemanticSearchIgnoreList({ bucket: r2Bucket })
+	const isIgnoredVideoId = (videoId: string) =>
+		isDocIdIgnored({
+			docId: getDocId('youtube', videoId),
+			ignoreList,
+		})
+	const ignoredVideos = videos.filter((video) =>
+		isIgnoredVideoId(video.videoId),
+	)
+	if (ignoredVideos.length) {
+		console.log(
+			`Ignore list: skipping ${ignoredVideos.length} videos from discovery/indexing.`,
+		)
+		videos = videos.filter((video) => !isIgnoredVideoId(video.videoId))
+	}
+
+	const ignoredManifestDocIds = Object.keys(manifest.docs).filter((docId) =>
+		isDocIdIgnored({ docId, ignoreList }),
+	)
+	const needsIgnoreRemovals = ignoredManifestDocIds.length > 0
+	if (needsIgnoreRemovals) {
+		console.log(
+			`Ignore list: ${ignoredManifestDocIds.length} docs currently in the manifest will be removed.`,
+		)
+	}
+
 	const discoveredDocIds = new Set(
 		videos.map((v) => getDocId('youtube', v.videoId)),
 	)
@@ -1327,7 +1354,7 @@ async function main() {
 			console.log('Dry run complete. Skipping Vectorize/R2 writes.')
 			return
 		}
-		if (!prune) return
+		if (!prune && !needsIgnoreRemovals) return
 		// If pruning, we still need to update Vectorize + manifest for removals.
 		// (We still had to talk to YouTube to discover the current set.)
 	}
@@ -1390,7 +1417,8 @@ async function main() {
 			})
 			if (useCache) {
 				await writeVideoEnrichedDataCache({ ...cacheKey, data: details }).catch(
-					(error) => console.warn(`Failed to write cache (${video.videoId})`, error),
+					(error) =>
+						console.warn(`Failed to write cache (${video.videoId})`, error),
 				)
 			}
 			return { video, details }
@@ -1419,11 +1447,38 @@ async function main() {
 		text: string
 		metadata: Record<string, unknown>
 	}> = []
-	const nextDocs: Record<string, ManifestDoc> = prune ? {} : { ...manifest.docs }
+	const nextDocs: Record<string, ManifestDoc> = {}
+
+	// In non-prune mode we normally carry forward any existing manifest docs.
+	// The ignore list is an explicit override: ensure ignored docs are removed
+	// from the manifest and their vectors are deleted.
+	if (!prune) {
+		let ignoredFromManifest = 0
+		for (const [docId, oldDoc] of Object.entries(manifest.docs)) {
+			if (isDocIdIgnored({ docId, ignoreList })) {
+				ignoredFromManifest++
+				for (const chunk of oldDoc.chunks ?? []) {
+					if (chunk?.id) idsToDelete.push(String(chunk.id))
+				}
+				continue
+			}
+			nextDocs[docId] = oldDoc
+		}
+		if (ignoredFromManifest) {
+			console.log(
+				`Ignore list: deleting ${ignoredFromManifest} existing manifest docs (non-prune mode).`,
+			)
+		}
+	}
+	if (prune) {
+		// In prune mode we intentionally rebuild `nextDocs` from discovered videos.
+		// (Ignored docs were filtered out of discovery above.)
+	}
 
 	for (const { video, details } of enriched) {
 		const videoId = video.videoId
 		const docId = getDocId('youtube', videoId)
+		if (isDocIdIgnored({ docId, ignoreList })) continue
 		const url = `/youtube?video=${encodeURIComponent(videoId)}`
 		const title = details.title || video.title || `YouTube video ${videoId}`
 		const isFromPlaylist = video.sources.includes('playlist')

--- a/other/semantic-search/index-youtube-playlist.ts
+++ b/other/semantic-search/index-youtube-playlist.ts
@@ -1470,15 +1470,12 @@ async function main() {
 			)
 		}
 	}
-	if (prune) {
-		// In prune mode we intentionally rebuild `nextDocs` from discovered videos.
-		// (Ignored docs were filtered out of discovery above.)
-	}
+	// In prune mode we intentionally rebuild `nextDocs` from discovered videos.
+	// (Ignored docs were filtered out of discovery above.)
 
 	for (const { video, details } of enriched) {
 		const videoId = video.videoId
 		const docId = getDocId('youtube', videoId)
-		if (isDocIdIgnored({ docId, ignoreList })) continue
 		const url = `/youtube?video=${encodeURIComponent(videoId)}`
 		const title = details.title || video.title || `YouTube video ${videoId}`
 		const isFromPlaylist = video.sources.includes('playlist')

--- a/other/semantic-search/readme.md
+++ b/other/semantic-search/readme.md
@@ -61,6 +61,23 @@ Indexed sources (via `index-repo-content.ts`):
 - `content/data/testimonials.yml` (each testimonial author is indexed as its own
   doc)
 
+## Ignore list (prevent re-indexing)
+
+All indexers support an optional ignore list stored in R2 (JSON):
+
+- Key: `manifests/ignore-list.json` (override with
+  `SEMANTIC_SEARCH_IGNORE_LIST_KEY`)
+- Shape:
+  - `{ "version": 1, "patterns": ["youtube:dQw4w9WgXcQ", "youtube:*", "blog:secret-post"] }`
+
+Patterns match doc IDs (keys in the manifests). A trailing `*` acts as a prefix
+wildcard (only supported at the end of the string).
+
+When a doc is ignored, indexers will:
+
+- skip indexing it, even if it would otherwise be discovered, and
+- delete any existing vectors + manifest entries for it.
+
 ## YouTube playlist indexing
 
 Script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.995.0",
         "@conform-to/react": "^1.17.1",
         "@conform-to/zod": "^1.17.1",
         "@epic-web/cachified": "^5.6.1",
@@ -245,6 +246,952 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.995.0.tgz",
+      "integrity": "sha512-r+t8qrQ0m9zoovYOH+wilp/glFRB/E+blsDyWzq2C+9qmyhCAQwaxjLaHM8T/uluAmhtZQIYqOH9ILRnvWtRNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/credential-provider-node": "^3.972.10",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.3",
+        "@aws-sdk/middleware-expect-continue": "^3.972.3",
+        "@aws-sdk/middleware-flexible-checksums": "^3.972.9",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-location-constraint": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.11",
+        "@aws-sdk/middleware-ssec": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/signature-v4-multi-region": "3.995.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.995.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.10",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.23.2",
+        "@smithy/eventstream-serde-browser": "^4.2.8",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
+        "@smithy/eventstream-serde-node": "^4.2.8",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-blob-browser": "^4.2.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/hash-stream-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/md5-js": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.993.0.tgz",
+      "integrity": "sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.993.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.9",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.23.2",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
+      "integrity": "sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/xml-builder": "^3.972.5",
+        "@smithy/core": "^3.23.2",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.0.tgz",
+      "integrity": "sha512-ThlLhTqX68jvoIVv+pryOdb5coP1cX1/MaTbB9xkGDCbWbsqQcLqzPxuSoW1DCnAAIacmXCWpzUNOB9pv+xXQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.9.tgz",
+      "integrity": "sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
+      "integrity": "sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.9.tgz",
+      "integrity": "sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/credential-provider-env": "^3.972.9",
+        "@aws-sdk/credential-provider-http": "^3.972.11",
+        "@aws-sdk/credential-provider-login": "^3.972.9",
+        "@aws-sdk/credential-provider-process": "^3.972.9",
+        "@aws-sdk/credential-provider-sso": "^3.972.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.9",
+        "@aws-sdk/nested-clients": "3.993.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
+      "integrity": "sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.993.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.10.tgz",
+      "integrity": "sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.9",
+        "@aws-sdk/credential-provider-http": "^3.972.11",
+        "@aws-sdk/credential-provider-ini": "^3.972.9",
+        "@aws-sdk/credential-provider-process": "^3.972.9",
+        "@aws-sdk/credential-provider-sso": "^3.972.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.9",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
+      "integrity": "sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.9.tgz",
+      "integrity": "sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.993.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/token-providers": "3.993.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
+      "integrity": "sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.993.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.3.tgz",
+      "integrity": "sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-arn-parser": "^3.972.2",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.3.tgz",
+      "integrity": "sha512-4msC33RZsXQpUKR5QR4HnvBSNCPLGHmB55oDiROqqgyOc+TOfVu2xgi5goA7ms6MdZLeEh2905UfWMnMMF4mRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.972.9.tgz",
+      "integrity": "sha512-E663+r/UQpvF3aJkD40p5ZANVQFsUcbE39jifMtN7wc0t1M0+2gJJp3i75R49aY9OiSX5lfVyPUNjN/BNRCCZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/crc64-nvme": "3.972.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
+      "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.3.tgz",
+      "integrity": "sha512-nIg64CVrsXp67vbK0U1/Is8rik3huS3QkRHn2DRDx4NldrEFMgdkZGI/+cZMKD9k4YOS110Dfu21KZLHrFA/1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
+      "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
+      "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.11.tgz",
+      "integrity": "sha512-Qr0T7ZQTRMOuR6ahxEoJR1thPVovfWrKB2a6KBGR+a8/ELrFodrgHwhq50n+5VMaGuLtGhHiISU3XGsZmtmVXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-arn-parser": "^3.972.2",
+        "@smithy/core": "^3.23.2",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.3.tgz",
+      "integrity": "sha512-dU6kDuULN3o3jEHcjm0c4zWJlY1zWVkjG9NPe9qxYLLpcbdj5kRYBS2DdWYD+1B9f910DezRuws7xDEqKkHQIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
+      "integrity": "sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.993.0",
+        "@smithy/core": "^3.23.2",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
+      "integrity": "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.993.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.9",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.23.2",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
+      "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.995.0.tgz",
+      "integrity": "sha512-9Qx5JcAucnxnomREPb2D6L8K8GLG0rknt3+VK/BU3qTUynAcV4W21DQ04Z2RKDw+DYpW88lsZpXbVetWST2WUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.993.0.tgz",
+      "integrity": "sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.993.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
+      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
+      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
+      "integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
+      "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
+      "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
+      "integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
+      "integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "fast-xml-parser": "5.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -8092,6 +9039,738 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
+      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
+      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
+      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
+      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
+      "integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
+      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
+      "integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
+      "integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
+      "integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
+      "integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
+      "integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
+      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.9.tgz",
+      "integrity": "sha512-m80d/iicI7DlBDxyQP6Th7BW/ejDGiF0bgI754+tiwK0lgMkcaIBgvwwVc7OFbY4eUzpGtnig52MhPAEJ7iNYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.0",
+        "@smithy/chunked-blob-reader-native": "^4.2.1",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
+      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.8.tgz",
+      "integrity": "sha512-v0FLTXgHrTeheYZFGhR+ehX5qUm4IQsjAiL9qehad2cyjMWcN2QG6/4mSwbSgEQzI7jwfoXj7z4fxZUx/Mhj2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
+      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.8.tgz",
+      "integrity": "sha512-oGMaLj4tVZzLi3itBa9TCswgMBr7k9b+qKYowQ6x1rTyTuO1IU2YHdHUa+891OsOH+wCsH7aTPRsTJO3RMQmjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
+      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
+      "integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
+      "integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
+      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
+      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
+      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
+      "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
+      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
+      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
+      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
+      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
+      "integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
+      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
+      "integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.35",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
+      "integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
+      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
+      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
+      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.8.tgz",
+      "integrity": "sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -10698,6 +12377,12 @@
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -14031,6 +15716,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fault": {
       "version": "2.0.1",
@@ -30708,6 +32411,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "setup": "npm install && prisma migrate reset --force && npm run validate && npm run prime-cache:mocks && npm run test:e2e:install && npm run test:e2e:run"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.995.0",
     "@conform-to/react": "^1.17.1",
     "@conform-to/zod": "^1.17.1",
     "@epic-web/cachified": "^5.6.1",


### PR DESCRIPTION
Add `/search/admin` route to inspect and manage semantic search data, and implement an ignore list to prevent re-indexing.

---
<p><a href="https://cursor.com/agents?id=bc-4d4ba2fa-3d86-422b-87ec-e868c935a73b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d4ba2fa-3d86-422b-87ec-e868c935a73b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new admin mutations over R2 manifests and triggers deletions in the Cloudflare Vectorize index, so misconfiguration or misuse could delete indexed data even though access is admin-gated and behavior is straightforward.
> 
> **Overview**
> Adds an admin-only `/search/admin` route to browse semantic-search manifests (with filtering/pagination), manage an ignore list, and delete a doc from one or more manifests while best-effort deleting its associated Vectorize vectors.
> 
> Introduces an R2-backed admin store (`semantic-search-admin.server.ts`) using the S3-compatible API, with a fixture-backed read-only mode when `MOCKS=true`, and wires new R2/ignore-list env vars into `.env.example` and `env.server.ts`.
> 
> Implements a shared ignore-list pattern format (exact match + trailing `*` prefix wildcard), adds unit tests, updates all semantic-search indexer scripts to skip ignored docs and proactively remove ignored docs/vectors already present in manifests, and documents the behavior in `other/semantic-search/readme.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f48c8e3dbfceffc869a8d349f18da8612c99b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic Search admin UI for browsing, filtering, editing manifests, documents, and ignore patterns.
  * Ignore-list support to skip indexing and remove existing vectors for excluded documents.
  * New environment variables to configure R2/S3 storage and batch vector deletion.

* **Documentation**
  * Added docs explaining ignore-list usage, pattern format, and behavior.

* **Tests**
  * Added unit tests for ignore-list matching utilities.

* **Chores**
  * Added AWS S3 client library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->