### PR TITLE
Open issue resolution

### DIFF
--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { describe, expect, test, vi } from 'vitest'
+
+const oneDay = 1000 * 60 * 60 * 24
+
+describe('mdx not-found caching', () => {
+	test('caches missing mdx pages for 1 day (no swr)', async () => {
+		const originalEnv = {
+			CACHE_DATABASE_PATH: process.env.CACHE_DATABASE_PATH,
+			LITEFS_DIR: process.env.LITEFS_DIR,
+			FLY_REGION: process.env.FLY_REGION,
+			FLY_INSTANCE: process.env.FLY_INSTANCE,
+		}
+
+		const cacheDbPath = path.join(os.tmpdir(), `kcd-cache-${randomUUID()}.db`)
+
+		try {
+			process.env.CACHE_DATABASE_PATH = cacheDbPath
+			// litefs-js requires these env vars to compute "primary instance" info.
+			process.env.LITEFS_DIR = path.resolve(process.cwd(), 'prisma')
+			process.env.FLY_REGION = 'test'
+			process.env.FLY_INSTANCE = 'test'
+
+			vi.resetModules()
+			vi.doMock('#app/utils/github.server.ts', () => {
+				return {
+					downloadDirList: async () => [],
+					downloadMdxFileOrDirectory: async () => ({
+						entry: `content/blog/definitely-does-not-exist`,
+						files: [],
+					}),
+				}
+			})
+
+			const { getMdxPage } = await import('../mdx.server.ts')
+			const { cache } = await import('../cache.server.ts')
+
+			const slug = `definitely-does-not-exist-${randomUUID()}`
+			const page = await getMdxPage({ contentDir: 'blog', slug }, {})
+			expect(page).toBeNull()
+
+			const keys = [
+				`mdx-page:blog:${slug}:compiled`,
+				`blog:${slug}:downloaded`,
+				`blog:${slug}:compiled`,
+			]
+
+			for (const key of keys) {
+				const entry = await cache.get(key)
+				expect(entry).not.toBeNull()
+				expect(entry!.metadata.ttl).toBe(oneDay)
+				expect(entry!.metadata.swr).toBe(0)
+			}
+		} finally {
+			for (const [key, value] of Object.entries(originalEnv)) {
+				if (typeof value === 'string') process.env[key] = value
+				else delete process.env[key]
+			}
+			await fs.rm(cacheDbPath, { force: true }).catch(() => {})
+		}
+	})
+})
+

--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -1,14 +1,20 @@
-// @vitest-environment node
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { TextDecoder, TextEncoder } from 'node:util'
 import { describe, expect, test, vi } from 'vitest'
 
 const oneDay = 1000 * 60 * 60 * 24
 
 describe('mdx not-found caching', () => {
 	test('caches missing mdx pages for 1 day (no swr)', async () => {
+		// `esbuild` (used by `mdx-bundler`) asserts that `TextEncoder` produces the
+		// current-realm `Uint8Array`. Under Vitest's default jsdom environment, the
+		// global `TextEncoder` can come from a different realm and fail that check.
+		globalThis.TextEncoder = TextEncoder
+		globalThis.TextDecoder = TextDecoder
+
 		const originalEnv = {
 			CACHE_DATABASE_PATH: process.env.CACHE_DATABASE_PATH,
 			LITEFS_DIR: process.env.LITEFS_DIR,

--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'

--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -25,6 +25,11 @@ describe('mdx not-found caching', () => {
 			process.env.FLY_INSTANCE = 'test'
 
 			vi.resetModules()
+			// `cache.server.ts` imports `getUser` from `session.server.ts`, which pulls
+			// in Prisma + lots of env requirements. This test doesn't need that.
+			vi.doMock('../session.server.ts', () => {
+				return { getUser: async () => null }
+			})
 			// `cache.server.ts` imports `updatePrimaryCacheValue` from this route module,
 			// which uses the `vite-env-only` macro. That macro is not processed in the
 			// Vitest environment, so we stub the module for this unit test.

--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -25,6 +25,12 @@ describe('mdx not-found caching', () => {
 			process.env.FLY_INSTANCE = 'test'
 
 			vi.resetModules()
+			// `cache.server.ts` imports `updatePrimaryCacheValue` from this route module,
+			// which uses the `vite-env-only` macro. That macro is not processed in the
+			// Vitest environment, so we stub the module for this unit test.
+			vi.doMock('#app/routes/resources/cache.sqlite.ts', () => {
+				return { updatePrimaryCacheValue: undefined }
+			})
 			// Avoid importing `mdx-bundler` (and therefore `esbuild`) in jsdom tests.
 			// For this test we only care about the "missing page -> null" path.
 			vi.doMock('#app/utils/compile-mdx.server.ts', () => {

--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -73,6 +73,10 @@ describe('mdx not-found caching', () => {
 		} finally {
 			// Prevent mock/module state leaking if more tests are added later.
 			vi.restoreAllMocks()
+			vi.unmock('../session.server.ts')
+			vi.unmock('#app/routes/resources/cache.sqlite.ts')
+			vi.unmock('#app/utils/compile-mdx.server.ts')
+			vi.unmock('#app/utils/github.server.ts')
 			vi.resetModules()
 
 			for (const [key, value] of Object.entries(originalEnv)) {

--- a/app/utils/__tests__/mdx-not-found-cache.test.ts
+++ b/app/utils/__tests__/mdx-not-found-cache.test.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { randomUUID } from 'node:crypto'
 import { describe, expect, test, vi } from 'vitest'
 
 const oneDay = 1000 * 60 * 60 * 24

--- a/app/utils/mdx.server.ts
+++ b/app/utils/mdx.server.ts
@@ -19,6 +19,19 @@ type CachifiedOptions = {
 
 const defaultTTL = 1000 * 60 * 60 * 24 * 14
 const defaultStaleWhileRevalidate = 1000 * 60 * 60 * 24 * 365 * 100
+const notFoundTTL = 1000 * 60 * 60 * 24
+const notFoundStaleWhileRevalidate = 0
+
+function applyNotFoundCacheMetadata(
+	metadata: { ttl?: number | null; swr?: number | null },
+	maxTtl: number | null | undefined,
+) {
+	// Cache negative lookups briefly to avoid hammering GitHub for repeated 404s,
+	// but don't keep them around for long (and never serve them stale).
+	const effectiveMaxTtl = typeof maxTtl === 'number' ? maxTtl : Infinity
+	metadata.ttl = Math.min(effectiveMaxTtl, notFoundTTL)
+	metadata.swr = notFoundStaleWhileRevalidate
+}
 
 const checkCompiledValue = (value: unknown) =>
 	typeof value === 'object' &&
@@ -45,7 +58,7 @@ export async function getMdxPage(
 		staleWhileRevalidate: defaultStaleWhileRevalidate,
 		forceFresh,
 		checkValue: checkCompiledValue,
-		getFreshValue: async () => {
+		getFreshValue: async (context) => {
 			const pageFiles = await downloadMdxFilesCached(contentDir, slug, options)
 			const compiledPage = await compileMdxCached({
 				contentDir,
@@ -59,13 +72,12 @@ export async function getMdxPage(
 				})
 				return Promise.reject(err)
 			})
+			if (!compiledPage) {
+				applyNotFoundCacheMetadata(context.metadata, ttl)
+			}
 			return compiledPage
 		},
 	})
-	if (!page) {
-		// if there's no page, let's remove it from the cache
-		void cache.delete(key)
-	}
 	return page
 }
 
@@ -189,13 +201,14 @@ export async function downloadMdxFilesCached(
 
 			return true
 		},
-		getFreshValue: async () =>
-			downloadMdxFileOrDirectory(`${contentDir}/${slug}`),
+		getFreshValue: async (context) => {
+			const result = await downloadMdxFileOrDirectory(`${contentDir}/${slug}`)
+			if (!result.files.length) {
+				applyNotFoundCacheMetadata(context.metadata, ttl)
+			}
+			return result
+		},
 	})
-	// if there aren't any files, remove it from the cache
-	if (!downloaded.files.length) {
-		void cache.delete(key)
-	}
 	return downloaded
 }
 
@@ -220,7 +233,7 @@ async function compileMdxCached({
 		...options,
 		key,
 		checkValue: checkCompiledValue,
-		getFreshValue: async () => {
+		getFreshValue: async (context) => {
 			const compiledPage = await compileMdx<MdxPage['frontmatter']>(slug, files)
 			if (compiledPage) {
 				if (
@@ -262,14 +275,11 @@ async function compileMdxCached({
 					editLink: `https://github.com/kentcdodds/kentcdodds.com/edit/main/${entry}`,
 				}
 			} else {
+				applyNotFoundCacheMetadata(context.metadata, context.metadata.ttl)
 				return null
 			}
 		},
 	})
-	// if there's no page, remove it from the cache
-	if (!page) {
-		void cache.delete(key)
-	}
 	return page
 }
 

--- a/app/utils/mdx.server.ts
+++ b/app/utils/mdx.server.ts
@@ -225,6 +225,7 @@ async function compileMdxCached({
 	files: Array<GitHubFile>
 	options: CachifiedOptions
 }) {
+	const { ttl = defaultTTL } = options
 	const key = `${contentDir}:${slug}:compiled`
 	const page = await cachified({
 		cache,
@@ -275,7 +276,7 @@ async function compileMdxCached({
 					editLink: `https://github.com/kentcdodds/kentcdodds.com/edit/main/${entry}`,
 				}
 			} else {
-				applyNotFoundCacheMetadata(context.metadata, context.metadata.ttl)
+				applyNotFoundCacheMetadata(context.metadata, ttl)
 				return null
 			}
 		},


### PR DESCRIPTION
Fixes #461 by caching "not found" MDX pages for only 1 day with no stale-while-revalidate.

---
<p><a href="https://cursor.com/agents?id=bc-9806b3dd-9191-43ea-9fda-0c6ead412fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9806b3dd-9191-43ea-9fda-0c6ead412fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to caching metadata for MDX misses plus a new test; main risk is incorrectly caching temporary failures as “not found” for up to 24 hours.
> 
> **Overview**
> Adds explicit *negative caching* for missing MDX content: when download/compile yields no files or `null`, cachified cache metadata is overridden to `ttl=1 day` and `swr=0` instead of deleting the cache entry.
> 
> Introduces `applyNotFoundCacheMetadata` and updates `getMdxPage`, `downloadMdxFilesCached`, and `compileMdxCached` to use it, plus a new Vitest unit test that stubs GitHub/MDX compilation and asserts the 1-day/no-SWR metadata on all related cache keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 359bec0a0df03b7a68c2ca3e0e2fcf1ff7a8f630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests verifying caching behavior for missing MDX pages.

* **Performance Improvements**
  * Improved caching for non-existent pages to reduce repeated fetches and improve responsiveness.
  * Missing-page cache entries now use short-lived expiration and revalidation to minimize unnecessary requests.

* **Behavior Changes**
  * 404/empty results are cached briefly with explicit metadata so repeated requests are avoided while keeping content fresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->