### PR TITLE
Signup mobile onboarding

### DIFF
--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -225,8 +225,8 @@ function TeamOption({
 				'mx-auto mb-2 block h-16 w-16 object-contain sm:h-20 sm:w-20 lg:mb-16 lg:h-auto lg:w-auto',
 			widths: [64, 80, 96, 128, 160, 256, 320, 350, 512, 685, 1370],
 			sizes: [
-				'(max-width: 639px) 64px',
-				'(min-width: 640px) and (max-width: 1023px) 80px',
+				'(max-width: 479px) 64px',
+				'(min-width: 480px) and (max-width: 1023px) 80px',
 				'(min-width:1024px) and (max-width:1620px) 20vw',
 				'320px',
 			],
@@ -263,13 +263,13 @@ function TeamOption({
 					aria-hidden="true"
 					className={teamImageClassName}
 				/>
-				<H6 as="span" className="text-sm leading-none lg:text-lg">
+				<span className="text-sm font-medium leading-none text-black dark:text-white lg:text-lg">
 					<span className="lg:hidden" aria-hidden="true">
 						{team.label.replace(' Team', '')}
 					</span>
 					<span className="sr-only lg:hidden">{team.label}</span>
 					<span className="hidden lg:inline">{team.label}</span>
-				</H6>
+				</span>
 			</label>
 		</div>
 	)

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -216,10 +216,38 @@ function TeamOption({
 		onewheeling: TEAM_ONEWHEELING_MAP,
 	}[teamMap][value]
 
+	// On mobile we render a compact "profile" version to avoid the big cards
+	// taking over the entire signup flow (issue #86).
+	const profileImage = {
+		BLUE: images.kodyProfileBlue,
+		RED: images.kodyProfileRed,
+		YELLOW: images.kodyProfileYellow,
+	}[value]
+
+	const { className: profileClassName, ...profileImgProps } = getImgProps(
+		profileImage,
+		{
+			className:
+				'mx-auto mb-3 block h-14 w-14 rounded-full object-contain lg:mb-16 lg:h-auto lg:w-auto lg:rounded-none',
+			widths: [80, 96, 112, 128, 160, 192],
+			sizes: ['(max-width: 1023px) 26vw', '80px'],
+			transformations: { resize: { type: 'pad', aspectRatio: '1:1' } },
+		},
+	)
+
+	const sportImgProps = getImgProps(team.image, {
+		className: 'mx-auto mb-16 block',
+		widths: [350, 512, 685, 1370, 2055],
+		sizes: [
+			'(min-width:1023px) and (max-width:1620px) 20vw',
+			'320px',
+		],
+	})
+
 	return (
 		<div
 			className={clsx(
-				'focus-ring relative col-span-full mb-3 rounded-lg bg-gray-100 lg:col-span-4 lg:mb-0 dark:bg-gray-800',
+				'focus-ring relative rounded-lg bg-gray-100 dark:bg-gray-800 lg:col-span-4',
 				team.focusClassName,
 				{
 					'ring-2': selected,
@@ -227,12 +255,12 @@ function TeamOption({
 			)}
 		>
 			{selected ? (
-				<span className="text-team-current absolute top-9 left-9">
-					<CheckCircledIcon />
+				<span className="text-team-current absolute top-2 left-2 lg:top-9 lg:left-9">
+					<CheckCircledIcon size={28} />
 				</span>
 			) : null}
 
-			<label className="block cursor-pointer px-12 pt-20 pb-12 text-center">
+			<label className="flex cursor-pointer flex-col items-center justify-center px-3 py-4 text-center lg:block lg:px-12 lg:pt-20 lg:pb-12">
 				<input
 					className="sr-only"
 					type="radio"
@@ -240,18 +268,23 @@ function TeamOption({
 					value={value}
 					aria-describedby={error ? 'team-error' : undefined}
 				/>
-				<img
-					{...getImgProps(team.image, {
-						className: 'mx-auto mb-16 block',
-						widths: [350, 512, 685, 1370, 2055],
-						sizes: [
-							'(max-width: 1023px) 65vw',
-							'(min-width:1023px) and (max-width:1620px) 20vw',
-							'320px',
-						],
-					})}
-				/>
-				<H6 as="span">{team.label}</H6>
+				<picture>
+					<source
+						media="(min-width: 1024px)"
+						srcSet={sportImgProps.srcSet}
+						sizes={sportImgProps.sizes}
+					/>
+					<img
+						{...profileImgProps}
+						alt=""
+						aria-hidden="true"
+						className={clsx(profileClassName)}
+					/>
+				</picture>
+				<H6 as="span" className="text-sm leading-none lg:text-lg">
+					<span className="lg:hidden">{team.label.replace(' Team', '')}</span>
+					<span className="hidden lg:inline">{team.label}</span>
+				</H6>
 			</label>
 		</div>
 	)
@@ -309,17 +342,19 @@ export default function NewAccount() {
 							</div>
 						) : null}
 
-						<fieldset className="contents">
+						<fieldset className="col-span-full border-0 p-0">
 							<legend className="sr-only">Team</legend>
-							{data.teamsInOrder.map((teamOption) => (
-								<TeamOption
-									key={teamOption}
-									teamMap={data.teamMap}
-									team={teamOption}
-									error={actionData?.errors.team}
-									selected={formValues.team === teamOption}
-								/>
-							))}
+							<div className="grid grid-cols-3 gap-3 md:gap-4 lg:grid-cols-12 lg:gap-6">
+								{data.teamsInOrder.map((teamOption) => (
+									<TeamOption
+										key={teamOption}
+										teamMap={data.teamMap}
+										team={teamOption}
+										error={actionData?.errors.team}
+										selected={formValues.team === teamOption}
+									/>
+								))}
+							</div>
 						</fieldset>
 
 						<div className="col-span-full h-20 lg:h-24" />

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -239,7 +239,7 @@ function TeamOption({
 		className: 'mx-auto mb-16 block',
 		widths: [350, 512, 685, 1370, 2055],
 		sizes: [
-			'(min-width:1023px) and (max-width:1620px) 20vw',
+			'(min-width:1024px) and (max-width:1620px) 20vw',
 			'320px',
 		],
 	})
@@ -278,7 +278,7 @@ function TeamOption({
 						{...profileImgProps}
 						alt=""
 						aria-hidden="true"
-						className={clsx(profileClassName)}
+						className={profileClassName}
 					/>
 				</picture>
 				<H6 as="span" className="text-sm leading-none lg:text-lg">

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -216,33 +216,22 @@ function TeamOption({
 		onewheeling: TEAM_ONEWHEELING_MAP,
 	}[teamMap][value]
 
-	// On mobile we render a compact "profile" version to avoid the big cards
-	// taking over the entire signup flow (issue #86).
-	const profileImage = {
-		BLUE: images.kodyProfileBlue,
-		RED: images.kodyProfileRed,
-		YELLOW: images.kodyProfileYellow,
-	}[value]
-
-	const { className: profileClassName, ...profileImgProps } = getImgProps(
-		profileImage,
+	// Mobile uses the full illustration, but sized down so all three options can
+	// fit in a single row (issue #86).
+	const { className: teamImageClassName, ...teamImageProps } = getImgProps(
+		team.image,
 		{
 			className:
-				'mx-auto mb-3 block h-14 w-14 rounded-full object-contain lg:mb-16 lg:h-auto lg:w-auto lg:rounded-none',
-			widths: [80, 96, 112, 128, 160, 192],
-			sizes: ['(max-width: 1023px) 26vw', '80px'],
-			transformations: { resize: { type: 'pad', aspectRatio: '1:1' } },
+				'mx-auto mb-2 block h-16 w-16 object-contain sm:h-20 sm:w-20 lg:mb-16 lg:h-auto lg:w-auto',
+			widths: [64, 80, 96, 128, 160, 256, 320, 350, 512, 685, 1370],
+			sizes: [
+				'(max-width: 639px) 64px',
+				'(min-width: 640px) and (max-width: 1023px) 80px',
+				'(min-width:1024px) and (max-width:1620px) 20vw',
+				'320px',
+			],
 		},
 	)
-
-	const sportImgProps = getImgProps(team.image, {
-		className: 'mx-auto mb-16 block',
-		widths: [350, 512, 685, 1370, 2055],
-		sizes: [
-			'(min-width:1024px) and (max-width:1620px) 20vw',
-			'320px',
-		],
-	})
 
 	return (
 		<div
@@ -260,7 +249,7 @@ function TeamOption({
 				</span>
 			) : null}
 
-			<label className="flex cursor-pointer flex-col items-center justify-center px-3 py-4 text-center lg:block lg:px-12 lg:pt-20 lg:pb-12">
+			<label className="flex cursor-pointer flex-col items-center justify-center px-1 py-3 text-center sm:px-2 lg:block lg:px-12 lg:pt-20 lg:pb-12">
 				<input
 					className="sr-only"
 					type="radio"
@@ -268,19 +257,12 @@ function TeamOption({
 					value={value}
 					aria-describedby={error ? 'team-error' : undefined}
 				/>
-				<picture>
-					<source
-						media="(min-width: 1024px)"
-						srcSet={sportImgProps.srcSet}
-						sizes={sportImgProps.sizes}
-					/>
-					<img
-						{...profileImgProps}
-						alt=""
-						aria-hidden="true"
-						className={profileClassName}
-					/>
-				</picture>
+				<img
+					{...teamImageProps}
+					alt=""
+					aria-hidden="true"
+					className={teamImageClassName}
+				/>
 				<H6 as="span" className="text-sm leading-none lg:text-lg">
 					<span className="lg:hidden" aria-hidden="true">
 						{team.label.replace(' Team', '')}

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -282,7 +282,10 @@ function TeamOption({
 					/>
 				</picture>
 				<H6 as="span" className="text-sm leading-none lg:text-lg">
-					<span className="lg:hidden">{team.label.replace(' Team', '')}</span>
+					<span className="lg:hidden" aria-hidden="true">
+						{team.label.replace(' Team', '')}
+					</span>
+					<span className="sr-only lg:hidden">{team.label}</span>
 					<span className="hidden lg:inline">{team.label}</span>
 				</H6>
 			</label>


### PR DESCRIPTION
Make the signup onboarding team selection mobile-friendly by switching to compact Kody profile tiles on small screens.

---
<p><a href="https://cursor.com/agents?id=bc-48fce2b0-261f-419c-9014-80392f887818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48fce2b0-261f-419c-9014-80392f887818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational and accessibility tweaks to the signup UI; no auth, data, or server-side behavior changes.
> 
> **Overview**
> Improves the signup onboarding team picker for mobile by rendering the three teams in a compact 3-column grid, shrinking the illustrations, and adjusting padding/alignment so all options fit in one row.
> 
> Updates selection affordances and accessibility: the check icon is resized/repositioned responsively, labels are shortened on small screens while keeping full text for screen readers, and the team image is marked decorative (`alt=""`, `aria-hidden`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 076cf2b5772bef1f41fec295ccb365a3169d15d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team options now switch between compact profile images on mobile and larger sport images on desktop.
  * Responsive label typography for team choices (smaller on mobile, larger on desktop).

* **Style**
  * Redesigned signup team selection into a compact, rounded layout with a smaller, repositioned selection indicator.
  * Team choices wrapped in a responsive grid (dense on small screens, expanded on large screens); team fieldset made borderless and padding-free with minor spacing/layout tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->