### PR TITLE
Navigation links responsiveness

### DIFF
--- a/app/components/navbar.css
+++ b/app/components/navbar.css
@@ -62,6 +62,9 @@ body:has(#mobile-menu:popover-open) [popovertarget='mobile-menu'] {
 }
 
 @container (max-width: 1150px) {
+	.navbar-links [data-nav-item='discord'] {
+		display: none;
+	}
 	.navbar-links [data-nav-item='chats'] {
 		display: none;
 	}

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -25,6 +25,7 @@ import { TeamCircle } from './team-circle.tsx'
 
 const LINKS = [
 	{ id: 'blog', name: 'Blog', to: '/blog' },
+	{ id: 'talks', name: 'Talks', to: '/talks' },
 	{ id: 'courses', name: 'Courses', to: '/courses' },
 	{ id: 'discord', name: 'Discord', to: '/discord' },
 	{ id: 'chats', name: 'Chats', to: '/chats/05' },

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,9 +1,28 @@
 import { expect, test } from '@playwright/test'
 
 test('App loads and nav works', async ({ page }) => {
+	await page.setViewportSize({ width: 1400, height: 900 })
 	await page.goto('/')
 
 	const nav = page.getByRole('navigation')
+
+	// Wide viewport: all links visible, and Talks is between Blog and Courses.
+	const navLinks = page.locator('.navbar-links [data-nav-item] a')
+	await expect(navLinks).toHaveText([
+		'Blog',
+		'Talks',
+		'Courses',
+		'Discord',
+		'Chats',
+		'Calls',
+		'About',
+	])
+
+	// Narrower desktop viewport: Discord + Chats hide (same behavior as Chats had).
+	await page.setViewportSize({ width: 1100, height: 900 })
+	await expect(page.locator('.navbar-links [data-nav-item="discord"]')).toBeHidden()
+	await expect(page.locator('.navbar-links [data-nav-item="chats"]')).toBeHidden()
+
 	const blogLink = nav.getByRole('link', { name: 'Blog' })
 	await blogLink.click()
 


### PR DESCRIPTION
Add "Talks" to the navbar between Blog and Courses, and make "Discord" hide on narrow screens like "Chats".

---
<p><a href="https://cursor.com/agents?id=bc-d8957ebd-395d-456e-8d65-277fe88c109e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8957ebd-395d-456e-8d65-277fe88c109e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only navigation and CSS breakpoint change with an accompanying e2e assertion update; minimal blast radius.
> 
> **Overview**
> Adds a new `Talks` link to the primary navbar (positioned between `Blog` and `Courses`).
> 
> Updates responsive styling so `Discord` is hidden under the `@container (max-width: 1150px)` breakpoint (matching existing `Chats` behavior), and expands the Playwright smoke test to assert link order/visibility across wide vs. narrower viewports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51ae4fdc9d2caa59e00269df9a8f1dbb7925ceb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Talks" section link to the navigation menu.

* **Style**
  * Improved responsive navbar to hide Discord link on narrow viewport widths alongside existing hidden items.

* **Tests**
  * Added navigation tests verifying proper link ordering and visibility across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->