### PR TITLE
Forms demos styling

### DIFF
--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -921,14 +921,16 @@ pre {
 	background-color: var(--bg-primary);
 }
 
-.prose :where(form, .demo) :where(button) {
+.prose :where(form, .demo) :where(button):not([type='checkbox']):not(
+		[type='radio']
+	) {
 	background-color: var(--bg-secondary);
 	cursor: pointer;
 	font-weight: 500;
 }
 
 .prose :where(form, .demo) :where(button:hover) {
-	background-color: var(--bg-alt);
+	background-color: var(--bg-primary);
 }
 
 .prose :where(form, .demo)

--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -928,7 +928,7 @@ pre {
 	font-weight: 500;
 }
 
-.prose :where(form, .demo) :where(button):hover {
+.prose :where(form, .demo) :where(button):hover:not(:disabled) {
 	background-color: var(--bg-primary);
 }
 

--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -902,48 +902,53 @@ pre {
 
 /* Form controls inside blog content are otherwise left "unstyled" by preflight. */
 .prose :where(form, .demo)
-	:where(input, select, textarea, button):not([type='checkbox']):not(
-		[type='radio']
+	:where(
+		input:not([type='checkbox'], [type='radio']),
+		select,
+		textarea,
+		button
 	) {
 	font: inherit;
 	font-size: 1rem;
-	line-height: 1.25rem;
-
+	line-height: 1.25;
 	border: 1px solid var(--border-secondary);
 	border-radius: 0.5rem;
 	padding: 0.5rem 0.75rem;
 	color: var(--text-primary);
 }
 
-.prose :where(form, .demo) :where(input, select, textarea):not(
-		[type='checkbox']
-	):not([type='radio']) {
+.prose :where(form, .demo)
+	:where(input:not([type='checkbox'], [type='radio']), select, textarea) {
 	background-color: var(--bg-primary);
 }
 
-.prose :where(form, .demo) :where(button):not([type='checkbox']):not(
-		[type='radio']
-	) {
+.prose :where(form, .demo) :where(button) {
 	background-color: var(--bg-secondary);
 	cursor: pointer;
 	font-weight: 500;
 }
 
-.prose :where(form, .demo) :where(button:hover) {
+.prose :where(form, .demo) :where(button):hover {
 	background-color: var(--bg-primary);
 }
 
 .prose :where(form, .demo)
-	:where(input, select, textarea, button):not([type='checkbox']):not(
-		[type='radio']
+	:where(
+		input:not([type='checkbox'], [type='radio']),
+		select,
+		textarea,
+		button
 	):focus-visible {
 	outline: 2px solid var(--color-team-current);
 	outline-offset: 2px;
 }
 
 .prose :where(form, .demo)
-	:where(input, select, textarea, button):not([type='checkbox']):not(
-		[type='radio']
+	:where(
+		input:not([type='checkbox'], [type='radio']),
+		select,
+		textarea,
+		button
 	):disabled {
 	opacity: 0.6;
 	cursor: not-allowed;

--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -899,14 +899,50 @@ pre {
 	background-color: var(--bg-alt);
 	padding: 2rem;
 }
-.prose .demo button,
-.prose .demo input {
-	padding: revert;
-	margin: revert;
-	display: revert;
-	border: revert;
-	background: revert;
-	appearance: revert;
-	line-height: revert;
-	color: revert;
+
+/* Form controls inside blog content are otherwise left "unstyled" by preflight. */
+.prose :where(form, .demo)
+	:where(input, select, textarea, button):not([type='checkbox']):not(
+		[type='radio']
+	) {
+	font: inherit;
+	font-size: 1rem;
+	line-height: 1.25rem;
+
+	border: 1px solid var(--border-secondary);
+	border-radius: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	color: var(--text-primary);
+}
+
+.prose :where(form, .demo) :where(input, select, textarea):not(
+		[type='checkbox']
+	):not([type='radio']) {
+	background-color: var(--bg-primary);
+}
+
+.prose :where(form, .demo) :where(button) {
+	background-color: var(--bg-secondary);
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.prose :where(form, .demo) :where(button:hover) {
+	background-color: var(--bg-alt);
+}
+
+.prose :where(form, .demo)
+	:where(input, select, textarea, button):not([type='checkbox']):not(
+		[type='radio']
+	):focus-visible {
+	outline: 2px solid var(--color-team-current);
+	outline-offset: 2px;
+}
+
+.prose :where(form, .demo)
+	:where(input, select, textarea, button):not([type='checkbox']):not(
+		[type='radio']
+	):disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
 }


### PR DESCRIPTION
Add theme-aware styling to blog-embedded form controls to improve the appearance of demos in light and dark mode.

---
<p><a href="https://cursor.com/agents?id=bc-5828e26f-717c-4948-85be-eacef56fa988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5828e26f-717c-4948-85be-eacef56fa988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes scoped to form controls inside `.prose` content; risk is limited to potential visual regressions in blog posts/demos.
> 
> **Overview**
> Adds theme-aware styling for form controls inside `.prose` content (including `.demo` blocks), replacing the previous `revert`-based reset for `button`/`input`.
> 
> Inputs/selects/textareas/buttons now share consistent typography, padding, borders, and colors, with specific button hover styling plus `:focus-visible` outlines and disabled-state treatment for better usability in blog-embedded demos.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19023d58a94987ab465ecf10b5136d9a6e65fa8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated form control appearance inside blog content for a cohesive, themed look across inputs, selects, textareas, and buttons.
  * Controls now inherit surrounding typography and use consistent sizing, spacing, borders, radii, padding, and background treatments.
  * Buttons receive distinct visuals, cursor behavior, hover/disabled states and improved focus-visible outlines for clearer interaction and accessibility feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->