### PR TITLE
Promotification countdown timer

### DIFF
--- a/app/components/hooks/__tests__/use-countdown.test.tsx
+++ b/app/components/hooks/__tests__/use-countdown.test.tsx
@@ -20,12 +20,12 @@ function CountdownProbe({
 	return <div data-testid="seconds-left">{secondsLeft}</div>
 }
 
-afterEach(() => {
-	vi.useRealTimers()
-	vi.restoreAllMocks()
-})
-
 describe('useCountdown', () => {
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
 	it('jumps to current remaining time on focus (no rapid catch-up)', () => {
 		vi.useFakeTimers()
 
@@ -50,6 +50,41 @@ describe('useCountdown', () => {
 		// (it should not tick down rapidly 55 times).
 		act(() => {
 			window.dispatchEvent(new Event('focus'))
+		})
+
+		expect(screen.getByTestId('seconds-left')).toHaveTextContent('65')
+		expect(seen[0]).toBe(120)
+		expect(seen.at(-1)).toBe(65)
+		expect(seen.length).toBeLessThan(10)
+	})
+
+	it('jumps to current remaining time on visibilitychange (no rapid catch-up)', () => {
+		vi.useFakeTimers()
+
+		const start = new Date('2026-02-21T00:00:00.000Z')
+		const end = new Date(start.getTime() + 2 * 60 * 1000) // +2 minutes
+		vi.setSystemTime(start)
+
+		const seen: Array<number> = []
+		render(
+			<CountdownProbe
+				endTimeMs={end.getTime()}
+				onSeconds={(s) => seen.push(s)}
+			/>,
+		)
+
+		expect(screen.getByTestId('seconds-left')).toHaveTextContent('120')
+
+		// Simulate leaving the tab for ~55s (timers do not run while hidden).
+		vi.setSystemTime(new Date(start.getTime() + 55 * 1000))
+
+		// Coming back should immediately reflect the current remaining time.
+		Object.defineProperty(document, 'hidden', {
+			value: false,
+			configurable: true,
+		})
+		act(() => {
+			document.dispatchEvent(new Event('visibilitychange'))
 		})
 
 		expect(screen.getByTestId('seconds-left')).toHaveTextContent('65')

--- a/app/components/hooks/__tests__/use-countdown.test.tsx
+++ b/app/components/hooks/__tests__/use-countdown.test.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import { act, render, screen } from '@testing-library/react'
+import * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useCountdown } from '../use-countdown.ts'
 

--- a/app/components/hooks/__tests__/use-countdown.test.tsx
+++ b/app/components/hooks/__tests__/use-countdown.test.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useCountdown } from '../use-countdown.ts'
+
+function CountdownProbe({
+	endTimeMs,
+	onSeconds,
+}: {
+	endTimeMs: number
+	onSeconds: (secondsLeft: number) => void
+}) {
+	const timeLeftMs = useCountdown(endTimeMs, 1000)
+	const secondsLeft = Math.floor(timeLeftMs / 1000)
+
+	React.useEffect(() => {
+		onSeconds(secondsLeft)
+	}, [onSeconds, secondsLeft])
+
+	return <div data-testid="seconds-left">{secondsLeft}</div>
+}
+
+afterEach(() => {
+	vi.useRealTimers()
+	vi.restoreAllMocks()
+})
+
+describe('useCountdown', () => {
+	it('jumps to current remaining time on focus (no rapid catch-up)', () => {
+		vi.useFakeTimers()
+
+		const start = new Date('2026-02-21T00:00:00.000Z')
+		const end = new Date(start.getTime() + 2 * 60 * 1000) // +2 minutes
+		vi.setSystemTime(start)
+
+		const seen: Array<number> = []
+		render(
+			<CountdownProbe
+				endTimeMs={end.getTime()}
+				onSeconds={(s) => seen.push(s)}
+			/>,
+		)
+
+		expect(screen.getByTestId('seconds-left')).toHaveTextContent('120')
+
+		// Simulate leaving the tab for ~55s (timers do not run while hidden).
+		vi.setSystemTime(new Date(start.getTime() + 55 * 1000))
+
+		// Coming back should immediately reflect the current remaining time
+		// (it should not tick down rapidly 55 times).
+		act(() => {
+			window.dispatchEvent(new Event('focus'))
+		})
+
+		expect(screen.getByTestId('seconds-left')).toHaveTextContent('65')
+		expect(seen[0]).toBe(120)
+		expect(seen.at(-1)).toBe(65)
+		expect(seen.length).toBeLessThan(10)
+	})
+})
+

--- a/app/components/hooks/use-countdown.ts
+++ b/app/components/hooks/use-countdown.ts
@@ -58,22 +58,18 @@ export function useCountdown(endTimeMs: number, intervalMs = 1000) {
 			scheduleNextTick()
 		}
 
-		function handleFocus() {
-			resync()
-		}
-
 		function handleVisibilityChange() {
 			// When becoming visible again, jump immediately to the correct value.
 			if (!document.hidden) resync()
 		}
 
-		window.addEventListener('focus', handleFocus)
+		window.addEventListener('focus', resync)
 		document.addEventListener('visibilitychange', handleVisibilityChange)
 
 		return () => {
 			cancelled = true
 			clearScheduledTick()
-			window.removeEventListener('focus', handleFocus)
+			window.removeEventListener('focus', resync)
 			document.removeEventListener('visibilitychange', handleVisibilityChange)
 		}
 	}, [endTimeMs, intervalMs])

--- a/app/components/hooks/use-countdown.ts
+++ b/app/components/hooks/use-countdown.ts
@@ -1,0 +1,65 @@
+import * as React from 'react'
+
+function getTimeLeftMs(endTimeMs: number) {
+	return Math.max(0, endTimeMs - Date.now())
+}
+
+/**
+ * Countdown to an absolute timestamp.
+ *
+ * Important: compute from `Date.now()` each tick so returning from a background
+ * tab jumps to the current remaining time instead of "catching up" quickly.
+ */
+export function useCountdown(endTimeMs: number, intervalMs = 1000) {
+	const [timeLeftMs, setTimeLeftMs] = React.useState(() =>
+		getTimeLeftMs(endTimeMs),
+	)
+
+	React.useEffect(() => {
+		if (intervalMs <= 0) return
+
+		let timeoutId: number | undefined
+		let cancelled = false
+
+		function tick() {
+			if (cancelled) return
+			setTimeLeftMs(getTimeLeftMs(endTimeMs))
+		}
+
+		function scheduleNextTick() {
+			if (cancelled) return
+
+			const remaining = getTimeLeftMs(endTimeMs)
+			if (remaining <= 0) return
+
+			// Align to the next interval boundary relative to `endTimeMs`.
+			const delay = remaining % intervalMs || intervalMs
+			timeoutId = window.setTimeout(() => {
+				tick()
+				scheduleNextTick()
+			}, delay)
+		}
+
+		// Initialize immediately (helps hydration + visibilitychange updates).
+		tick()
+		scheduleNextTick()
+
+		function handleVisibilityChange() {
+			// When becoming visible again, jump immediately to the correct value.
+			if (!document.hidden) tick()
+		}
+
+		window.addEventListener('focus', tick)
+		document.addEventListener('visibilitychange', handleVisibilityChange)
+
+		return () => {
+			cancelled = true
+			if (timeoutId !== undefined) window.clearTimeout(timeoutId)
+			window.removeEventListener('focus', tick)
+			document.removeEventListener('visibilitychange', handleVisibilityChange)
+		}
+	}, [endTimeMs, intervalMs])
+
+	return timeLeftMs
+}
+

--- a/app/routes/resources/promotification.tsx
+++ b/app/routes/resources/promotification.tsx
@@ -8,10 +8,10 @@ import { useSpinDelay } from 'spin-delay'
 import invariant from 'tiny-invariant'
 
 import { LinkButton } from '#app/components/button.tsx'
+import { useCountdown } from '#app/components/hooks/use-countdown.ts'
 import { AlarmIcon } from '#app/components/icons.tsx'
 import { NotificationMessage } from '#app/components/notification-message.tsx'
 import { Spinner } from '#app/components/spinner.tsx'
-import { useCountdown } from '#app/components/hooks/use-countdown.ts'
 import { type Route } from './+types/promotification'
 
 export function getPromoCookieValue({

--- a/app/routes/resources/promotification.tsx
+++ b/app/routes/resources/promotification.tsx
@@ -1,0 +1,137 @@
+// A full stack component + action for promotional notification messages.
+// The user can dismiss (snooze) the promo for a period of time via an httpOnly cookie.
+import * as cookie from 'cookie'
+import * as React from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useFetcher, data as json } from 'react-router'
+import { useSpinDelay } from 'spin-delay'
+import invariant from 'tiny-invariant'
+
+import { LinkButton } from '#app/components/button.tsx'
+import { AlarmIcon } from '#app/components/icons.tsx'
+import { NotificationMessage } from '#app/components/notification-message.tsx'
+import { Spinner } from '#app/components/spinner.tsx'
+import { useCountdown } from '#app/components/hooks/use-countdown.ts'
+import { type Route } from './+types/promotification'
+
+export function getPromoCookieValue({
+	promoName,
+	request,
+}: {
+	promoName: string
+	request: Request
+}) {
+	const cookies = cookie.parse(request.headers.get('Cookie') || '')
+	return cookies[promoName]
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const formData = await request.formData()
+	const maxAge = Number(formData.get('maxAge')) || 60 * 60 * 24 * 7 * 2
+	const promoName = formData.get('promoName')
+	invariant(typeof promoName === 'string', 'promoName must be a string')
+
+	const cookieHeader = cookie.serialize(promoName, 'hidden', {
+		httpOnly: true,
+		secure: true,
+		sameSite: 'lax',
+		path: '/',
+		maxAge,
+	})
+	return json({ success: true }, { headers: { 'Set-Cookie': cookieHeader } })
+}
+
+type NotificationMessageProps = Parameters<typeof NotificationMessage>[0]
+
+export function Promotification({
+	children,
+	promoName,
+	dismissTimeSeconds = 60 * 60 * 24 * 4,
+	cookieValue,
+	promoEndTime,
+	...props
+}: {
+	promoName: string
+	/** maxAge for the cookie */
+	dismissTimeSeconds?: number
+	cookieValue: string | undefined
+	promoEndTime: Date
+} & NotificationMessageProps & {
+		queryStringKey?: never
+		autoClose?: never
+		visibleMs?: never
+	} & Required<Pick<NotificationMessageProps, 'children'>>) {
+	const promoEndTimeMs = promoEndTime.getTime()
+	const isPastEndTime = useRef(promoEndTimeMs <= Date.now())
+
+	const [visible, setVisible] = useState(cookieValue !== 'hidden')
+	const fetcher = useFetcher<typeof action>()
+	const showSpinner = useSpinDelay(fetcher.state !== 'idle')
+	const disableLink = fetcher.state !== 'idle' || fetcher.data?.success
+
+	useEffect(() => {
+		if (fetcher.data?.success) {
+			setVisible(false)
+		}
+	}, [fetcher.data])
+
+	// Key fix for issue #462: compute from absolute end time each tick so we jump
+	// after tab inactivity rather than counting down rapidly to catch up.
+	const timeLeft = useCountdown(promoEndTimeMs, 1000)
+	const completed = timeLeft <= 0
+	const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24))
+	const hours = Math.floor((timeLeft / (1000 * 60 * 60)) % 24)
+	const minutes = Math.floor((timeLeft / 1000 / 60) % 60)
+	const seconds = Math.floor((timeLeft / 1000) % 60)
+
+	if (isPastEndTime.current) return null
+
+	return (
+		<NotificationMessage
+			{...props}
+			autoClose={false}
+			visible={visible}
+			onDismiss={() => setVisible(false)}
+		>
+			{children}
+			<div className="mt-4">
+				{completed ? (
+					<div>{`Time's up. The sale is over`}</div>
+				) : (
+					<div className="flex flex-wrap gap-3 tabular-nums">
+						<span>
+							{days} day{days === 1 ? '' : 's'}
+						</span>
+						<span>
+							{hours} hour{hours === 1 ? '' : 's'}
+						</span>
+						<span>
+							{minutes} min{minutes === 1 ? '' : 's'}
+						</span>
+						<span>
+							{seconds} sec{seconds === 1 ? '' : 's'}
+						</span>
+					</div>
+				)}
+				<fetcher.Form action="/resources/promotification" method="POST">
+					<input type="hidden" name="promoName" value={promoName} />
+					<input type="hidden" name="maxAge" value={dismissTimeSeconds} />
+					<div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+						<LinkButton
+							type="submit"
+							className={`text-inverse flex items-center gap-1 transition-opacity ${
+								showSpinner ? 'opacity-50' : ''
+							}`}
+							disabled={disableLink}
+						>
+							<span>Remind me later</span>
+							<AlarmIcon />
+						</LinkButton>
+						<Spinner size={16} showSpinner={showSpinner} />
+					</div>
+				</fetcher.Form>
+			</div>
+		</NotificationMessage>
+	)
+}
+

--- a/app/routes/resources/promotification.tsx
+++ b/app/routes/resources/promotification.tsx
@@ -47,7 +47,9 @@ export async function action({ request }: Route.ActionArgs) {
 			? Math.min(Math.floor(rawMaxAge), MAX_MAX_AGE_SECONDS)
 			: DEFAULT_MAX_AGE_SECONDS
 
-	const cookieHeader = cookie.stringifySetCookie(promoName, 'hidden', {
+	const cookieHeader = cookie.stringifySetCookie({
+		name: promoName,
+		value: 'hidden',
 		httpOnly: true,
 		secure: true,
 		sameSite: 'lax',
@@ -92,6 +94,11 @@ export function Promotification({
 			setVisible(false)
 		}
 	}, [fetcher.data])
+
+	const dismissError =
+		fetcher.state === 'idle' && fetcher.data?.success === false
+			? (fetcher.data?.error ?? 'Could not dismiss. Please try again.')
+			: null
 
 	useEffect(() => {
 		// `promoEndTime` can change if a parent swaps promos; keep this derived.
@@ -140,6 +147,11 @@ export function Promotification({
 							<input type="hidden" name="promoName" value={promoName} />
 							<input type="hidden" name="maxAge" value={dismissTimeSeconds} />
 							<div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+								{dismissError ? (
+									<p className="text-sm text-red-500" role="alert">
+										{dismissError}
+									</p>
+								) : null}
 								<LinkButton
 									type="submit"
 									className={`text-inverse flex items-center gap-1 transition-opacity ${


### PR DESCRIPTION
Fixes the promotification countdown timer rapidly counting down after tab inactivity by re-implementing it with a `Date.now()` based hook.

The previous `requestAnimationFrame`-based countdown would attempt to "catch up" all missed frames when a backgrounded tab was refocused, leading to a rapid, incorrect countdown. The new `useCountdown` hook calculates the remaining time based on `Date.now()` and refreshes on visibility changes, ensuring the timer always displays the correct, current remaining time.

---
<p><a href="https://cursor.com/agents?id=bc-733d587b-447f-45dd-b56d-5b1ee05a9eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-733d587b-447f-45dd-b56d-5b1ee05a9eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-facing promo UI timing behavior and adds a public cookie-setting endpoint; incorrect validation or cookie attributes could cause promos to not dismiss or be set unexpectedly.
> 
> **Overview**
> Adds a new `useCountdown` hook that computes remaining time from `Date.now()` and resyncs on `focus`/`visibilitychange` to avoid “catch-up” rapid ticking after tab inactivity.
> 
> Introduces a new `resources/promotification` route that renders a promo notification with a live days/hours/minutes/seconds countdown and a “Remind me later” action that sets a validated, capped-lifetime httpOnly cookie to hide the promo. Adds Vitest coverage asserting the countdown jumps directly to the current remaining time on refocus/visibility changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb33f37f586c0bc42d1b3fc1b97b3484c3f1735d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promotional banner with live countdown and end-of-promo message
  * Dismissible promos persisted via a cookie/snooze with configurable duration (server-set)
  * Submission UX: spinner and disabled action while posting

* **Bug Fixes / Reliability**
  * More accurate countdown behavior across tab visibility and focus changes (drift resync)

* **Tests**
  * Added tests for countdown timing, tab visibility/focus recovery, and callback reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->