### PR TITLE
Open issue resolution

### DIFF
--- a/app/routes/blog_/$slug.tsx
+++ b/app/routes/blog_/$slug.tsx
@@ -15,12 +15,11 @@ import { H2, H4, H6, Paragraph } from '#app/components/typography.tsx'
 import { externalLinks } from '#app/external-links.tsx'
 import { getImageBuilder, getImgProps, images } from '#app/images.tsx'
 import { FavoriteToggle } from '#app/routes/resources/favorite.tsx'
-import { type KCDHandle, type MdxListItem, type Team } from '#app/types.ts'
+import { type KCDHandle, type MdxListItem } from '#app/types.ts'
 import {
 	getBlogReadRankings,
 	getBlogRecommendations,
 	getTotalPostReads,
-	type ReadRankings,
 } from '#app/utils/blog.server.ts'
 import { getRankingLeader } from '#app/utils/blog.ts'
 import { getBlogMdxListItems, getMdxPage } from '#app/utils/mdx.server.ts'

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -15,6 +15,25 @@ const mdxServerMocks = vi.hoisted(() => ({
 
 vi.mock('#app/utils/mdx.server.ts', () => mdxServerMocks)
 
+// The route module imports server DB/session helpers; mock them to avoid
+// requiring DATABASE_URL and an actual SQLite DB in unit tests.
+vi.mock('#app/utils/session.server.ts', () => ({
+	getUser: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('#app/utils/prisma.server.ts', () => ({
+	prisma: {
+		favorite: {
+			findUnique: vi.fn().mockResolvedValue(null),
+		},
+	},
+}))
+
+// The route module imports this component, but tests only exercise the loader.
+vi.mock('#app/routes/resources/favorite.tsx', () => ({
+	FavoriteToggle: () => null,
+}))
+
 // The route module imports this client helper, which otherwise pulls in Prisma.
 vi.mock('../../action/mark-as-read.tsx', () => ({
 	markAsRead: vi.fn(),

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -58,11 +58,17 @@ describe('/blog/:slug loader cache behavior', () => {
 			data: { recommendations: [] },
 			init: {
 				status: 404,
-				headers: { 'Cache-Control': 'private, max-age=3600' },
+				headers: { 'Cache-Control': 'private, max-age=60' },
 			},
 		})
 
 		expect(blogServerMocks.getBlogRecommendations).toHaveBeenCalledTimes(1)
+		expect(blogServerMocks.getBlogRecommendations).toHaveBeenCalledWith(
+			expect.objectContaining({
+				keywords: [],
+				exclude: ['does-not-exist'],
+			}),
+		)
 		expect(blogServerMocks.getBlogReadRankings).not.toHaveBeenCalled()
 		expect(blogServerMocks.getTotalPostReads).not.toHaveBeenCalled()
 	})

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -26,6 +26,11 @@ vi.mock('#app/utils/use-root-data.ts', () => ({
 	useRootData: () => ({ requestInfo: { origin: 'http://localhost' } }),
 }))
 
+// In Vitest, the Vite macro plugin isn't installed, so mock the macro helper.
+vi.mock('vite-env-only/macros', () => ({
+	serverOnly$: (fn: unknown) => fn,
+}))
+
 // Import after mocks so the route loader sees the mocked deps.
 import { loader } from '../$slug.tsx'
 

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -18,6 +18,11 @@ vi.mock('#app/utils/mdx.server.ts', () => ({
 	getBlogMdxListItems,
 }))
 
+// The route module imports this client helper, which otherwise pulls in Prisma.
+vi.mock('../../action/mark-as-read.tsx', () => ({
+	markAsRead: vi.fn(),
+}))
+
 // Import after mocks so the route loader sees the mocked deps.
 import { loader } from '../$slug.tsx'
 

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -53,13 +53,14 @@ describe('/blog/:slug loader cache behavior', () => {
 			thrown = e
 		}
 
-		expect(thrown).toBeInstanceOf(Response)
-		const response = thrown as Response
-		expect(response.status).toBe(404)
-		expect(response.headers.get('Cache-Control')).toBe('private, max-age=3600')
-
-		const data = await response.json()
-		expect(data).toEqual({ recommendations: [] })
+		expect(thrown).toMatchObject({
+			type: 'DataWithResponseInit',
+			data: { recommendations: [] },
+			init: {
+				status: 404,
+				headers: { 'Cache-Control': 'private, max-age=3600' },
+			},
+		})
 
 		expect(blogServerMocks.getBlogRecommendations).toHaveBeenCalledTimes(1)
 		expect(blogServerMocks.getBlogReadRankings).not.toHaveBeenCalled()
@@ -80,11 +81,15 @@ describe('/blog/:slug loader cache behavior', () => {
 		const request = new Request('http://localhost/blog/my-post')
 		const params = { slug: 'my-post' }
 
-		const response = (await loader({ request, params } as any)) as Response
-		expect(response.status).toBe(200)
-
-		const data = await response.json()
-		expect(data).toMatchObject({
+		const result = (await loader({ request, params } as any)) as any
+		expect(result).toMatchObject({
+			type: 'DataWithResponseInit',
+			init: {
+				status: 200,
+				headers: { 'Cache-Control': 'private, max-age=3600' },
+			},
+		})
+		expect(result.data).toMatchObject({
 			page: { slug: 'my-post' },
 			recommendations: [],
 			readRankings: [],

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -46,14 +46,7 @@ describe('/blog/:slug loader cache behavior', () => {
 		const request = new Request('http://localhost/blog/does-not-exist')
 		const params = { slug: 'does-not-exist' }
 
-		let thrown: unknown
-		try {
-			await loader({ request, params } as any)
-		} catch (e) {
-			thrown = e
-		}
-
-		expect(thrown).toMatchObject({
+		await expect(loader({ request, params } as any)).rejects.toMatchObject({
 			type: 'DataWithResponseInit',
 			data: { recommendations: [] },
 			init: {

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+
+const getBlogRecommendations = vi.fn()
+const getBlogReadRankings = vi.fn()
+const getTotalPostReads = vi.fn()
+
+vi.mock('#app/utils/blog.server.ts', () => ({
+	getBlogRecommendations,
+	getBlogReadRankings,
+	getTotalPostReads,
+}))
+
+const getMdxPage = vi.fn()
+const getBlogMdxListItems = vi.fn()
+
+vi.mock('#app/utils/mdx.server.ts', () => ({
+	getMdxPage,
+	getBlogMdxListItems,
+}))
+
+// Import after mocks so the route loader sees the mocked deps.
+import { loader } from '../$slug.tsx'
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('/blog/:slug loader cache behavior', () => {
+	test('does not compute/cachify per-slug stats when post is missing (404)', async () => {
+		getMdxPage.mockResolvedValueOnce(null)
+		getBlogRecommendations.mockResolvedValueOnce([])
+
+		const request = new Request('http://localhost/blog/does-not-exist')
+		const params = { slug: 'does-not-exist' }
+
+		let thrown: unknown
+		try {
+			await loader({ request, params } as any)
+		} catch (e) {
+			thrown = e
+		}
+
+		expect(thrown).toBeInstanceOf(Response)
+		const response = thrown as Response
+		expect(response.status).toBe(404)
+		expect(response.headers.get('Cache-Control')).toBe('private, max-age=3600')
+
+		const data = await response.json()
+		expect(data).toEqual({ recommendations: [] })
+
+		expect(getBlogRecommendations).toHaveBeenCalledTimes(1)
+		expect(getBlogReadRankings).not.toHaveBeenCalled()
+		expect(getTotalPostReads).not.toHaveBeenCalled()
+	})
+
+	test('computes per-slug stats when post exists (200)', async () => {
+		getMdxPage.mockResolvedValueOnce({
+			code: 'export default function Test() { return null }',
+			slug: 'my-post',
+			editLink: 'https://example.com/edit',
+			frontmatter: { title: 'My Post', categories: ['react'], meta: {} },
+		})
+		getBlogRecommendations.mockResolvedValueOnce([])
+		getBlogReadRankings.mockResolvedValueOnce([])
+		getTotalPostReads.mockResolvedValueOnce(0)
+
+		const request = new Request('http://localhost/blog/my-post')
+		const params = { slug: 'my-post' }
+
+		const response = (await loader({ request, params } as any)) as Response
+		expect(response.status).toBe(200)
+
+		const data = await response.json()
+		expect(data).toMatchObject({
+			page: { slug: 'my-post' },
+			recommendations: [],
+			readRankings: [],
+			totalReads: '0',
+			leadingTeam: null,
+		})
+
+		expect(getBlogRecommendations).toHaveBeenCalledTimes(1)
+		expect(getBlogReadRankings).toHaveBeenCalledTimes(1)
+		expect(getTotalPostReads).toHaveBeenCalledTimes(1)
+	})
+})
+

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -23,6 +23,12 @@ vi.mock('../../action/mark-as-read.tsx', () => ({
 	markAsRead: vi.fn(),
 }))
 
+// The route module imports this hook, which pulls in `root.tsx` and server auth/db code.
+// We only exercise the loader, so a lightweight mock keeps this test hermetic.
+vi.mock('#app/utils/use-root-data.ts', () => ({
+	useRootData: () => ({ requestInfo: { origin: 'http://localhost' } }),
+}))
+
 // Import after mocks so the route loader sees the mocked deps.
 import { loader } from '../$slug.tsx'
 

--- a/app/routes/blog_/__tests__/blog-slug-loader.test.ts
+++ b/app/routes/blog_/__tests__/blog-slug-loader.test.ts
@@ -98,6 +98,9 @@ describe('/blog/:slug loader cache behavior', () => {
 		})
 
 		expect(blogServerMocks.getBlogRecommendations).toHaveBeenCalledTimes(1)
+		expect(blogServerMocks.getBlogRecommendations).toHaveBeenCalledWith(
+			expect.objectContaining({ keywords: ['react'] }),
+		)
 		expect(blogServerMocks.getBlogReadRankings).toHaveBeenCalledTimes(1)
 		expect(blogServerMocks.getTotalPostReads).toHaveBeenCalledTimes(1)
 	})


### PR DESCRIPTION
Fixes #461 by preventing the `/blog/:slug` loader from computing and caching per-slug ranking stats for 404 (missing MDX) pages.

This change addresses cache bloat by ensuring that non-existent blog slugs do not trigger expensive computations and long-term caching of irrelevant data.

---
<p><a href="https://cursor.com/agents?id=bc-696ac094-02cc-4ead-9e02-60bc735eba2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-696ac094-02cc-4ead-9e02-60bc735eba2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the 404 path and cache headers for missing blog slugs, with targeted unit tests reducing regression risk.
> 
> **Overview**
> Prevents `/blog/:slug` from computing/caching per-slug read rankings and total-read stats when the MDX page is missing: the loader now *early-returns a 404* with only recommendations (no keywords) and a short `Cache-Control` TTL.
> 
> For existing posts, the loader preserves the full 200 response (recommendations, rankings, total reads, leading team, favorite state) and refactors the flow to fetch user/favorite only after confirming the page exists. Adds Vitest unit tests verifying invalid slug short-circuits, 404 behavior avoids stats/user work, and 200 behavior still computes stats with expected headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 265f6f3aec3e97225da32c420b99138bc211b60d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added hermetic Vitest tests for the blog loader covering missing (404) and existing post flows; verifies recommendations, read rankings, total reads, leading team and response headers.

* **Refactor**
  * Simplified blog loader control flow: early 404 responses return only recommendations with short-lived headers; successful responses return recommendations plus read rankings, total reads and leading team as top-level fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->