### PR TITLE
Open issue selection

### DIFF
--- a/content/blog/implementing-a-simple-state-machine-library-in-javascript.mdx
+++ b/content/blog/implementing-a-simple-state-machine-library-in-javascript.mdx
@@ -462,9 +462,9 @@ function createMachine(stateMachineDefinition) {
 > **By virtue of a transition “happening”, states are exited, and entered and
 > the relevant actions are performed**
 
-Ok, so we'll need to call the `action` for the transition, the `onExit` for the
-current state and the `onEnter` for the next state. To do that, we'll also need
-to get the destination state definition as well. Let's do all of that:
+Ok, so we'll need to call the `onExit` for the current state, the `action` for
+the transition, and then the `onEnter` for the next state. To do that, we'll
+also need to get the destination state definition as well. Let's do all of that:
 
 ```js lines=10-16
 function createMachine(stateMachineDefinition) {
@@ -480,8 +480,8 @@ function createMachine(stateMachineDefinition) {
 			const destinationStateDefinition =
 				stateMachineDefinition[destinationState]
 
-			destinationTransition.action()
 			currentStateDefinition.actions.onExit()
+			destinationTransition.action()
 			destinationStateDefinition.actions.onEnter()
 
 			return machine.value
@@ -513,8 +513,8 @@ function createMachine(stateMachineDefinition) {
 			const destinationStateDefinition =
 				stateMachineDefinition[destinationState]
 
-			destinationTransition.action()
 			currentStateDefinition.actions.onExit()
+			destinationTransition.action()
 			destinationStateDefinition.actions.onEnter()
 
 			machine.value = destinationState
@@ -544,8 +544,8 @@ function createMachine(stateMachineDefinition) {
 			const destinationStateDefinition =
 				stateMachineDefinition[destinationState]
 
-			destinationTransition.action()
 			currentStateDefinition.actions.onExit()
+			destinationTransition.action()
 			destinationStateDefinition.actions.onEnter()
 
 			machine.value = destinationState
@@ -609,12 +609,12 @@ get:
 
 ```
 current state: off
-transition action for "switch" in "off" state
 off: onExit
+transition action for "switch" in "off" state
 on: onEnter
 current state: on
-transition action for "switch" in "on" state
 on: onExit
+transition action for "switch" in "on" state
 off: onEnter
 current state: off
 ```

--- a/content/blog/implementing-a-simple-state-machine-library-in-javascript.mdx
+++ b/content/blog/implementing-a-simple-state-machine-library-in-javascript.mdx
@@ -620,7 +620,9 @@ current state: off
 ```
 
 And you can play around with this
-[in codesandbox](https://codesandbox.io/s/example-state-machine-implementation-vnz6c).
+[in codesandbox](https://codesandbox.io/s/example-state-machine-implementation-vnz6c)
+(note: this sandbox predates the `onExit -> action -> onEnter` ordering shown
+above, so the logs use the older `action -> onExit -> onEnter` order).
 
 I hope you found that interesting, informative, and entertaining. If you're
 really like to dive into this stuff further, then definitely give


### PR DESCRIPTION
Reorder state machine transition lifecycle calls in blog post to `onExit` → `action` → `onEnter` to fix issue #499.

---
<p><a href="https://cursor.com/agents?id=bc-61208cfd-12a1-4d7d-99ca-c49c7e3290c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61208cfd-12a1-4d7d-99ca-c49c7e3290c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust example code and expected logs; no production logic is modified.
> 
> **Overview**
> Corrects the blog post’s state machine transition lifecycle ordering to call `onExit` before the transition `action`, followed by `onEnter`, updating all included code snippets accordingly.
> 
> Updates the example console output to match the new ordering and adds a note that the linked CodeSandbox still reflects the previous `action`-first behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4091166bab44eb4eb6df55e3c234c937584f684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated state machine implementation blog post clarifying transition execution order: onExit handlers execute first, followed by the transition action, then onEnter handlers. Examples updated to reflect the correct sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->