### PR TITLE
Open issue selection

### DIFF
--- a/app/routes/chats/$season.tsx
+++ b/app/routes/chats/$season.tsx
@@ -9,6 +9,7 @@ import { type KCDHandle } from '#app/types.ts'
 import { getCWKEpisodePath } from '#app/utils/chats-with-kent.ts'
 import { orderBy } from '#app/utils/cjs/lodash.ts'
 import {
+	formatDate,
 	formatDuration,
 	reuseUsefulLoaderHeaders,
 	useCapturedRouteError,
@@ -91,8 +92,13 @@ export default function ChatsSeason() {
 						</span>
 						{episode.title}
 					</div>
-					<div className="text-lg font-medium text-gray-400">
-						{formatDuration(episode.duration)}
+					<div className="text-lg font-medium text-gray-400 lg:text-right">
+						<div>
+							<time dateTime={episode.publishedAt}>
+								{formatDate(episode.publishedAt)}
+							</time>
+						</div>
+						<div>{formatDuration(episode.duration)}</div>
 					</div>
 				</div>
 			</Grid>

--- a/app/routes/chats/_layout.tsx
+++ b/app/routes/chats/_layout.tsx
@@ -24,6 +24,7 @@ import {
 	getFeaturedEpisode,
 } from '#app/utils/chats-with-kent.ts'
 import {
+	formatDate,
 	formatDuration,
 	getDisplayUrl,
 	getOrigin,
@@ -151,7 +152,9 @@ function PodcastHome() {
 						caption="Featured episode"
 						subTitle={`Season ${featured.seasonNumber} Episode ${
 							featured.episodeNumber
-						} — ${formatDuration(featured.duration)}`}
+						} — ${formatDate(featured.publishedAt)} — ${formatDuration(
+							featured.duration,
+						)}`}
 						title={featured.title}
 						href={getCWKEpisodePath(featured)}
 						imageUrl={featured.image}

--- a/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -32,6 +32,7 @@ import {
 	getFeaturedEpisode,
 } from '#app/utils/chats-with-kent.ts'
 import {
+	formatDate,
 	formatDuration,
 	getDisplayUrl,
 	getOrigin,
@@ -429,9 +430,15 @@ export default function PodcastDetail() {
 			</Grid>
 
 			<Grid as="header" className="mb-12">
-				<H2 className="col-span-full lg:col-span-8 lg:col-start-3">
-					{episode.title}
-				</H2>
+				<div className="col-span-full lg:col-span-8 lg:col-start-3">
+					<H2>{episode.title}</H2>
+					<H6 variant="secondary" as="div" className="mt-3">
+						Published{' '}
+						<time dateTime={episode.publishedAt}>
+							{formatDate(episode.publishedAt)}
+						</time>
+					</H6>
+				</div>
 			</Grid>
 
 			<Grid as="main" className="mb-24 lg:mb-64">
@@ -544,7 +551,9 @@ export default function PodcastDetail() {
 					caption="Featured episode"
 					subTitle={`Season ${featured.seasonNumber} Episode ${
 						featured.episodeNumber
-					} — ${formatDuration(featured.duration)}`}
+					} — ${formatDate(featured.publishedAt)} — ${formatDuration(
+						featured.duration,
+					)}`}
 					title={featured.title}
 					href={getCWKEpisodePath(featured)}
 					imageUrl={featured.image}

--- a/app/utils/simplecast.server.ts
+++ b/app/utils/simplecast.server.ts
@@ -37,9 +37,49 @@ const headers = {
 
 const seasonsCacheKey = `simplecast:seasons:${CHATS_WITH_KENT_PODCAST_ID}`
 
-const cwkCachedListItemSchema = z
+const cwkCachedLinkSchema = z
 	.object({
+		name: z.string().min(1),
+		url: z.string().min(1),
+	})
+	.passthrough()
+
+const cwkCachedGuestSchema = z
+	.object({
+		name: z.string().min(1),
+		company: z.string().optional(),
+		github: z.string().optional(),
+		x: z.string().optional(),
+	})
+	.passthrough()
+
+const cwkCachedMetaSchema = z
+	.object({
+		keywords: z.array(z.string()).optional(),
+	})
+	.catchall(z.string())
+	.optional()
+
+const cwkCachedEpisodeSchema = z
+	.object({
+		slug: z.string().min(1),
+		title: z.string().min(1),
+		meta: cwkCachedMetaSchema,
+		descriptionHTML: z.string(),
+		description: z.string(),
+		summaryHTML: z.string(),
 		publishedAt: z.string().min(1),
+		updatedAt: z.string().min(1),
+		seasonNumber: z.number(),
+		episodeNumber: z.number(),
+		homeworkHTMLs: z.array(z.string()),
+		resources: z.array(cwkCachedLinkSchema),
+		image: z.string().min(1),
+		guests: z.array(cwkCachedGuestSchema),
+		duration: z.number(),
+		transcriptHTML: z.string(),
+		simpleCastId: z.string().min(1),
+		mediaUrl: z.string().min(1),
 	})
 	.passthrough()
 
@@ -47,17 +87,10 @@ const cwkCachedSeasonsSchema = z.array(
 	z
 		.object({
 			seasonNumber: z.number(),
-			episodes: z.array(cwkCachedListItemSchema),
+			episodes: z.array(cwkCachedEpisodeSchema),
 		})
 		.passthrough(),
 )
-
-const cwkCachedEpisodeSchema = z
-	.object({
-		title: z.string().min(1),
-		publishedAt: z.string().min(1),
-	})
-	.passthrough()
 
 function isTooManyRequests(json: unknown): json is SimplecastTooManyRequests {
 	return (

--- a/app/utils/simplecast.server.ts
+++ b/app/utils/simplecast.server.ts
@@ -188,6 +188,7 @@ async function getEpisode(episodeId: string) {
 	const {
 		id,
 		is_published,
+		published_at,
 		updated_at,
 		slug,
 		transcription: transcriptMarkdown,
@@ -232,6 +233,10 @@ async function getEpisode(episodeId: string) {
 				},
 	])
 
+	// Simplecast exposes both published and updated timestamps; fall back to
+	// `updated_at` so older/malformed episodes still render a date.
+	const publishedAt = published_at ?? updated_at
+
 	const cwkEpisode: CWKEpisode = {
 		transcriptHTML,
 		descriptionHTML,
@@ -242,6 +247,7 @@ async function getEpisode(episodeId: string) {
 		resources,
 		image: image_url,
 		episodeNumber: number,
+		publishedAt,
 		updatedAt: updated_at,
 		homeworkHTMLs,
 		seasonNumber,

--- a/app/utils/simplecast.server.ts
+++ b/app/utils/simplecast.server.ts
@@ -68,7 +68,21 @@ const getCachedSeasons = async ({
 		checkValue: (value: unknown) =>
 			Array.isArray(value) &&
 			value.every(
-				(v) => typeof v.seasonNumber === 'number' && Array.isArray(v.episodes),
+				(v) =>
+					typeof v === 'object' &&
+					v !== null &&
+					'seasonNumber' in v &&
+					typeof (v as { seasonNumber?: unknown }).seasonNumber === 'number' &&
+					'episodes' in v &&
+					Array.isArray((v as { episodes?: unknown }).episodes) &&
+					(v as { episodes: Array<unknown> }).episodes.every(
+						(e) =>
+							typeof e === 'object' &&
+							e !== null &&
+							'publishedAt' in e &&
+							typeof (e as { publishedAt?: unknown }).publishedAt === 'string' &&
+							(e as { publishedAt: string }).publishedAt.length > 0,
+					),
 			),
 	})
 
@@ -95,7 +109,12 @@ async function getCachedEpisode(
 		getFreshValue: () => getEpisode(episodeId),
 		forceFresh,
 		checkValue: (value: unknown) =>
-			typeof value === 'object' && value !== null && 'title' in value,
+			typeof value === 'object' &&
+			value !== null &&
+			'title' in value &&
+			'publishedAt' in value &&
+			typeof (value as { publishedAt?: unknown }).publishedAt === 'string' &&
+			(value as { publishedAt: string }).publishedAt.length > 0,
 	})
 }
 

--- a/mocks/simplecast.ts
+++ b/mocks/simplecast.ts
@@ -71,6 +71,7 @@ for (const seasonListItem of seasonListItems) {
 				transcription: faker.lorem.paragraphs(30),
 				status: 'published',
 				is_published: true,
+				published_at: faker.date.past().toISOString(),
 				updated_at: faker.date.past().toISOString(),
 				image_url: faker.image.avatar(),
 				audio_file_url: 'set audio_file_url to a real file if we ever use this',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -80,6 +80,7 @@ type CWKEpisode = {
 	descriptionHTML: string
 	description: string
 	summaryHTML: string
+	publishedAt: string
 	updatedAt: string
 	seasonNumber: number
 	episodeNumber: number
@@ -110,6 +111,7 @@ type CWKListItem = Pick<
 	| 'image'
 	| 'guests'
 	| 'duration'
+	| 'publishedAt'
 	| 'simpleCastId'
 >
 

--- a/types/simplecast.d.ts
+++ b/types/simplecast.d.ts
@@ -11,6 +11,7 @@ type SimplecastEpisode = {
 	transcription: string | null
 	status: 'draft' | 'published'
 	is_published: boolean
+	published_at?: string
 	updated_at: string
 	image_url: string
 	audio_file_url: string


### PR DESCRIPTION
Add `publishedAt` field to chat episodes and display it in the UI to fix issue #540.

---
<p><a href="https://cursor.com/agents?id=bc-a40487a7-4e82-447d-95a8-271795fc7a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40487a7-4e82-447d-95a8-271795fc7a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Simplecast ingestion/caching layer and episode data model; incorrect schema assumptions or missing timestamps could cause cache misses or runtime validation failures, though changes are straightforward and have a safe fallback.
> 
> **Overview**
> Chats with Kent episodes now include a `publishedAt` field sourced from Simplecast’s `published_at` (falling back to `updated_at`) and threaded through `CWKEpisode`/`CWKListItem` types.
> 
> The UI displays the published date alongside duration in season episode rows, featured episode subtitles, and the episode detail header (using existing `formatDate`).
> 
> Server-side caching validation for Simplecast season/episode payloads is tightened by replacing ad-hoc checks with Zod schemas to ensure cached data matches the new shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98ad1c6064597df4cc868dd644c84e5738882da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episodes now show published date alongside duration across season lists, featured sections, and episode pages — formatted and displayed as a separate date/time block (right-aligned on large screens).
* **Chores**
  * Improved backend handling and validation of episode publish dates to ensure accurate, consistent display across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->