### PR TITLE
Auth password support

### DIFF
--- a/app/components/form-elements.tsx
+++ b/app/components/form-elements.tsx
@@ -72,6 +72,7 @@ function Field({
 	description,
 	id,
 	additionalAriaDescribedBy,
+	autoComplete,
 	...props
 }: {
 	defaultValue?: string | null
@@ -99,7 +100,7 @@ function Field({
 					{...props}
 					{...inputProps}
 					name={name}
-					autoComplete={name}
+					autoComplete={autoComplete ?? name}
 					defaultValue={defaultValue}
 				/>
 			)}

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -752,12 +752,12 @@ function ProfileButton({
 	imageUrl,
 	imageAlt,
 	team,
-	magicLinkVerified,
+	signupEmail,
 }: {
 	imageUrl: string
 	imageAlt: string
 	team: OptionalTeam
-	magicLinkVerified: boolean | undefined
+	signupEmail: string | undefined
 }) {
 	const user = useOptionalUser()
 	const controls = useAnimation()
@@ -789,9 +789,9 @@ function ProfileButton({
 	return (
 		<Link
 			prefetch="intent"
-			to={user ? '/me' : magicLinkVerified ? '/signup' : '/login'}
+			to={user ? '/me' : signupEmail ? '/signup' : '/login'}
 			aria-label={
-				user ? 'My Account' : magicLinkVerified ? 'Finish signing up' : 'Login'
+				user ? 'My Account' : signupEmail ? 'Finish signing up' : 'Login'
 			}
 			className={clsx(
 				'ml-4 inline-flex h-14 w-14 items-center justify-center rounded-full focus:outline-none',
@@ -907,7 +907,7 @@ function Navbar() {
 					</div>
 
 					<ProfileButton
-						magicLinkVerified={requestInfo.session.magicLinkVerified}
+						signupEmail={requestInfo.session.signupEmail}
 						imageUrl={avatar.src}
 						imageAlt={avatar.alt}
 						team={team}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -134,7 +134,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 			},
 			session: {
 				email: loginInfoSession.getEmail(),
-				magicLinkVerified: loginInfoSession.getMagicLinkVerified(),
+				signupEmail: loginInfoSession.getSignupEmail(),
 			},
 		},
 	}

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -7,7 +7,7 @@ import { HeaderSection } from '#app/components/sections/header-section.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { type KCDHandle } from '#app/types.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
-import { getDomainUrl } from '#app/utils/misc.tsx'
+import { getDomainUrl } from '#app/utils/misc.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { sendPasswordResetEmail } from '#app/utils/send-email.server.ts'
 import { getUser } from '#app/utils/session.server.ts'
@@ -43,20 +43,20 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const emailAddress = formData.get('email')
 	invariantResponse(typeof emailAddress === 'string', 'Form submitted incorrectly')
-	const email = emailAddress.toLowerCase()
-	if (email) loginSession.setEmail(email)
+	const email = emailAddress.trim().toLowerCase()
 
 	// honeypot
 	const failedHoneypot = Boolean(formData.get('website'))
 	if (failedHoneypot) {
 		console.info(`FAILED HONEYPOT ON FORGOT PASSWORD`, {
-			email,
 			website: formData.get('website'),
 		})
 		return redirect('/forgot-password', {
 			headers: await loginSession.getHeaders(),
 		})
 	}
+
+	if (email) loginSession.setEmail(email)
 
 	if (!email.match(/.+@.+/)) {
 		loginSession.flashError('A valid email is required')
@@ -136,7 +136,10 @@ export default function ForgotPassword() {
 								defaultValue={data.email}
 							/>
 
-							<div style={{ position: 'absolute', left: '-9999px' }}>
+							<div
+								aria-hidden="true"
+								style={{ position: 'absolute', left: '-9999px' }}
+							>
 								<label htmlFor="website-field">Website</label>
 								<input
 									type="text"

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -1,5 +1,5 @@
 import { invariantResponse } from '@epic-web/invariant'
-import { data as json, redirect, Form, useLoaderData, type MetaFunction } from 'react-router'
+import { data as json, redirect, Form, type MetaFunction } from 'react-router'
 import { Button, ButtonLink } from '#app/components/button.tsx'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
@@ -119,8 +119,7 @@ export async function action({ request }: Route.ActionArgs) {
 	return redirect('/reset-password', { headers: await loginSession.getHeaders() })
 }
 
-export default function ForgotPassword() {
-	const data = useLoaderData<Route.ComponentProps['loaderData']>()
+export default function ForgotPassword({ loaderData: data }: Route.ComponentProps) {
 	return (
 		<div className="mt-24 pt-6">
 			<HeaderSection

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -125,7 +125,7 @@ export default function ForgotPassword() {
 		<div className="mt-24 pt-6">
 			<HeaderSection
 				as="header"
-				title="Reset your password."
+				title="Set or reset your password."
 				subTitle="We'll email you a verification code."
 				className="mb-16"
 			/>

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -1,5 +1,5 @@
+import { invariantResponse } from '@epic-web/invariant'
 import { data as json, redirect, Form, useLoaderData, type MetaFunction } from 'react-router'
-import invariant from 'tiny-invariant'
 import { Button, ButtonLink } from '#app/components/button.tsx'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
@@ -42,7 +42,7 @@ export async function action({ request }: Route.ActionArgs) {
 	const formData = await request.formData()
 
 	const emailAddress = formData.get('email')
-	invariant(typeof emailAddress === 'string', 'Form submitted incorrectly')
+	invariantResponse(typeof emailAddress === 'string', 'Form submitted incorrectly')
 	const email = emailAddress.toLowerCase()
 	if (email) loginSession.setEmail(email)
 

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -61,7 +61,6 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!email.match(/.+@.+/)) {
 		loginSession.flashError('A valid email is required')
 		return redirect('/forgot-password', {
-			status: 400,
 			headers: await loginSession.getHeaders(),
 		})
 	}

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -7,11 +7,9 @@ import { HeaderSection } from '#app/components/sections/header-section.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { type KCDHandle } from '#app/types.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
-import { getDomainUrl, isResponse } from '#app/utils/misc.ts'
+import { createAndSendPasswordResetVerificationEmail } from '#app/utils/password-reset.server.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
-import { sendPasswordResetEmail } from '#app/utils/send-email.server.ts'
 import { getUser } from '#app/utils/session.server.ts'
-import { createVerification } from '#app/utils/verification.server.ts'
 import { type Route } from './+types/forgot-password'
 
 export const handle: KCDHandle = {
@@ -71,43 +69,11 @@ export async function action({ request }: Route.ActionArgs) {
 	})
 
 	if (user) {
-		const domainUrl = getDomainUrl(request)
-		let verificationId: string | null = null
-		try {
-			const { verification, code } = await createVerification({
-				type: 'PASSWORD_RESET',
-				target: email,
-			})
-			verificationId = verification.id
-
-			const verificationUrl = new URL('/reset-password', domainUrl)
-			verificationUrl.searchParams.set('verification', verification.id)
-			verificationUrl.searchParams.set('code', code)
-
-			await sendPasswordResetEmail({
-				emailAddress: email,
-				verificationCode: code,
-				verificationUrl: verificationUrl.toString(),
-				domainUrl,
-				team: user.team,
-			})
-		} catch (error) {
-			// `ensurePrimary()` throws a Response to replay the request on the primary instance.
-			// If we swallow it, the email will never get sent.
-			if (isResponse(error)) throw error
-			if (verificationId) {
-				try {
-					// Best effort: don't leave unused verifications around if email sending fails.
-					await prisma.verification.delete({ where: { id: verificationId } })
-				} catch (cleanupError) {
-					console.error(
-						'Failed to cleanup verification after password reset email failure',
-						cleanupError,
-					)
-				}
-			}
-			console.error('Failed to send password reset email', error)
-		}
+		await createAndSendPasswordResetVerificationEmail({
+			emailAddress: email,
+			team: user.team,
+			request,
+		})
 	}
 
 	// Avoid leaking whether an account exists for the email address.

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -1,0 +1,156 @@
+import { data as json, redirect, Form, useLoaderData, type MetaFunction } from 'react-router'
+import invariant from 'tiny-invariant'
+import { Button, ButtonLink } from '#app/components/button.tsx'
+import { Field, InputError } from '#app/components/form-elements.tsx'
+import { Grid } from '#app/components/grid.tsx'
+import { HeaderSection } from '#app/components/sections/header-section.tsx'
+import { Spacer } from '#app/components/spacer.tsx'
+import { type KCDHandle } from '#app/types.ts'
+import { getLoginInfoSession } from '#app/utils/login.server.ts'
+import { getDomainUrl } from '#app/utils/misc.tsx'
+import { prisma } from '#app/utils/prisma.server.ts'
+import { sendPasswordResetEmail } from '#app/utils/send-email.server.ts'
+import { getUser } from '#app/utils/session.server.ts'
+import { createVerification } from '#app/utils/verification.server.ts'
+import { type Route } from './+types/forgot-password'
+
+export const handle: KCDHandle = {
+	getSitemapEntries: () => null,
+}
+
+export const meta: MetaFunction<typeof loader> = () => {
+	return [{ title: 'Forgot password' }]
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const user = await getUser(request)
+	if (user) return redirect('/me')
+
+	const loginSession = await getLoginInfoSession(request)
+	return json(
+		{
+			email: loginSession.getEmail() ?? '',
+			error: loginSession.getError(),
+			message: loginSession.getMessage(),
+		},
+		{ headers: await loginSession.getHeaders() },
+	)
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const loginSession = await getLoginInfoSession(request)
+	const formData = await request.formData()
+
+	const emailAddress = formData.get('email')
+	invariant(typeof emailAddress === 'string', 'Form submitted incorrectly')
+	const email = emailAddress.toLowerCase()
+	if (email) loginSession.setEmail(email)
+
+	// honeypot
+	const failedHoneypot = Boolean(formData.get('website'))
+	if (failedHoneypot) {
+		console.info(`FAILED HONEYPOT ON FORGOT PASSWORD`, {
+			email,
+			website: formData.get('website'),
+		})
+		return redirect('/forgot-password', {
+			headers: await loginSession.getHeaders(),
+		})
+	}
+
+	if (!email.match(/.+@.+/)) {
+		loginSession.flashError('A valid email is required')
+		return redirect('/forgot-password', {
+			status: 400,
+			headers: await loginSession.getHeaders(),
+		})
+	}
+
+	const user = await prisma.user.findUnique({
+		where: { email },
+		select: { id: true, team: true },
+	})
+
+	if (user) {
+		const { verification, code } = await createVerification({
+			type: 'PASSWORD_RESET',
+			target: email,
+		})
+
+		const domainUrl = getDomainUrl(request)
+		const verificationUrl = new URL('/reset-password', domainUrl)
+		verificationUrl.searchParams.set('verification', verification.id)
+		verificationUrl.searchParams.set('code', code)
+
+		await sendPasswordResetEmail({
+			emailAddress: email,
+			verificationCode: code,
+			verificationUrl: verificationUrl.toString(),
+			domainUrl,
+			team: user.team,
+		})
+	}
+
+	// Avoid leaking whether an account exists for the email address.
+	loginSession.flashMessage(
+		'If an account exists for that email, you will receive a password reset email shortly.',
+	)
+
+	return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+}
+
+export default function ForgotPassword() {
+	const data = useLoaderData<Route.ComponentProps['loaderData']>()
+	return (
+		<div className="mt-24 pt-6">
+			<HeaderSection
+				as="header"
+				title="Reset your password."
+				subTitle="We'll email you a verification code."
+				className="mb-16"
+			/>
+			<main>
+				<Grid>
+					<div className="col-span-full lg:col-span-6">
+						{data.error ? (
+							<div className="mb-8">
+								<InputError id="forgot-password-error">{data.error}</InputError>
+							</div>
+						) : null}
+						{data.message ? (
+							<p className="text-secondary mb-8 text-lg">{data.message}</p>
+						) : null}
+
+						<Form method="POST" noValidate>
+							<Field
+								name="email"
+								label="Email"
+								type="email"
+								autoComplete="email"
+								defaultValue={data.email}
+							/>
+
+							<div style={{ position: 'absolute', left: '-9999px' }}>
+								<label htmlFor="website-field">Website</label>
+								<input
+									type="text"
+									id="website-field"
+									name="website"
+									tabIndex={-1}
+									autoComplete="off"
+								/>
+							</div>
+
+							<Button type="submit">Email me a reset code</Button>
+						</Form>
+						<Spacer size="2xs" />
+						<ButtonLink to="/login" variant="secondary">
+							Back to login
+						</ButtonLink>
+					</div>
+				</Grid>
+			</main>
+		</div>
+	)
+}
+

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -72,23 +72,29 @@ export async function action({ request }: Route.ActionArgs) {
 	})
 
 	if (user) {
-		const { verification, code } = await createVerification({
-			type: 'PASSWORD_RESET',
-			target: email,
-		})
+		void (async () => {
+			try {
+				const { verification, code } = await createVerification({
+					type: 'PASSWORD_RESET',
+					target: email,
+				})
 
-		const domainUrl = getDomainUrl(request)
-		const verificationUrl = new URL('/reset-password', domainUrl)
-		verificationUrl.searchParams.set('verification', verification.id)
-		verificationUrl.searchParams.set('code', code)
+				const domainUrl = getDomainUrl(request)
+				const verificationUrl = new URL('/reset-password', domainUrl)
+				verificationUrl.searchParams.set('verification', verification.id)
+				verificationUrl.searchParams.set('code', code)
 
-		await sendPasswordResetEmail({
-			emailAddress: email,
-			verificationCode: code,
-			verificationUrl: verificationUrl.toString(),
-			domainUrl,
-			team: user.team,
-		})
+				await sendPasswordResetEmail({
+					emailAddress: email,
+					verificationCode: code,
+					verificationUrl: verificationUrl.toString(),
+					domainUrl,
+					team: user.team,
+				})
+			} catch (error) {
+				console.error('Failed to send password reset email', error)
+			}
+		})()
 	}
 
 	// Avoid leaking whether an account exists for the email address.

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -102,10 +102,10 @@ export async function action({ request }: Route.ActionArgs) {
 	// honeypot
 	const failedHoneypot = Boolean(formData.get('website'))
 	if (failedHoneypot) {
-		console.info(
-			`FAILED HONEYPOT ON LOGIN`,
-			Object.fromEntries(formData.entries()),
-		)
+		console.info(`FAILED HONEYPOT ON LOGIN`, {
+			email,
+			website: formData.get('website'),
+		})
 		return redirect(`/login`, {
 			headers: await loginSession.getHeaders(),
 		})

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -4,7 +4,16 @@ import { type PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/serv
 import clsx from 'clsx'
 import { AnimatePresence, motion } from 'framer-motion'
 import * as React from 'react'
-import { Form, useNavigate, useRevalidator, data as json, redirect, type HeadersFunction, type MetaFunction } from 'react-router';
+import {
+	Form,
+	Link,
+	useNavigate,
+	useRevalidator,
+	data as json,
+	redirect,
+	type HeadersFunction,
+	type MetaFunction,
+} from 'react-router'
 import { z } from 'zod'
 import { Button, LinkButton } from '#app/components/button.tsx'
 import { Input, InputError, Label } from '#app/components/form-elements.tsx'
@@ -14,18 +23,19 @@ import { HeroSection } from '#app/components/sections/hero-section.tsx'
 import { Paragraph } from '#app/components/typography.tsx'
 import { getGenericSocialImage, images } from '#app/images.tsx'
 import { type RootLoaderType } from '#app/root.tsx'
+import { getClientSession } from '#app/utils/client.server.ts'
+import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
 import {
 	getDisplayUrl,
-	getDomainUrl,
-	getErrorMessage,
 	getOrigin,
 	getUrl,
 	reuseUsefulLoaderHeaders,
 } from '#app/utils/misc.ts'
+import { verifyPassword } from '#app/utils/password.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
-import { getUser, sendToken } from '#app/utils/session.server.ts'
-import { isEmailVerified } from '#app/utils/verifier.server.ts'
+import { getSession, getUser } from '#app/utils/session.server.ts'
 import  { type Route } from './+types/login'
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -44,6 +54,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		{
 			email: loginSession.getEmail(),
 			error: loginSession.getError(),
+			message: loginSession.getMessage(),
 		},
 		{ headers },
 	)
@@ -74,9 +85,13 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const emailAddress = formData.get('email')
 	invariantResponse(typeof emailAddress === 'string', 'Form submitted incorrectly')
-	if (emailAddress) loginSession.setEmail(emailAddress)
+	const email = emailAddress.toLowerCase()
+	if (email) loginSession.setEmail(email)
 
-	if (!emailAddress.match(/.+@.+/)) {
+	const password = formData.get('password')
+	invariantResponse(typeof password === 'string', 'Form submitted incorrectly')
+
+	if (!email.match(/.+@.+/)) {
 		loginSession.flashError('A valid email is required')
 		return redirect(`/login`, {
 			status: 400,
@@ -84,8 +99,8 @@ export async function action({ request }: Route.ActionArgs) {
 		})
 	}
 
-	// this is our honeypot. Our login is passwordless.
-	const failedHoneypot = Boolean(formData.get('password'))
+	// honeypot
+	const failedHoneypot = Boolean(formData.get('website'))
 	if (failedHoneypot) {
 		console.info(
 			`FAILED HONEYPOT ON LOGIN`,
@@ -96,36 +111,67 @@ export async function action({ request }: Route.ActionArgs) {
 		})
 	}
 
-	try {
-		const verifiedStatus = await isEmailVerified(emailAddress)
-		if (!verifiedStatus.verified) {
-			const errorMessage = `I tried to verify that email and got this error message: "${verifiedStatus.message}". If you think this is wrong, sign up for Kent's mailing list first (using the form on the bottom of the page) and once that's confirmed you'll be able to sign up.`
-			loginSession.flashError(errorMessage)
-			return redirect(`/login`, {
-				status: 400,
-				headers: await loginSession.getHeaders(),
-			})
-		}
-	} catch (error: unknown) {
-		console.error(`There was an error verifying an email address:`, error)
-		// continue on... This was probably our fault...
-		// IDEA: notify me of this issue...
-	}
-
-	try {
-		const domainUrl = getDomainUrl(request)
-		const magicLink = await sendToken({ emailAddress, domainUrl })
-		loginSession.setMagicLink(magicLink)
-		return redirect(`/login`, {
-			headers: await loginSession.getHeaders(),
-		})
-	} catch (e: unknown) {
-		loginSession.flashError(getErrorMessage(e))
+	if (!password) {
+		loginSession.flashError('Password is required')
 		return redirect(`/login`, {
 			status: 400,
 			headers: await loginSession.getHeaders(),
 		})
 	}
+
+	const userWithPassword = await prisma.user.findUnique({
+		where: { email },
+		select: {
+			id: true,
+			password: { select: { hash: true } },
+		},
+	})
+
+	if (!userWithPassword?.password) {
+		loginSession.flashError(
+			'Invalid email or password. If you previously used magic links, use "Reset password" to set one.',
+		)
+		return redirect(`/login`, {
+			status: 400,
+			headers: await loginSession.getHeaders(),
+		})
+	}
+
+	const isValid = await verifyPassword({
+		password,
+		hash: userWithPassword.password.hash,
+	})
+
+	if (!isValid) {
+		loginSession.flashError(
+			'Invalid email or password. If you previously used magic links, use "Reset password" to set one.',
+		)
+		return redirect(`/login`, {
+			status: 400,
+			headers: await loginSession.getHeaders(),
+		})
+	}
+
+	const session = await getSession(request)
+	await session.signIn({ id: userWithPassword.id })
+
+	const clientSession = await getClientSession(request, null)
+	const clientId = clientSession.getClientId()
+	if (clientId) {
+		await ensurePrimary()
+		await prisma.postRead.updateMany({
+			data: { userId: userWithPassword.id, clientId: null },
+			where: { clientId },
+		})
+	}
+	clientSession.setUser({})
+
+	const headers = new Headers()
+	loginSession.clean()
+	await loginSession.getHeaders(headers)
+	await session.getHeaders(headers)
+	await clientSession.getHeaders(headers)
+	return redirect('/me', { headers })
 }
 
 const AuthenticationOptionsSchema = z.object({
@@ -134,6 +180,7 @@ const AuthenticationOptionsSchema = z.object({
 
 function Login({ loaderData: data }: Route.ComponentProps) {
 	const inputRef = React.useRef<HTMLInputElement>(null)
+	const passwordRef = React.useRef<HTMLInputElement>(null)
 	const navigate = useNavigate()
 	const { revalidate } = useRevalidator()
 	const [error, setError] = React.useState<string>()
@@ -267,19 +314,41 @@ function Login({ loaderData: data }: Route.ComponentProps) {
 										/>
 									</div>
 
-									<div style={{ position: 'absolute', left: '-9999px' }}>
-										<label htmlFor="password-field">Password</label>
-										<input
-											type="password"
-											id="password-field"
+									<div className="mb-6">
+										<div className="mb-4 flex flex-wrap items-baseline justify-between">
+											<Label htmlFor="password">Password</Label>
+											<Link
+												to="/forgot-password"
+												prefetch="intent"
+												className="underlined text-secondary text-sm focus:outline-none"
+											>
+												Forgot password?
+											</Link>
+										</div>
+										<Input
+											ref={passwordRef}
+											id="password"
 											name="password"
+											type="password"
+											autoComplete="current-password"
+											required
+											placeholder="Password"
+										/>
+									</div>
+
+									<div style={{ position: 'absolute', left: '-9999px' }}>
+										<label htmlFor="website-field">Website</label>
+										<input
+											type="text"
+											id="website-field"
+											name="website"
 											tabIndex={-1}
-											autoComplete="nope"
+											autoComplete="off"
 										/>
 									</div>
 
 									<div className="flex flex-wrap gap-4">
-										<Button type="submit">Email a login link</Button>
+										<Button type="submit">Log in</Button>
 										<LinkButton
 											type="reset"
 											onClick={() => {
@@ -290,6 +359,17 @@ function Login({ loaderData: data }: Route.ComponentProps) {
 											Reset
 										</LinkButton>
 									</div>
+									<p className="text-secondary mt-4 text-sm">
+										Need an account?{' '}
+										<Link
+											to="/signup"
+											prefetch="intent"
+											className="underlined focus:outline-none"
+										>
+											Create one
+										</Link>
+										.
+									</p>
 
 									<div className="sr-only" aria-live="polite">
 										{formIsValid
@@ -300,12 +380,12 @@ function Login({ loaderData: data }: Route.ComponentProps) {
 									<div className="mt-2">
 										{data.error ? (
 											<InputError id="error-message">{data.error}</InputError>
-										) : data.email ? (
+										) : data.message ? (
 											<p
 												id="success-message"
 												className="text-lg text-gray-500 dark:text-slate-500"
 											>
-												{`✨ A magic link has been sent to ${data.email}.`}
+												{data.message}
 											</p>
 										) : null}
 									</div>
@@ -344,9 +424,9 @@ function Login({ loaderData: data }: Route.ComponentProps) {
 			<Grid>
 				<Paragraph className="col-span-full mb-10 md:col-span-4">
 					{`
-              To sign in to your account or to create a new one fill in your
-              email above and we'll send you an email with a magic link to get
-              you started.
+              To sign in to your account, use your email and password above (or
+              use a passkey if you've set one up). If you previously used magic
+              links, you'll need to set a password first.
             `}
 				</Paragraph>
 

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -135,7 +135,7 @@ export async function action({ request }: Route.ActionArgs) {
 
 	if (!userWithPassword?.password || !isValid) {
 		loginSession.flashError(
-			'Invalid email or password. If you previously used magic links, use "Reset password" to set one.',
+			'Invalid email or password. If you do not have a password yet, use "Reset password" to set one.',
 		)
 		return redirect(`/login`, {
 			status: 400,
@@ -320,7 +320,7 @@ function Login({ loaderData: data }: Route.ComponentProps) {
 												prefetch="intent"
 												className="underlined text-secondary text-sm focus:outline-none"
 											>
-												Forgot password?
+												Reset password
 											</Link>
 										</div>
 										<Input
@@ -421,11 +421,17 @@ function Login({ loaderData: data }: Route.ComponentProps) {
 			/>
 			<Grid>
 				<Paragraph className="col-span-full mb-10 md:col-span-4">
-					{`
-              To sign in to your account, use your email and password above (or
-              use a passkey if you've set one up). If you previously used magic
-              links, you'll need to set a password first.
-            `}
+					To sign in to your account, use your email and password above (or use
+					a passkey if you have set one up). If you do not have a password yet,
+					use{' '}
+					<Link
+						to="/forgot-password"
+						prefetch="intent"
+						className="underlined focus:outline-none"
+					>
+						Reset password
+					</Link>{' '}
+					to set one.
 				</Paragraph>
 
 				<Paragraph

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -106,7 +106,6 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!email.match(/.+@.+/)) {
 		loginSession.flashError('A valid email is required')
 		return redirect(`/login`, {
-			status: 400,
 			headers: await loginSession.getHeaders(),
 		})
 	}
@@ -114,7 +113,6 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!password) {
 		loginSession.flashError('Password is required')
 		return redirect(`/login`, {
-			status: 400,
 			headers: await loginSession.getHeaders(),
 		})
 	}
@@ -138,7 +136,6 @@ export async function action({ request }: Route.ActionArgs) {
 			'Invalid email or password. If you do not have a password yet, use "Reset password" to set one.',
 		)
 		return redirect(`/login`, {
-			status: 400,
 			headers: await loginSession.getHeaders(),
 		})
 	}

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -32,7 +32,7 @@ import {
 	getUrl,
 	reuseUsefulLoaderHeaders,
 } from '#app/utils/misc.ts'
-import { verifyPassword } from '#app/utils/password.server.ts'
+import { DUMMY_PASSWORD_HASH, verifyPassword } from '#app/utils/password.server.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
@@ -127,22 +127,13 @@ export async function action({ request }: Route.ActionArgs) {
 		},
 	})
 
-	if (!userWithPassword?.password) {
-		loginSession.flashError(
-			'Invalid email or password. If you previously used magic links, use "Reset password" to set one.',
-		)
-		return redirect(`/login`, {
-			status: 400,
-			headers: await loginSession.getHeaders(),
-		})
-	}
-
+	const passwordHash = userWithPassword?.password?.hash ?? DUMMY_PASSWORD_HASH
 	const isValid = await verifyPassword({
 		password,
-		hash: userWithPassword.password.hash,
+		hash: passwordHash,
 	})
 
-	if (!isValid) {
+	if (!userWithPassword?.password || !isValid) {
 		loginSession.flashError(
 			'Invalid email or password. If you previously used magic links, use "Reset password" to set one.',
 		)

--- a/app/routes/magic.tsx
+++ b/app/routes/magic.tsx
@@ -1,64 +1,19 @@
 import { redirect } from 'react-router';
 import { type KCDHandle } from '#app/types.ts'
 
-import { getClientSession } from '#app/utils/client.server.ts'
-import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
-import { getErrorMessage, isResponse } from '#app/utils/misc.ts'
-import { prisma } from '#app/utils/prisma.server.ts'
-import { getUserSessionFromMagicLink } from '#app/utils/session.server.ts'
 import  { type Route } from './+types/magic'
 export const handle: KCDHandle = {
 	getSitemapEntries: () => null,
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-	await ensurePrimary()
 	const loginInfoSession = await getLoginInfoSession(request)
-	try {
-		const session = await getUserSessionFromMagicLink(request)
-		loginInfoSession.setMagicLinkVerified(true)
-		if (session) {
-			const headers = new Headers()
-			loginInfoSession.clean()
-			await loginInfoSession.getHeaders(headers)
-			await session.getHeaders(headers)
-			const user = await session.getUser()
-			if (user) {
-				const clientSession = await getClientSession(request, null)
-				// update all PostReads from clientId to userId
-				const clientId = clientSession.getClientId()
-				if (clientId) {
-					await prisma.postRead.updateMany({
-						data: { userId: user.id, clientId: null },
-						where: { clientId },
-					})
-					clientSession.setUser(user)
-					await clientSession.getHeaders(headers)
-				}
-			} else {
-				// This shouldn't happen, but if it does, we'll handle it when we redirect to /me
-			}
-			return redirect('/me', { headers })
-		} else {
-			loginInfoSession.setMagicLink(request.url)
-			return redirect('/signup', {
-				headers: await loginInfoSession.getHeaders(),
-			})
-		}
-	} catch (error: unknown) {
-		if (isResponse(error)) throw error
-
-		console.error(error)
-		loginInfoSession.clean()
-		loginInfoSession.flashError(
-			getErrorMessage(error) ||
-				'Sign in link invalid. Please request a new one.',
-		)
-		return redirect('/login', {
-			headers: await loginInfoSession.getHeaders(),
-		})
-	}
+	loginInfoSession.clean()
+	loginInfoSession.flashMessage(
+		'Magic links are no longer supported. Please log in with your password (or reset it).',
+	)
+	return redirect('/login', { headers: await loginInfoSession.getHeaders() })
 }
 
 export default function Magic() {

--- a/app/routes/me/_layout.tsx
+++ b/app/routes/me/_layout.tsx
@@ -30,7 +30,6 @@ import { getBlogMdxListItems } from '#app/utils/mdx.server.ts'
 import {
 	getDiscordAuthorizeURL,
 	getDisplayUrl,
-	getDomainUrl,
 	getErrorMessage,
 	getOrigin,
 	getTeam,

--- a/app/routes/me/_layout.tsx
+++ b/app/routes/me/_layout.tsx
@@ -8,7 +8,6 @@ import { Field, InputError, Label } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
 import {
 	CheckCircledIcon,
-	EyeIcon,
 	LogoutIcon,
 	PlusIcon,
 	RefreshIcon,
@@ -43,8 +42,7 @@ import {
 	TEAM_SKIING_MAP,
 	TEAM_SNOWBOARD_MAP,
 } from '#app/utils/onboarding.ts'
-import { getMagicLink, prisma } from '#app/utils/prisma.server.ts'
-import { getQrCodeDataURL } from '#app/utils/qrcode.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import {
 	deleteOtherSessions,
@@ -106,13 +104,6 @@ export async function loader({ request }: Route.LoaderArgs) {
 			orderBy: { createdAt: 'desc' },
 		}),
 	])
-	const qrLoginCode = await getQrCodeDataURL(
-		getMagicLink({
-			emailAddress: user.email,
-			validateSessionMagicLink: false,
-			domainUrl: getDomainUrl(request),
-		}),
-	)
 
 	const wantsBlogPosts = rawFavorites.some((f) => f.contentType === 'blog-post')
 	const wantsTalks = rawFavorites.some((f) => f.contentType === 'talk')
@@ -228,7 +219,6 @@ export async function loader({ request }: Route.LoaderArgs) {
 		activities[Math.floor(Math.random() * activities.length)] ?? 'skiing'
 	return json(
 		{
-			qrLoginCode,
 			sessionCount,
 			teamType: activity,
 			favorites,
@@ -350,8 +340,6 @@ export async function action({ request }: Route.ActionArgs) {
 	}
 }
 
-const SHOW_QR_DURATION = 15_000
-
 function YouScreen({ loaderData: data, actionData }: Route.ComponentProps) {
 	const teamMap = {
 		skiing: TEAM_SKIING_MAP,
@@ -368,18 +356,7 @@ function YouScreen({ loaderData: data, actionData }: Route.ComponentProps) {
 	if (!team) throw new Error('team required')
 
 	const authorizeURL = getDiscordAuthorizeURL(requestInfo.origin)
-	const [qrIsVisible, setQrIsVisible] = React.useState(false)
 	const [deleteModalOpen, setDeleteModalOpen] = React.useState(false)
-
-	React.useEffect(() => {
-		if (!qrIsVisible) return
-
-		const timeout = setTimeout(() => {
-			setQrIsVisible(false)
-		}, SHOW_QR_DURATION)
-
-		return () => clearTimeout(timeout)
-	}, [qrIsVisible, setQrIsVisible])
 
 	return (
 		<main>
@@ -553,32 +530,11 @@ function YouScreen({ loaderData: data, actionData }: Route.ComponentProps) {
 			</div>
 
 			<Grid>
-				<div className="col-span-full mb-12 lg:col-span-5 lg:col-start-8 lg:mb-0">
-					<H2>Need to login somewhere else?</H2>
+				<div className="col-span-full mb-12">
+					<H2>Log in on another device</H2>
 					<H2 variant="secondary" as="p">
-						Scan this QR code on the other device.
+						Use your password, or set up a passkey for easier sign-in.
 					</H2>
-				</div>
-
-				<div className="bg-secondary relative col-span-full rounded-lg p-4 lg:col-span-5 lg:col-start-1 lg:row-start-1">
-					<img
-						src={data.qrLoginCode}
-						alt="Login QR Code"
-						className="w-full rounded-lg object-contain"
-					/>
-					<button
-						onClick={() => setQrIsVisible(true)}
-						className={clsx(
-							'focus-ring text-primary bg-secondary absolute inset-0 flex h-full w-full flex-col items-center justify-center rounded-lg text-lg font-medium transition duration-200',
-							{
-								'opacity-100': !qrIsVisible,
-								'opacity-0': qrIsVisible,
-							},
-						)}
-					>
-						<EyeIcon size={36} />
-						<span>click to reveal</span>
-					</button>
 				</div>
 			</Grid>
 
@@ -646,6 +602,9 @@ function YouScreen({ loaderData: data, actionData }: Route.ComponentProps) {
 					</ButtonLink>
 					<ButtonLink variant="secondary" to="passkeys">
 						Manage Passkeys
+					</ButtonLink>
+					<ButtonLink variant="secondary" to="password">
+						Password
 					</ButtonLink>
 					<Form
 						action="/me"

--- a/app/routes/me_.password.tsx
+++ b/app/routes/me_.password.tsx
@@ -1,4 +1,4 @@
-import { data as json, redirect, Form, useActionData, useLoaderData } from 'react-router'
+import { data as json, redirect, Form } from 'react-router'
 import { Button, ButtonLink } from '#app/components/button.tsx'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
@@ -114,10 +114,10 @@ export async function action({ request }: Route.ActionArgs) {
 	})
 }
 
-export default function PasswordRoute() {
-	const data = useLoaderData<Route.ComponentProps['loaderData']>()
-	const actionData = useActionData<Route.ComponentProps['actionData']>()
-
+export default function PasswordRoute({
+	loaderData: data,
+	actionData,
+}: Route.ComponentProps) {
 	return (
 		<div className="mt-24 pt-6">
 			<HeaderSection

--- a/app/routes/me_.password.tsx
+++ b/app/routes/me_.password.tsx
@@ -1,0 +1,192 @@
+import { data as json, redirect, Form, useActionData, useLoaderData } from 'react-router'
+import { Button, ButtonLink } from '#app/components/button.tsx'
+import { Field, InputError } from '#app/components/form-elements.tsx'
+import { Grid } from '#app/components/grid.tsx'
+import { HeaderSection } from '#app/components/sections/header-section.tsx'
+import { Spacer } from '#app/components/spacer.tsx'
+import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
+import { getPasswordHash, getPasswordStrengthError, verifyPassword } from '#app/utils/password.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
+import { getSession, requireUser } from '#app/utils/session.server.ts'
+import { type Route } from './+types/me_.password'
+
+type ActionData =
+	| {
+			status: 'error'
+			errors: {
+				currentPassword?: string | null
+				password?: string | null
+				confirmPassword?: string | null
+				generalError?: string | null
+			}
+	  }
+	| { status: 'success'; errors: {} }
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const user = await requireUser(request)
+	const password = await prisma.password.findUnique({
+		where: { userId: user.id },
+		select: { userId: true },
+	})
+	return json({ hasPassword: Boolean(password) })
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const user = await requireUser(request)
+	const formData = await request.formData()
+
+	const currentPassword = formData.get('currentPassword')
+	const password = typeof formData.get('password') === 'string' ? String(formData.get('password')) : ''
+	const confirmPassword =
+		typeof formData.get('confirmPassword') === 'string'
+			? String(formData.get('confirmPassword'))
+			: ''
+
+	const existingPassword = await prisma.password.findUnique({
+		where: { userId: user.id },
+		select: { hash: true },
+	})
+
+	if (existingPassword) {
+		if (typeof currentPassword !== 'string' || !currentPassword) {
+			return json<ActionData>(
+				{
+					status: 'error',
+					errors: { currentPassword: 'Current password is required' },
+				},
+				400,
+			)
+		}
+		const ok = await verifyPassword({
+			password: currentPassword,
+			hash: existingPassword.hash,
+		})
+		if (!ok) {
+			return json<ActionData>(
+				{
+					status: 'error',
+					errors: { currentPassword: 'Current password is incorrect' },
+				},
+				400,
+			)
+		}
+	}
+
+	const passwordError = await getPasswordStrengthError(password)
+	const confirmPasswordError = (() => {
+		if (!confirmPassword) return 'Confirm your password'
+		if (confirmPassword !== password) return 'Passwords must match'
+		return null
+	})()
+
+	if (passwordError || confirmPasswordError) {
+		return json<ActionData>(
+			{
+				status: 'error',
+				errors: {
+					password: passwordError,
+					confirmPassword: confirmPasswordError,
+				},
+			},
+			400,
+		)
+	}
+
+	const passwordHash = await getPasswordHash(password)
+
+	await ensurePrimary()
+	await prisma.password.upsert({
+		where: { userId: user.id },
+		update: { hash: passwordHash },
+		create: { userId: user.id, hash: passwordHash },
+	})
+
+	// Invalidate all sessions (including this one) after a password change.
+	await prisma.session.deleteMany({ where: { userId: user.id } })
+	const session = await getSession(request)
+	await session.signIn({ id: user.id })
+
+	const headers = new Headers()
+	await session.getHeaders(headers)
+	return redirect(`/me?message=${encodeURIComponent('✅ Password updated')}`, {
+		headers,
+	})
+}
+
+export default function PasswordRoute() {
+	const data = useLoaderData<Route.ComponentProps['loaderData']>()
+	const actionData = useActionData<Route.ComponentProps['actionData']>()
+
+	return (
+		<div className="mt-24 pt-6">
+			<HeaderSection
+				as="header"
+				title={data.hasPassword ? 'Change your password.' : 'Set a password.'}
+				subTitle="Passwords are used to log in on new devices."
+				className="mb-16"
+			/>
+			<main>
+				<Grid>
+					<div className="col-span-full lg:col-span-6">
+						{actionData?.status === 'error' &&
+						actionData.errors.generalError ? (
+							<div className="mb-8">
+								<InputError id="password-general-error">
+									{actionData.errors.generalError}
+								</InputError>
+							</div>
+						) : null}
+
+						<Form method="POST" noValidate className="mb-8">
+							{data.hasPassword ? (
+								<Field
+									name="currentPassword"
+									label="Current password"
+									type="password"
+									autoComplete="current-password"
+									error={
+										actionData?.status === 'error'
+											? actionData.errors.currentPassword
+											: null
+									}
+								/>
+							) : null}
+
+							<Field
+								name="password"
+								label="New password"
+								type="password"
+								autoComplete="new-password"
+								error={
+									actionData?.status === 'error'
+										? actionData.errors.password
+										: null
+								}
+							/>
+							<Field
+								name="confirmPassword"
+								label="Confirm password"
+								type="password"
+								autoComplete="new-password"
+								error={
+									actionData?.status === 'error'
+										? actionData.errors.confirmPassword
+										: null
+								}
+							/>
+							<Button type="submit">
+								{data.hasPassword ? 'Update password' : 'Set password'}
+							</Button>
+						</Form>
+
+						<ButtonLink to="/me" variant="secondary">
+							Back to account
+						</ButtonLink>
+						<Spacer size="2xs" />
+					</div>
+				</Grid>
+			</main>
+		</div>
+	)
+}
+

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -1,0 +1,397 @@
+import { data as json, redirect, Form, useActionData, useLoaderData, type MetaFunction } from 'react-router'
+import invariant from 'tiny-invariant'
+import { Button, ButtonLink } from '#app/components/button.tsx'
+import { Field, InputError } from '#app/components/form-elements.tsx'
+import { Grid } from '#app/components/grid.tsx'
+import { HeaderSection } from '#app/components/sections/header-section.tsx'
+import { Spacer } from '#app/components/spacer.tsx'
+import { type KCDHandle } from '#app/types.ts'
+import { getClientSession } from '#app/utils/client.server.ts'
+import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
+import { getLoginInfoSession } from '#app/utils/login.server.ts'
+import { getDomainUrl } from '#app/utils/misc.tsx'
+import { getPasswordStrengthError, getPasswordHash } from '#app/utils/password.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
+import { sendPasswordResetEmail } from '#app/utils/send-email.server.ts'
+import { getSession, getUser } from '#app/utils/session.server.ts'
+import {
+	consumeVerification,
+	consumeVerificationForTarget,
+	createVerification,
+} from '#app/utils/verification.server.ts'
+import { type Route } from './+types/reset-password'
+
+export const handle: KCDHandle = {
+	getSitemapEntries: () => null,
+}
+
+export const meta: MetaFunction<typeof loader> = () => {
+	return [{ title: 'Reset password' }]
+}
+
+type ActionData =
+	| {
+			status: 'error'
+			errors: {
+				email?: string | null
+				code?: string | null
+				password?: string | null
+				confirmPassword?: string | null
+				generalError?: string | null
+			}
+	  }
+	| { status: 'success'; errors: {} }
+
+const actionIds = {
+	verify: 'verify',
+	reset: 'reset',
+	resend: 'resend',
+	cancel: 'cancel',
+} as const
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const user = await getUser(request)
+	if (user) return redirect('/me')
+
+	const loginSession = await getLoginInfoSession(request)
+	const url = new URL(request.url)
+	const verificationId = url.searchParams.get('verification')
+	const code = url.searchParams.get('code')
+
+	// Support verification links in email.
+	if (verificationId && code) {
+		const result = await consumeVerification({
+			id: verificationId,
+			code,
+			type: 'PASSWORD_RESET',
+		})
+		if (result) {
+			loginSession.setResetPasswordEmail(result.target)
+			loginSession.setEmail(result.target)
+			loginSession.flashMessage('Verification successful. Choose a new password.')
+			return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+		}
+		loginSession.flashError(
+			'Verification link invalid or expired. Please request a new one.',
+		)
+		return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+	}
+
+	const resetEmail = loginSession.getResetPasswordEmail()
+	return json(
+		{
+			step: resetEmail ? 'set-password' : 'verify',
+			email: resetEmail ?? loginSession.getEmail() ?? '',
+			error: loginSession.getError(),
+			message: loginSession.getMessage(),
+		} as const,
+		{ headers: await loginSession.getHeaders() },
+	)
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const loginSession = await getLoginInfoSession(request)
+	const formData = await request.formData()
+	const actionId = formData.get('actionId')
+
+	if (actionId === actionIds.cancel) {
+		loginSession.clean()
+		return redirect('/login', { headers: await loginSession.getHeaders() })
+	}
+
+	if (actionId === actionIds.resend) {
+		const emailAddress = formData.get('email')
+		invariant(typeof emailAddress === 'string', 'Form submitted incorrectly')
+		const email = emailAddress.toLowerCase()
+		if (email) loginSession.setEmail(email)
+
+		if (!email.match(/.+@.+/)) {
+			loginSession.flashError('A valid email is required')
+			return redirect('/reset-password', {
+				status: 400,
+				headers: await loginSession.getHeaders(),
+			})
+		}
+
+		const user = await prisma.user.findUnique({
+			where: { email },
+			select: { id: true, team: true },
+		})
+		if (user) {
+			const { verification, code } = await createVerification({
+				type: 'PASSWORD_RESET',
+				target: email,
+			})
+			const domainUrl = getDomainUrl(request)
+			const verificationUrl = new URL('/reset-password', domainUrl)
+			verificationUrl.searchParams.set('verification', verification.id)
+			verificationUrl.searchParams.set('code', code)
+
+			await sendPasswordResetEmail({
+				emailAddress: email,
+				verificationCode: code,
+				verificationUrl: verificationUrl.toString(),
+				domainUrl,
+				team: user.team,
+			})
+		}
+
+		loginSession.flashMessage(
+			'If an account exists for that email, you will receive a password reset email shortly.',
+		)
+		return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+	}
+
+	if (actionId === actionIds.verify) {
+		const emailAddress = formData.get('email')
+		const code = formData.get('code')
+		invariant(typeof emailAddress === 'string', 'Form submitted incorrectly')
+		invariant(typeof code === 'string', 'Form submitted incorrectly')
+		const email = emailAddress.toLowerCase()
+		if (email) loginSession.setEmail(email)
+
+		if (!email.match(/.+@.+/)) {
+			return json<ActionData>(
+				{ status: 'error', errors: { email: 'A valid email is required' } },
+				400,
+			)
+		}
+		if (!code) {
+			return json<ActionData>(
+				{ status: 'error', errors: { code: 'Verification code is required' } },
+				400,
+			)
+		}
+
+		const result = await consumeVerificationForTarget({
+			target: email,
+			code,
+			type: 'PASSWORD_RESET',
+		})
+
+		if (!result) {
+			return json<ActionData>(
+				{
+					status: 'error',
+					errors: {
+						generalError:
+							'Verification code invalid or expired. Please request a new one.',
+					},
+				},
+				400,
+			)
+		}
+
+		loginSession.setResetPasswordEmail(result.target)
+		loginSession.setEmail(result.target)
+		loginSession.flashMessage('Verification successful. Choose a new password.')
+		return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+	}
+
+	// Password set/reset step
+	const resetEmail = loginSession.getResetPasswordEmail()
+	if (!resetEmail) {
+		loginSession.flashError('Verify your email before resetting your password.')
+		return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+	}
+
+	const password = typeof formData.get('password') === 'string' ? String(formData.get('password')) : ''
+	const confirmPassword =
+		typeof formData.get('confirmPassword') === 'string'
+			? String(formData.get('confirmPassword'))
+			: ''
+
+	const passwordError = await getPasswordStrengthError(password)
+	const confirmPasswordError = (() => {
+		if (!confirmPassword) return 'Confirm your password'
+		if (confirmPassword !== password) return 'Passwords must match'
+		return null
+	})()
+
+	if (passwordError || confirmPasswordError) {
+		return json<ActionData>(
+			{
+				status: 'error',
+				errors: {
+					password: passwordError,
+					confirmPassword: confirmPasswordError,
+				},
+			},
+			400,
+		)
+	}
+
+	const userRecord = await prisma.user.findUnique({
+		where: { email: resetEmail },
+		select: { id: true },
+	})
+
+	if (!userRecord) {
+		loginSession.clean()
+		loginSession.flashError('No account found for that email. Create one instead.')
+		return redirect('/signup', { headers: await loginSession.getHeaders() })
+	}
+
+	const passwordHash = await getPasswordHash(password)
+
+	await ensurePrimary()
+	await prisma.password.upsert({
+		where: { userId: userRecord.id },
+		update: { hash: passwordHash },
+		create: { userId: userRecord.id, hash: passwordHash },
+	})
+	// Sign out everywhere on password reset.
+	await prisma.session.deleteMany({ where: { userId: userRecord.id } })
+
+	const session = await getSession(request)
+	await session.signIn({ id: userRecord.id })
+
+	const clientSession = await getClientSession(request, null)
+	const clientId = clientSession.getClientId()
+	if (clientId) {
+		await prisma.postRead.updateMany({
+			data: { userId: userRecord.id, clientId: null },
+			where: { clientId },
+		})
+	}
+	clientSession.setUser({})
+
+	const headers = new Headers()
+	loginSession.clean()
+	await loginSession.getHeaders(headers)
+	await session.getHeaders(headers)
+	await clientSession.getHeaders(headers)
+	return redirect('/me', { headers })
+}
+
+export default function ResetPassword() {
+	const data = useLoaderData<Route.ComponentProps['loaderData']>()
+	const actionData = useActionData<Route.ComponentProps['actionData']>()
+
+	return (
+		<div className="mt-24 pt-6">
+			<HeaderSection
+				as="header"
+				title="Reset your password."
+				subTitle="Use the code from your email."
+				className="mb-16"
+			/>
+			<main>
+				<Grid>
+					<div className="col-span-full lg:col-span-6">
+						{data.error ? (
+							<div className="mb-8">
+								<InputError id="reset-password-error">{data.error}</InputError>
+							</div>
+						) : null}
+						{actionData?.status === 'error' && actionData.errors.generalError ? (
+							<div className="mb-8">
+								<InputError id="reset-password-general-error">
+									{actionData.errors.generalError}
+								</InputError>
+							</div>
+						) : null}
+						{data.message ? (
+							<p className="text-secondary mb-8 text-lg">{data.message}</p>
+						) : null}
+
+						{data.step === 'verify' ? (
+							<>
+								<Form method="POST" noValidate className="mb-8">
+									<input
+										type="hidden"
+										name="actionId"
+										value={actionIds.verify}
+									/>
+									<Field
+										name="email"
+										label="Email"
+										type="email"
+										autoComplete="email"
+										defaultValue={data.email}
+										error={
+											actionData?.status === 'error' ? actionData.errors.email : null
+										}
+									/>
+									<Field
+										name="code"
+										label="Verification code"
+										type="text"
+										autoComplete="one-time-code"
+										placeholder="123456"
+										error={
+											actionData?.status === 'error' ? actionData.errors.code : null
+										}
+									/>
+									<Button type="submit">Verify code</Button>
+								</Form>
+
+								<Form method="POST" noValidate className="mb-8">
+									<input
+										type="hidden"
+										name="actionId"
+										value={actionIds.resend}
+									/>
+									<input type="hidden" name="email" value={data.email} />
+									<Button type="submit" variant="secondary">
+										Resend email
+									</Button>
+								</Form>
+
+								<ButtonLink to="/forgot-password" variant="secondary">
+									Back
+								</ButtonLink>
+							</>
+						) : (
+							<>
+								<Form method="POST" noValidate className="mb-8">
+									<input
+										type="hidden"
+										name="actionId"
+										value={actionIds.reset}
+									/>
+									<Field
+										name="password"
+										label="New password"
+										type="password"
+										autoComplete="new-password"
+										error={
+											actionData?.status === 'error'
+												? actionData.errors.password
+												: null
+										}
+									/>
+									<Field
+										name="confirmPassword"
+										label="Confirm password"
+										type="password"
+										autoComplete="new-password"
+										error={
+											actionData?.status === 'error'
+												? actionData.errors.confirmPassword
+												: null
+										}
+									/>
+									<Button type="submit">Set new password</Button>
+								</Form>
+
+								<Form method="POST">
+									<input
+										type="hidden"
+										name="actionId"
+										value={actionIds.cancel}
+									/>
+									<Button type="submit" variant="secondary">
+										Cancel
+									</Button>
+								</Form>
+							</>
+						)}
+						<Spacer size="2xs" />
+					</div>
+				</Grid>
+			</main>
+		</div>
+	)
+}
+

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -1,5 +1,5 @@
 import { invariantResponse } from '@epic-web/invariant'
-import { data as json, redirect, Form, useActionData, useLoaderData, type MetaFunction } from 'react-router'
+import { data as json, redirect, Form, type MetaFunction } from 'react-router'
 import { Button, ButtonLink } from '#app/components/button.tsx'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
@@ -309,10 +309,10 @@ export async function action({ request }: Route.ActionArgs) {
 	return redirect('/me', { headers })
 }
 
-export default function ResetPassword() {
-	const data = useLoaderData<Route.ComponentProps['loaderData']>()
-	const actionData = useActionData<Route.ComponentProps['actionData']>()
-
+export default function ResetPassword({
+	loaderData: data,
+	actionData,
+}: Route.ComponentProps) {
 	return (
 		<div className="mt-24 pt-6">
 			<HeaderSection

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -1,5 +1,5 @@
+import { invariantResponse } from '@epic-web/invariant'
 import { data as json, redirect, Form, useActionData, useLoaderData, type MetaFunction } from 'react-router'
-import invariant from 'tiny-invariant'
 import { Button, ButtonLink } from '#app/components/button.tsx'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
@@ -101,7 +101,7 @@ export async function action({ request }: Route.ActionArgs) {
 
 	if (actionId === actionIds.resend) {
 		const emailAddress = formData.get('email')
-		invariant(typeof emailAddress === 'string', 'Form submitted incorrectly')
+		invariantResponse(typeof emailAddress === 'string', 'Form submitted incorrectly')
 		const email = emailAddress.toLowerCase()
 		if (email) loginSession.setEmail(email)
 
@@ -145,8 +145,8 @@ export async function action({ request }: Route.ActionArgs) {
 	if (actionId === actionIds.verify) {
 		const emailAddress = formData.get('email')
 		const code = formData.get('code')
-		invariant(typeof emailAddress === 'string', 'Form submitted incorrectly')
-		invariant(typeof code === 'string', 'Form submitted incorrectly')
+		invariantResponse(typeof emailAddress === 'string', 'Form submitted incorrectly')
+		invariantResponse(typeof code === 'string', 'Form submitted incorrectly')
 		const email = emailAddress.toLowerCase()
 		if (email) loginSession.setEmail(email)
 

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -224,6 +224,10 @@ export async function action({ request }: Route.ActionArgs) {
 		loginSession.flashError('Verify your email before resetting your password.')
 		return redirect('/reset-password', { headers: await loginSession.getHeaders() })
 	}
+	if (actionId !== actionIds.reset) {
+		loginSession.flashError('Something went wrong. Please try again.')
+		return redirect('/reset-password', { headers: await loginSession.getHeaders() })
+	}
 
 	const passwordEntry = formData.get('password')
 	const password = typeof passwordEntry === 'string' ? passwordEntry : ''

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -118,22 +118,28 @@ export async function action({ request }: Route.ActionArgs) {
 			select: { id: true, team: true },
 		})
 		if (user) {
-			const { verification, code } = await createVerification({
-				type: 'PASSWORD_RESET',
-				target: email,
-			})
-			const domainUrl = getDomainUrl(request)
-			const verificationUrl = new URL('/reset-password', domainUrl)
-			verificationUrl.searchParams.set('verification', verification.id)
-			verificationUrl.searchParams.set('code', code)
+			void (async () => {
+				try {
+					const { verification, code } = await createVerification({
+						type: 'PASSWORD_RESET',
+						target: email,
+					})
+					const domainUrl = getDomainUrl(request)
+					const verificationUrl = new URL('/reset-password', domainUrl)
+					verificationUrl.searchParams.set('verification', verification.id)
+					verificationUrl.searchParams.set('code', code)
 
-			await sendPasswordResetEmail({
-				emailAddress: email,
-				verificationCode: code,
-				verificationUrl: verificationUrl.toString(),
-				domainUrl,
-				team: user.team,
-			})
+					await sendPasswordResetEmail({
+						emailAddress: email,
+						verificationCode: code,
+						verificationUrl: verificationUrl.toString(),
+						domainUrl,
+						team: user.team,
+					})
+				} catch (error) {
+					console.error('Failed to resend password reset email', error)
+				}
+			})()
 		}
 
 		loginSession.flashMessage(

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -117,7 +117,6 @@ export async function action({ request }: Route.ActionArgs) {
 		if (!email.match(/.+@.+/)) {
 			loginSession.flashError('A valid email is required')
 			return redirect('/reset-password', {
-				status: 400,
 				headers: await loginSession.getHeaders(),
 			})
 		}

--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -9,7 +9,7 @@ import { type KCDHandle } from '#app/types.ts'
 import { getClientSession } from '#app/utils/client.server.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
-import { getDomainUrl } from '#app/utils/misc.ts'
+import { getDomainUrl, isResponse } from '#app/utils/misc.ts'
 import { getPasswordStrengthError, getPasswordHash } from '#app/utils/password.server.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { sendPasswordResetEmail } from '#app/utils/send-email.server.ts'
@@ -118,28 +118,43 @@ export async function action({ request }: Route.ActionArgs) {
 			select: { id: true, team: true },
 		})
 		if (user) {
-			void (async () => {
-				try {
-					const { verification, code } = await createVerification({
-						type: 'PASSWORD_RESET',
-						target: email,
-					})
-					const domainUrl = getDomainUrl(request)
-					const verificationUrl = new URL('/reset-password', domainUrl)
-					verificationUrl.searchParams.set('verification', verification.id)
-					verificationUrl.searchParams.set('code', code)
+			const domainUrl = getDomainUrl(request)
+			let verificationId: string | null = null
+			try {
+				const { verification, code } = await createVerification({
+					type: 'PASSWORD_RESET',
+					target: email,
+				})
+				verificationId = verification.id
 
-					await sendPasswordResetEmail({
-						emailAddress: email,
-						verificationCode: code,
-						verificationUrl: verificationUrl.toString(),
-						domainUrl,
-						team: user.team,
-					})
-				} catch (error) {
-					console.error('Failed to resend password reset email', error)
+				const verificationUrl = new URL('/reset-password', domainUrl)
+				verificationUrl.searchParams.set('verification', verification.id)
+				verificationUrl.searchParams.set('code', code)
+
+				await sendPasswordResetEmail({
+					emailAddress: email,
+					verificationCode: code,
+					verificationUrl: verificationUrl.toString(),
+					domainUrl,
+					team: user.team,
+				})
+			} catch (error) {
+				// `ensurePrimary()` throws a Response to replay the request on the primary instance.
+				// If we swallow it, the email will never get sent.
+				if (isResponse(error)) throw error
+				if (verificationId) {
+					try {
+						// Best effort: don't leave unused verifications around if email sending fails.
+						await prisma.verification.delete({ where: { id: verificationId } })
+					} catch (cleanupError) {
+						console.error(
+							'Failed to cleanup verification after password reset resend failure',
+							cleanupError,
+						)
+					}
 				}
-			})()
+				console.error('Failed to resend password reset email', error)
+			}
 		}
 
 		loginSession.flashMessage(

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx'
 import * as React from 'react'
-import { Button, ButtonLink } from '#app/components/button.tsx'
 import { data as json, redirect, Form } from 'react-router'
+import { Button, ButtonLink } from '#app/components/button.tsx'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
 import { CheckCircledIcon } from '#app/components/icons.tsx'

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -130,7 +130,10 @@ export async function action({ request }: Route.ActionArgs) {
 				verificationUrl: verificationUrl.toString(),
 				domainUrl,
 			})
-		} catch (error) {
+		} catch (error: unknown) {
+			// `ensurePrimary()` throws a Response to replay the request on the primary instance.
+			// If we swallow it, the email will never get sent.
+			if (isResponse(error)) throw error
 			// Avoid leaving an unused verification record around if email sending fails.
 			try {
 				await ensurePrimary()

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -589,6 +589,16 @@ export default function NewAccount({
 				>
 					<input type="hidden" name="actionId" value={actionIds.signUp} />
 					<Grid>
+						{data.error ? (
+							<div className="col-span-full mb-8">
+								<InputError id="signup-error">{data.error}</InputError>
+							</div>
+						) : null}
+						{data.message ? (
+							<p className="text-secondary col-span-full mb-8 text-lg">
+								{data.message}
+							</p>
+						) : null}
 						{actionData?.errors.generalError ? (
 							<div className="col-span-full mb-4">
 								<InputError id="general-error">

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -25,12 +25,12 @@ import { getPasswordHash, getPasswordStrengthError } from '#app/utils/password.s
 import { prisma } from '#app/utils/prisma.server.ts'
 import { sendSignupVerificationEmail } from '#app/utils/send-email.server.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
+import { useTeam } from '#app/utils/team-provider.tsx'
 import {
 	consumeVerification,
 	consumeVerificationForTarget,
 	createVerification,
 } from '#app/utils/verification.server.ts'
-import { useTeam } from '#app/utils/team-provider.tsx'
 import  { type Route } from './+types/signup'
 
 export const handle: KCDHandle = {

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -15,7 +15,7 @@ import { shuffle } from '#app/utils/cjs/lodash.ts'
 import { getClientSession } from '#app/utils/client.server.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
-import { getDomainUrl, getErrorStack, isTeam, teams } from '#app/utils/misc.ts'
+import { getDomainUrl, getErrorStack, isResponse, isTeam, teams } from '#app/utils/misc.ts'
 import {
 	TEAM_ONEWHEELING_MAP,
 	TEAM_SKIING_MAP,
@@ -310,6 +310,8 @@ export async function action({ request }: Route.ActionArgs) {
 		await loginInfoSession.getHeaders(headers)
 		return redirect('/me', { headers })
 	} catch (error: unknown) {
+		// `ensurePrimary()` throws a Response to replay the request on the primary instance.
+		if (isResponse(error)) throw error
 		console.error(getErrorStack(error))
 		return json(
 			{

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx'
 import * as React from 'react'
-import { data as json, redirect, Form } from 'react-router';
-import { Button } from '#app/components/button.tsx'
+import { Button, ButtonLink } from '#app/components/button.tsx'
+import { data as json, redirect, Form } from 'react-router'
 import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
 import { CheckCircledIcon } from '#app/components/icons.tsx'
@@ -11,18 +11,25 @@ import { H2, H6, Paragraph } from '#app/components/typography.tsx'
 import { getImgProps, images } from '#app/images.tsx'
 import { tagKCDSiteSubscriber } from '#app/kit/kit.server.ts'
 import { type KCDHandle, type Team } from '#app/types.ts'
-import { handleFormSubmission } from '#app/utils/actions.server.ts'
 import { shuffle } from '#app/utils/cjs/lodash.ts'
 import { getClientSession } from '#app/utils/client.server.ts'
+import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
-import { getErrorStack, isTeam, teams } from '#app/utils/misc.ts'
+import { getDomainUrl, getErrorStack, isTeam, teams } from '#app/utils/misc.ts'
 import {
 	TEAM_ONEWHEELING_MAP,
 	TEAM_SKIING_MAP,
 	TEAM_SNOWBOARD_MAP,
 } from '#app/utils/onboarding.ts'
-import { prisma, validateMagicLink } from '#app/utils/prisma.server.ts'
+import { getPasswordHash, getPasswordStrengthError } from '#app/utils/password.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
+import { sendSignupVerificationEmail } from '#app/utils/send-email.server.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
+import {
+	consumeVerification,
+	consumeVerificationForTarget,
+	createVerification,
+} from '#app/utils/verification.server.ts'
 import { useTeam } from '#app/utils/team-provider.tsx'
 import  { type Route } from './+types/signup'
 
@@ -40,6 +47,8 @@ type ActionData = {
 		generalError?: string
 		firstName: string | null
 		team: string | null
+		password: string | null
+		confirmPassword: string | null
 	}
 }
 
@@ -55,8 +64,14 @@ function getErrorForTeam(team: string | null) {
 	return null
 }
 
+async function getErrorForPassword(password: string | null) {
+	return getPasswordStrengthError(password ?? '')
+}
+
 const actionIds = {
 	cancel: 'cancel',
+	requestCode: 'request code',
+	verifyCode: 'verify code',
 	signUp: 'sign up',
 }
 
@@ -65,89 +80,210 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const requestText = await request.text()
 	const form = new URLSearchParams(requestText)
-	if (form.get('actionId') === actionIds.cancel) {
+	const actionId = form.get('actionId')
+
+	if (actionId === actionIds.cancel) {
 		loginInfoSession.clean()
 		return redirect('/', {
 			headers: await loginInfoSession.getHeaders(),
 		})
 	}
 
-	const session = await getSession(request)
-	const magicLink = loginInfoSession.getMagicLink()
-	let email: string
-	try {
-		if (typeof magicLink !== 'string') {
-			throw new Error('email and magicLink required.')
+	if (actionId === actionIds.requestCode) {
+		const emailAddress = form.get('email')
+		const email = typeof emailAddress === 'string' ? emailAddress.toLowerCase() : ''
+		if (email) loginInfoSession.setEmail(email)
+
+		if (!email.match(/.+@.+/)) {
+			loginInfoSession.flashError('A valid email is required')
+			return redirect('/signup', {
+				status: 400,
+				headers: await loginInfoSession.getHeaders(),
+			})
 		}
 
-		email = await validateMagicLink(magicLink, loginInfoSession.getMagicLink())
-	} catch (error: unknown) {
-		console.error(getErrorStack(error))
+		const userExists = await prisma.user.findUnique({
+			where: { email },
+			select: { id: true },
+		})
+		if (userExists) {
+			loginInfoSession.flashMessage(
+				'An account already exists for that email. Log in instead (or reset your password).',
+			)
+			return redirect('/login', { headers: await loginInfoSession.getHeaders() })
+		}
 
-		loginInfoSession.clean()
-		loginInfoSession.flashError(
-			'Sign in link invalid. Please request a new one.',
-		)
-		return redirect('/login', {
+		const { verification, code } = await createVerification({
+			type: 'SIGNUP',
+			target: email,
+		})
+
+		const domainUrl = getDomainUrl(request)
+		const verificationUrl = new URL('/signup', domainUrl)
+		verificationUrl.searchParams.set('verification', verification.id)
+		verificationUrl.searchParams.set('code', code)
+
+		await sendSignupVerificationEmail({
+			emailAddress: email,
+			verificationCode: code,
+			verificationUrl: verificationUrl.toString(),
+			domainUrl,
+		})
+
+		loginInfoSession.flashMessage(`Verification code sent to ${email}.`)
+		return redirect(`/signup?verification=${verification.id}`, {
 			headers: await loginInfoSession.getHeaders(),
 		})
 	}
 
-	return handleFormSubmission<ActionData>({
-		form,
-		validators: {
-			firstName: getErrorForFirstName,
-			team: getErrorForTeam,
-		},
-		handleFormValues: async (formData) => {
-			const { firstName, team } = formData
+	if (actionId === actionIds.verifyCode) {
+		const verificationId = form.get('verificationId')
+		const code = form.get('code')
+		if (typeof code !== 'string' || !code) {
+			loginInfoSession.flashError('Verification code required')
+			return redirect('/signup', { headers: await loginInfoSession.getHeaders() })
+		}
 
-			try {
-				const user = await prisma.user.create({
-					data: { email, firstName, team },
-				})
-
-				// add user to mailing list
-				const sub = await tagKCDSiteSubscriber({
-					email,
-					firstName,
-					fields: { kcd_team: team, kcd_site_id: user.id },
-				})
-				await prisma.user.update({
-					data: { kitId: String(sub.id) },
-					where: { id: user.id },
-				})
-				const clientSession = await getClientSession(request, null)
-				const clientId = clientSession.getClientId()
-				// update all PostReads from clientId to userId
-				if (clientId) {
-					await prisma.postRead.updateMany({
-						data: { userId: user.id, clientId: null },
-						where: { clientId },
+		const result =
+			typeof verificationId === 'string' && verificationId
+				? await consumeVerification({
+						id: verificationId,
+						code,
+						type: 'SIGNUP',
 					})
-				}
-				clientSession.setUser(user)
+				: await consumeVerificationForTarget({
+						target: (form.get('email') ?? loginInfoSession.getEmail() ?? '')
+							.toString()
+							.toLowerCase(),
+						code,
+						type: 'SIGNUP',
+					})
 
-				const headers = new Headers()
-				await session.signIn(user)
-				await session.getHeaders(headers)
-				await clientSession.getHeaders(headers)
-				// IDEA: try using destroy... Didn't seem to work last time I tried though.
-				loginInfoSession.clean()
-				await loginInfoSession.getHeaders(headers)
-				return redirect('/me', { headers })
-			} catch (error: unknown) {
-				console.error(getErrorStack(error))
+		if (!result) {
+			loginInfoSession.flashError(
+				'Verification code invalid or expired. Please request a new one.',
+			)
+			return redirect(
+				typeof verificationId === 'string' && verificationId
+					? `/signup?verification=${verificationId}`
+					: '/signup',
+				{
+				status: 400,
+				headers: await loginInfoSession.getHeaders(),
+				},
+			)
+		}
 
-				loginInfoSession.flashError(
-					'There was a problem creating your account. Please try again.',
-				)
-				return redirect('/login', {
-					headers: await loginInfoSession.getHeaders(),
-				})
+		loginInfoSession.setSignupEmail(result.target)
+		loginInfoSession.setEmail(result.target)
+		loginInfoSession.flashMessage('Email verified. Finish creating your account.')
+		return redirect('/signup', { headers: await loginInfoSession.getHeaders() })
+	}
+
+	const signupEmail = loginInfoSession.getSignupEmail()
+	if (!signupEmail) {
+		loginInfoSession.flashError('Verify your email first to create an account.')
+		return redirect('/signup', { headers: await loginInfoSession.getHeaders() })
+	}
+
+	const firstName = form.get('firstName')
+	const team = form.get('team')
+	const password = form.get('password')
+	const confirmPassword = form.get('confirmPassword')
+
+	const errors: ActionData['errors'] = {
+		firstName: getErrorForFirstName(typeof firstName === 'string' ? firstName : null),
+		team: getErrorForTeam(typeof team === 'string' ? team : null),
+		password: await getErrorForPassword(typeof password === 'string' ? password : null),
+		confirmPassword: (() => {
+			if (typeof confirmPassword !== 'string' || !confirmPassword) {
+				return 'Confirm your password'
 			}
-		},
-	})
+			if (confirmPassword !== password) return 'Passwords must match'
+			return null
+		})(),
+	}
+
+	if (Object.values(errors).some((e) => e !== null)) {
+		return json(
+			{
+				status: 'error',
+				fields: {
+					firstName: typeof firstName === 'string' ? firstName : null,
+					team: typeof team === 'string' && isTeam(team) ? team : null,
+				},
+				errors: { ...errors },
+			} satisfies ActionData,
+			400,
+		)
+	}
+
+	try {
+		const safeFirstName = String(firstName).trim()
+		const safeTeam = team as Team
+		const safePassword = String(password)
+
+		const passwordHash = await getPasswordHash(safePassword)
+		await ensurePrimary()
+		const user = await prisma.user.create({
+			data: {
+				email: signupEmail,
+				firstName: safeFirstName,
+				team: safeTeam,
+				password: { create: { hash: passwordHash } },
+			},
+		})
+
+		// add user to mailing list
+		const sub = await tagKCDSiteSubscriber({
+			email: signupEmail,
+			firstName: safeFirstName,
+			fields: { kcd_team: safeTeam, kcd_site_id: user.id },
+		})
+		await prisma.user.update({
+			data: { kitId: String(sub.id) },
+			where: { id: user.id },
+		})
+
+		const session = await getSession(request)
+		const clientSession = await getClientSession(request, null)
+		const clientId = clientSession.getClientId()
+		// update all PostReads from clientId to userId
+		if (clientId) {
+			await prisma.postRead.updateMany({
+				data: { userId: user.id, clientId: null },
+				where: { clientId },
+			})
+		}
+		clientSession.setUser(user)
+
+		const headers = new Headers()
+		await session.signIn(user)
+		await session.getHeaders(headers)
+		await clientSession.getHeaders(headers)
+		loginInfoSession.clean()
+		await loginInfoSession.getHeaders(headers)
+		return redirect('/me', { headers })
+	} catch (error: unknown) {
+		console.error(getErrorStack(error))
+		return json(
+			{
+				status: 'error',
+				fields: {
+					firstName: typeof firstName === 'string' ? firstName : null,
+					team: typeof team === 'string' && isTeam(team) ? team : null,
+				},
+				errors: {
+					firstName: null,
+					team: null,
+					password: null,
+					confirmPassword: null,
+					generalError: 'There was a problem creating your account. Please try again.',
+				},
+			} satisfies ActionData,
+			500,
+		)
+	}
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -155,30 +291,59 @@ export async function loader({ request }: Route.LoaderArgs) {
 	if (user) return redirect('/me')
 
 	const loginInfoSession = await getLoginInfoSession(request)
-	const magicLink = loginInfoSession.getMagicLink()
-	const email = loginInfoSession.getEmail()
-	if (!magicLink || !email) {
-		loginInfoSession.clean()
-		loginInfoSession.flashError('Invalid magic link. Try again.')
-		return redirect('/login', {
-			headers: await loginInfoSession.getHeaders(),
+
+	const url = new URL(request.url)
+	const verificationId = url.searchParams.get('verification')
+	const code = url.searchParams.get('code')
+
+	// Support verification links in email.
+	if (verificationId && code) {
+		const result = await consumeVerification({
+			id: verificationId,
+			code,
+			type: 'SIGNUP',
 		})
+		if (result) {
+			loginInfoSession.setSignupEmail(result.target)
+			loginInfoSession.setEmail(result.target)
+			loginInfoSession.flashMessage('Email verified. Finish creating your account.')
+			return redirect('/signup', { headers: await loginInfoSession.getHeaders() })
+		}
+		loginInfoSession.flashError(
+			'Verification link invalid or expired. Please request a new one.',
+		)
+		return redirect('/signup', { headers: await loginInfoSession.getHeaders() })
 	}
 
-	const userForMagicLink = await prisma.user.findFirst({
-		where: { email },
+	const signupEmail = loginInfoSession.getSignupEmail()
+	const email = loginInfoSession.getEmail()
+	const error = loginInfoSession.getError()
+	const message = loginInfoSession.getMessage()
+
+	if (!signupEmail) {
+		return json(
+			{
+				step: 'verify',
+				email: email ?? '',
+				error,
+				message,
+				verificationId,
+			} as const,
+			{ headers: await loginInfoSession.getHeaders() },
+		)
+	}
+
+	// If a user already exists for this email, stop signup and send them to login.
+	const userExists = await prisma.user.findUnique({
+		where: { email: signupEmail },
 		select: { id: true },
 	})
-
-	if (userForMagicLink) {
-		// user exists, but they haven't clicked their magic link yet
-		// we don't want to tell them that a user exists with that email though
-		// so we'll invalidate the magic link and force them to try again.
-		loginInfoSession.clean()
-		loginInfoSession.flashError('Invalid magic link. Try again.')
-		return redirect('/login', {
-			headers: await loginInfoSession.getHeaders(),
-		})
+	if (userExists) {
+		loginInfoSession.unsetSignupEmail()
+		loginInfoSession.flashMessage(
+			'An account already exists for that email. Log in instead (or reset your password).',
+		)
+		return redirect('/login', { headers: await loginInfoSession.getHeaders() })
 	}
 
 	const activities = ['skiing', 'snowboarding', 'onewheeling'] as const
@@ -186,7 +351,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 		activities[Math.floor(Math.random() * activities.length)] ?? 'skiing'
 	return json(
 		{
-			email,
+			step: 'onboarding',
+			email: signupEmail,
+			error,
+			message,
 			// have to put this shuffle in the loader to ensure server render is the same as the client one.
 			teamsInOrder: shuffle(teams),
 			teamMap: activity,
@@ -280,20 +448,116 @@ export default function NewAccount({
 	actionData,
 }: Route.ComponentProps) {
 	const [, setTeam] = useTeam()
+
 	const [formValues, setFormValues] = React.useState<{
 		firstName: string
 		team?: Team
+		password: string
+		confirmPassword: string
 	}>({
 		firstName: '',
 		team: undefined,
+		password: '',
+		confirmPassword: '',
 	})
 
 	const team = formValues.team
 	React.useEffect(() => {
 		if (team && teams.includes(team)) setTeam(team)
 	}, [team, setTeam])
+
+	const passwordIsValid =
+		formValues.password.length >= 8 &&
+		formValues.password === formValues.confirmPassword
 	const formIsValid =
-		formValues.firstName.trim().length > 0 && formValues.team !== undefined
+		formValues.firstName.trim().length > 0 &&
+		formValues.team !== undefined &&
+		passwordIsValid
+
+	if (data.step === 'verify') {
+		return (
+			<div className="mt-24 pt-6">
+				<HeaderSection
+					as="header"
+					title="Create your account."
+					subTitle="We'll email you a verification code."
+					className="mb-16"
+				/>
+				<main>
+					<Grid>
+						<div className="col-span-full lg:col-span-6">
+							{data.error ? (
+								<div className="mb-8">
+									<InputError id="signup-error">{data.error}</InputError>
+								</div>
+							) : null}
+							{data.message ? (
+								<p className="text-secondary mb-8 text-lg">{data.message}</p>
+							) : null}
+
+							<Form method="POST" noValidate className="mb-12">
+								<input
+									type="hidden"
+									name="actionId"
+									value={actionIds.requestCode}
+								/>
+								<Field
+									name="email"
+									label="Email"
+									type="email"
+									autoComplete="email"
+									defaultValue={data.email}
+								/>
+								<Button type="submit">Email me a code</Button>
+							</Form>
+
+							{data.email.match(/.+@.+/) ? (
+								<Form method="POST" noValidate className="mb-12">
+									<input
+										type="hidden"
+										name="actionId"
+										value={actionIds.verifyCode}
+									/>
+									<input type="hidden" name="email" value={data.email} />
+									{data.verificationId ? (
+										<input
+											type="hidden"
+											name="verificationId"
+											value={data.verificationId}
+										/>
+									) : null}
+									<Field
+										name="code"
+										label="Verification code"
+										type="text"
+										autoComplete="one-time-code"
+										placeholder="123456"
+									/>
+									<Button type="submit">Verify code</Button>
+								</Form>
+							) : null}
+
+							<div className="flex flex-wrap gap-4">
+								<ButtonLink to="/login" variant="secondary">
+									Back to login
+								</ButtonLink>
+								<Form method="POST">
+									<input
+										type="hidden"
+										name="actionId"
+										value={actionIds.cancel}
+									/>
+									<Button type="submit" variant="danger">
+										Cancel
+									</Button>
+								</Form>
+							</div>
+						</div>
+					</Grid>
+				</main>
+			</div>
+		)
+	}
 
 	return (
 		<div className="mt-24 pt-6">
@@ -310,21 +574,31 @@ export default function NewAccount({
 						const formData = new FormData(event.currentTarget)
 						const firstName = formData.get('firstName')
 						const team = formData.get('team')
+						const password = formData.get('password')
+						const confirmPassword = formData.get('confirmPassword')
 						const selectedTeam =
 							typeof team === 'string' && isTeam(team) ? team : undefined
 						setFormValues({
 							firstName: typeof firstName === 'string' ? firstName : '',
 							team: selectedTeam,
+							password: typeof password === 'string' ? password : '',
+							confirmPassword:
+								typeof confirmPassword === 'string' ? confirmPassword : '',
 						})
 					}}
 				>
 					<input type="hidden" name="actionId" value={actionIds.signUp} />
 					<Grid>
+						{actionData?.errors.generalError ? (
+							<div className="col-span-full mb-4">
+								<InputError id="general-error">
+									{actionData.errors.generalError}
+								</InputError>
+							</div>
+						) : null}
 						{actionData?.errors.team ? (
 							<div className="col-span-full mb-4 text-right">
-								<InputError id="team-error">
-									{actionData.errors.team}
-								</InputError>
+								<InputError id="team-error">{actionData.errors.team}</InputError>
 							</div>
 						) : null}
 
@@ -387,10 +661,29 @@ export default function NewAccount({
 							/>
 						</div>
 
+						<div className="col-span-full mb-12 lg:col-span-5 lg:mb-20">
+							<Field
+								name="password"
+								label="Password"
+								type="password"
+								autoComplete="new-password"
+								error={actionData?.errors.password}
+							/>
+						</div>
+						<div className="col-span-full mb-12 lg:col-span-5 lg:col-start-7 lg:mb-20">
+							<Field
+								name="confirmPassword"
+								label="Confirm password"
+								type="password"
+								autoComplete="new-password"
+								error={actionData?.errors.confirmPassword}
+							/>
+						</div>
+
 						<div className="col-span-full">
-						<Button type="submit" disabled={!formIsValid}>
-							{`Create account`}
-						</Button>
+							<Button type="submit" disabled={!formIsValid}>
+								{`Create account`}
+							</Button>
 						</div>
 						<p className="text-primary col-span-4 mt-10 text-xs font-medium tracking-wider">
 							{`

--- a/app/utils/fetch-with-timeout.server.ts
+++ b/app/utils/fetch-with-timeout.server.ts
@@ -1,0 +1,18 @@
+/**
+ * Note: We intentionally do NOT use AbortSignal/AbortController here.
+ * Node.js v24 has a bug where aborting fetch requests can crash the process.
+ *
+ * Instead, we use Promise.race to implement timeouts without aborting.
+ */
+export function fetchWithTimeout(
+	url: string,
+	options: RequestInit = {},
+	timeoutMs: number = 1000,
+): Promise<Response> {
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		const id = setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
+		id.unref?.()
+	})
+	return Promise.race([fetch(url, options), timeoutPromise])
+}
+

--- a/app/utils/password.server.ts
+++ b/app/utils/password.server.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto'
 import bcrypt from 'bcrypt'
+import { fetchWithTimeout } from './fetch-with-timeout.server.ts'
 
 const BCRYPT_COST = 10
 // Precomputed bcrypt hash for timing-equal password comparisons.
@@ -22,20 +23,6 @@ export async function verifyPassword({
 	hash: string
 }) {
 	return bcrypt.compare(password, hash)
-}
-
-// Note: We intentionally do NOT use AbortSignal/AbortController here.
-// Node.js v24 has a bug where aborting fetch requests can crash the process.
-function fetchWithTimeout(
-	url: string,
-	options: RequestInit,
-	timeoutMs: number,
-): Promise<Response> {
-	const timeoutPromise = new Promise<never>((_, reject) => {
-		const id = setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
-		id.unref?.()
-	})
-	return Promise.race([fetch(url, options), timeoutPromise])
 }
 
 function getPasswordHashParts(password: string) {

--- a/app/utils/password.server.ts
+++ b/app/utils/password.server.ts
@@ -24,7 +24,7 @@ export async function verifyPassword({
 	return bcrypt.compare(password, hash)
 }
 
-export function getPasswordHashParts(password: string) {
+function getPasswordHashParts(password: string) {
 	const hash = crypto
 		.createHash('sha1')
 		.update(password, 'utf8')
@@ -33,7 +33,7 @@ export function getPasswordHashParts(password: string) {
 	return [hash.slice(0, 5), hash.slice(5)] as const
 }
 
-export async function checkIsCommonPassword(password: string) {
+async function checkIsCommonPassword(password: string) {
 	const [prefix, suffix] = getPasswordHashParts(password)
 	try {
 		const response = await fetch(
@@ -57,7 +57,7 @@ export async function checkIsCommonPassword(password: string) {
 	}
 }
 
-export function getPasswordValidationError(password: string) {
+function getPasswordValidationError(password: string) {
 	if (typeof password !== 'string' || !password.length) {
 		return 'Password is required'
 	}
@@ -65,7 +65,7 @@ export function getPasswordValidationError(password: string) {
 		return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`
 	}
 	if (new TextEncoder().encode(password).length > PASSWORD_MAX_BYTES) {
-		return 'Password is too long'
+		return `Password is too long (max ${PASSWORD_MAX_BYTES} bytes)`
 	}
 	return null
 }

--- a/app/utils/password.server.ts
+++ b/app/utils/password.server.ts
@@ -2,6 +2,9 @@ import crypto from 'node:crypto'
 import bcrypt from 'bcrypt'
 
 const BCRYPT_COST = 10
+// Precomputed bcrypt hash for timing-equal password comparisons.
+export const DUMMY_PASSWORD_HASH =
+	'$2b$10$fvrjcVttSLHkz9k1tjMfqu9ADv42kasEph8Oi2UR0zQNC9h0svQyu'
 const PASSWORD_MIN_LENGTH = 8
 // NOTE: bcrypt only uses the first 72 bytes of the password.
 // Enforcing this avoids giving users a false sense of security.

--- a/app/utils/password.server.ts
+++ b/app/utils/password.server.ts
@@ -1,0 +1,79 @@
+import crypto from 'node:crypto'
+import bcrypt from 'bcrypt'
+
+const BCRYPT_COST = 10
+const PASSWORD_MIN_LENGTH = 8
+// NOTE: bcrypt only uses the first 72 bytes of the password.
+// Enforcing this avoids giving users a false sense of security.
+const PASSWORD_MAX_BYTES = 72
+
+export async function getPasswordHash(password: string) {
+	return bcrypt.hash(password, BCRYPT_COST)
+}
+
+export async function verifyPassword({
+	password,
+	hash,
+}: {
+	password: string
+	hash: string
+}) {
+	return bcrypt.compare(password, hash)
+}
+
+export function getPasswordHashParts(password: string) {
+	const hash = crypto
+		.createHash('sha1')
+		.update(password, 'utf8')
+		.digest('hex')
+		.toUpperCase()
+	return [hash.slice(0, 5), hash.slice(5)] as const
+}
+
+export async function checkIsCommonPassword(password: string) {
+	const [prefix, suffix] = getPasswordHashParts(password)
+	try {
+		const response = await fetch(
+			`https://api.pwnedpasswords.com/range/${prefix}`,
+			{ signal: AbortSignal.timeout(1000) },
+		)
+		if (!response.ok) return false
+		const data = await response.text()
+		return data.split(/\r?\n/).some((line) => {
+			const [hashSuffix] = line.split(':')
+			return hashSuffix === suffix
+		})
+	} catch (error) {
+		// We don't want a third-party outage to block password creation/reset.
+		if (error instanceof DOMException && error.name === 'TimeoutError') {
+			console.warn('Password commonality check timed out')
+			return false
+		}
+		console.warn('Unknown error during password commonality check', error)
+		return false
+	}
+}
+
+export function getPasswordValidationError(password: string) {
+	if (typeof password !== 'string' || !password.length) {
+		return 'Password is required'
+	}
+	if (password.length < PASSWORD_MIN_LENGTH) {
+		return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`
+	}
+	if (new TextEncoder().encode(password).length > PASSWORD_MAX_BYTES) {
+		return 'Password is too long'
+	}
+	return null
+}
+
+export async function getPasswordStrengthError(password: string) {
+	const basicError = getPasswordValidationError(password)
+	if (basicError) return basicError
+	const isCommon = await checkIsCommonPassword(password)
+	if (isCommon) {
+		return 'This password is too common. Please choose a different one.'
+	}
+	return null
+}
+

--- a/app/utils/prisma.server.ts
+++ b/app/utils/prisma.server.ts
@@ -74,6 +74,16 @@ async function deleteExpiredSessions(
 	return result.count
 }
 
+async function deleteExpiredVerifications(
+	{ now = new Date() }: { now?: Date } = {},
+) {
+	await ensurePrimary()
+	const result = await prisma.verification.deleteMany({
+		where: { expiresAt: { lt: now } },
+	})
+	return result.count
+}
+
 async function getUserFromSessionId(
 	sessionId: string,
 	{ timings }: { timings?: Timings } = {},
@@ -151,6 +161,7 @@ export {
 	addPostRead,
 	createSession,
 	deleteExpiredSessions,
+	deleteExpiredVerifications,
 	getAllUserData,
 	getUserFromSessionId,
 	prisma,

--- a/app/utils/send-email.server.ts
+++ b/app/utils/send-email.server.ts
@@ -1,5 +1,4 @@
 import { getRandomFlyingKody } from '#app/images.tsx'
-import { type User } from '#app/types.ts'
 import { markdownToHtmlDocument } from './markdown.server.ts'
 import { getOptionalTeam } from './misc.ts'
 
@@ -51,120 +50,137 @@ async function sendEmail({ to, from, subject, text, html }: MailgunMessage) {
 	})
 }
 
-async function sendMagicLinkEmail({
+async function sendVerificationCodeEmail({
 	emailAddress,
-	magicLink,
-	user,
 	domainUrl,
+	subject,
+	title,
+	verificationCode,
+	verificationUrl,
+	team,
 }: {
 	emailAddress: string
-	magicLink: string
-	user?: User | null
 	domainUrl: string
+	subject: string
+	title: string
+	verificationCode: string
+	verificationUrl: string
+	team?: string | null
 }) {
 	const sender = `"Kent C. Dodds Team" <team+kcd@kentcdodds.com>`
 	const { hostname } = new URL(domainUrl)
-	const userExists = Boolean(user)
-
 	const randomSportyKody = getRandomFlyingKody(
-		user ? getOptionalTeam(user.team) : undefined,
+		team ? getOptionalTeam(team) : undefined,
 	)
 
 	const text = `
-Here's your sign-in link for ${hostname}:
+${title} for ${hostname}
 
-${magicLink}
+Verification code:
+${verificationCode}
 
-${
-	userExists
-		? `Welcome back ${emailAddress}!`
-		: `
-Clicking the link above will create a *new* account on ${hostname} with the email ${emailAddress}. Welcome!
-If you'd instead like to change your email address for an existing account, please send an email to team+email-change@kentcdodds.com from the original email address.
-      `.trim()
-}
+Or click this link:
+${verificationUrl}
 
-Thanks!
-
-– The KCD Team
-
-P.S. If you did not request this email, you can safely ignore it.
-  `.trim()
+This code expires soon. If you did not request this email, you can safely ignore it.
+`.trim()
 
 	const html = `
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-    <style type="text/css">
-      @font-face {
-        font-weight: 500;
-        font-style: normal;
-        font-display: swap;
-      }
-
-      @font-face {
-        font-weight: normal;
-        font-style: normal;
-        font-display: swap;
-      }
-    </style>
   </head>
   <body style="font-family:ui-sans-serif, sans-serif;">
     <div style="margin: 0 auto; max-width: 450px;">
+      <h2 style="text-align: center">${title}</h2>
 
-      <h2 style="text-align: center">${
-				user
-					? `Hey ${user.firstName}! Welcome back to ${hostname}!`
-					: `Hey ${emailAddress}! Welcome to ${hostname}`
-			}</h2>
+      <div style="text-align: center; font-size: 1.1rem; margin-bottom: 1rem;">
+        <div style="color: grey; font-size: .9rem; margin-bottom: .4rem;">Verification code</div>
+        <div style="font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 1.6rem; letter-spacing: .2rem; background: #f3f4f6; padding: .75rem 1rem; border-radius: 7px; display: inline-block;">
+          ${verificationCode}
+        </div>
+      </div>
 
-      <a href="${magicLink}" style="display: block; margin: 0 auto; width: 80%; padding: 1.5rem; background: #A6DEE4; border-radius: 7px; border-width: 0; font-size: 1.1rem; text-align: center; font-family: sans-serif; text-decoration: none; color: black">
-        ${userExists ? 'Login' : 'Create Account'}
+      <a href="${verificationUrl}" style="display: block; margin: 0 auto; width: 80%; padding: 1.2rem; background: #A6DEE4; border-radius: 7px; border-width: 0; font-size: 1.1rem; text-align: center; font-family: sans-serif; text-decoration: none; color: black">
+        Continue on ${hostname}
       </a>
 
       <br />
 
-      <center><img src="https://res.cloudinary.com/kentcdodds-com/image/upload/w_800,q_auto,f_auto/${
-				randomSportyKody.id
-			}" style="max-width: 80%;${
+      <center><img src="https://res.cloudinary.com/kentcdodds-com/image/upload/w_800,q_auto,f_auto/${randomSportyKody.id}" style="max-width: 80%;${
 				randomSportyKody.style?.aspectRatio
 					? `aspect-ratio: ${randomSportyKody.style.aspectRatio};`
 					: ''
 			}"></center>
 
-      <h3 style="text-align: center">Click the button above to login to ${hostname}</h3>
-
-      <div style="text-align: center; margin-top: 1rem; font-size: .9rem">
-        <div style="color: grey">This link is valid for 30 minutes.</div>
-        <a href="${domainUrl}/login" style="margin-top: .4rem; display: block">Click here to request a new link.</a>
-        <div style="color: grey">Be certain the link opens in the same browser you requested it from.</div>
-      </div>
-        
       <hr style="width: 20%; height: 0px; border: 1px solid lightgrey; margin-top: 2rem; margin-bottom: 2rem">
-        
+
       <div style="text-align: center; color: grey; font-size: .8rem; line-height: 1.2rem">
-        You received this because your email address was used to sign up for an account on
-        <a href="${domainUrl}" style="color: grey">${hostname}</a>. If you didn't sign up for an account,
-        feel free to disregard this email.
+        You received this because your email address was used on
+        <a href="${domainUrl}" style="color: grey">${hostname}</a>.
+        If you didn't request this, you can disregard this email.
       </div>
     </div>
   </body>
 </html>
-  `
+`
 
-	const message = {
+	await sendEmail({
 		from: sender,
 		to: emailAddress,
-		subject: `Here's your Magic ✨ sign-in link for kentcdodds.com`,
+		subject,
 		text,
 		html,
-	}
-
-	await sendEmail(message)
+	})
 }
 
-export { sendEmail, sendMagicLinkEmail }
+async function sendSignupVerificationEmail({
+	emailAddress,
+	verificationCode,
+	verificationUrl,
+	domainUrl,
+}: {
+	emailAddress: string
+	verificationCode: string
+	verificationUrl: string
+	domainUrl: string
+}) {
+	return sendVerificationCodeEmail({
+		emailAddress,
+		domainUrl,
+		subject: `Your verification code for kentcdodds.com`,
+		title: `Verify your email address`,
+		verificationCode,
+		verificationUrl,
+	})
+}
+
+async function sendPasswordResetEmail({
+	emailAddress,
+	verificationCode,
+	verificationUrl,
+	domainUrl,
+	team,
+}: {
+	emailAddress: string
+	verificationCode: string
+	verificationUrl: string
+	domainUrl: string
+	team?: string | null
+}) {
+	return sendVerificationCodeEmail({
+		emailAddress,
+		domainUrl,
+		subject: `Reset your password for kentcdodds.com`,
+		title: `Reset your password`,
+		verificationCode,
+		verificationUrl,
+		team,
+	})
+}
+
+export { sendEmail, sendSignupVerificationEmail, sendPasswordResetEmail }
 
 /*
 eslint

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -2,17 +2,13 @@ import { createCookieSessionStorage, redirect } from 'react-router';
 import { z } from 'zod'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { type User } from '#app/utils/prisma-generated.server/client.ts'
-import { getLoginInfoSession } from './login.server.ts'
 import { getRequiredServerEnvVar } from './misc.ts'
 import {
 	createSession,
-	getMagicLink,
 	getUserFromSessionId,
 	prisma,
 	sessionExpirationTime,
-	validateMagicLink,
 } from './prisma.server.ts'
-import { sendMagicLinkEmail } from './send-email.server.ts'
 import { time, type Timings } from './timing.server.ts'
 
 const sessionIdKey = '__session_id__'
@@ -28,35 +24,6 @@ const sessionStorage = createCookieSessionStorage({
 		httpOnly: true,
 	},
 })
-
-async function sendToken({
-	emailAddress,
-	domainUrl,
-}: {
-	emailAddress: string
-	domainUrl: string
-}) {
-	const magicLink = getMagicLink({
-		emailAddress,
-		validateSessionMagicLink: true,
-		domainUrl,
-	})
-
-	const user = await prisma.user
-		.findUnique({ where: { email: emailAddress } })
-		.catch(() => {
-			/* ignore... */
-			return null
-		})
-
-	await sendMagicLinkEmail({
-		emailAddress,
-		magicLink,
-		user,
-		domainUrl,
-	})
-	return magicLink
-}
 
 async function getSession(request: Request) {
 	const session = await sessionStorage.getSession(request.headers.get('Cookie'))
@@ -190,21 +157,6 @@ async function getUser(
 	})
 }
 
-async function getUserSessionFromMagicLink(request: Request) {
-	const loginInfoSession = await getLoginInfoSession(request)
-	const email = await validateMagicLink(
-		request.url,
-		loginInfoSession.getMagicLink(),
-	)
-
-	const user = await prisma.user.findUnique({ where: { email } })
-	if (!user) return null
-
-	const session = await getSession(request)
-	await session.signIn(user)
-	return session
-}
-
 async function requireAdminUser(request: Request): Promise<User> {
 	const user = await getUser(request)
 	if (!user) {
@@ -234,9 +186,7 @@ async function requireUser(
 export {
 	getSession,
 	deleteOtherSessions,
-	getUserSessionFromMagicLink,
 	requireUser,
 	requireAdminUser,
 	getUser,
-	sendToken,
 }

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -63,6 +63,15 @@ async function getSession(request: Request) {
 				prisma.session
 					.delete({ where: { id: sessionId } })
 					.catch((error: unknown) => {
+						// It's possible the session was already deleted (ex: user deleted).
+						if (
+							error &&
+							typeof error === 'object' &&
+							'code' in error &&
+							error.code === 'P2025'
+						) {
+							return
+						}
 						console.error(`Failure deleting user session: `, error)
 					})
 			}

--- a/app/utils/user-info.server.ts
+++ b/app/utils/user-info.server.ts
@@ -5,6 +5,7 @@ import { cache, cachified } from './cache.server.ts'
 import * as discord from './discord.server.ts'
 import { getAvatar, getOptionalTeam } from './misc-react.tsx'
 import { type Timings } from './timing.server.ts'
+import { fetchWithTimeout } from './fetch-with-timeout.server.ts'
 
 type UserInfo = {
 	avatar: {
@@ -18,21 +19,6 @@ type UserInfo = {
 	discord: {
 		username: string
 	} | null
-}
-
-// Note: We intentionally do NOT use AbortSignal or AbortController here.
-// Node.js v24 has a bug where aborting fetch requests causes a crash:
-// "uv__stream_destroy: Assertion `!uv__io_active...` failed"
-// Instead, we use Promise.race to implement timeouts without aborting.
-async function fetchWithTimeout(
-	url: string,
-	options: RequestInit,
-	timeoutMs: number,
-): Promise<Response> {
-	const timeoutPromise = new Promise<never>((_, reject) => {
-		setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
-	})
-	return Promise.race([fetch(url, options), timeoutPromise])
 }
 
 export async function gravatarExistsForEmail({

--- a/app/utils/user-info.server.ts
+++ b/app/utils/user-info.server.ts
@@ -3,9 +3,9 @@ import { getImageBuilder, images } from '../images.tsx'
 import * as k from '../kit/kit.server.ts'
 import { cache, cachified } from './cache.server.ts'
 import * as discord from './discord.server.ts'
+import { fetchWithTimeout } from './fetch-with-timeout.server.ts'
 import { getAvatar, getOptionalTeam } from './misc-react.tsx'
 import { type Timings } from './timing.server.ts'
-import { fetchWithTimeout } from './fetch-with-timeout.server.ts'
 
 type UserInfo = {
 	avatar: {

--- a/app/utils/verification.server.ts
+++ b/app/utils/verification.server.ts
@@ -98,7 +98,3 @@ export async function consumeVerificationForTarget({
 	return { target: verification.target }
 }
 
-export function getVerificationCodeMaxAgeMs() {
-	return VERIFICATION_CODE_MAX_AGE_MS
-}
-

--- a/app/utils/verification.server.ts
+++ b/app/utils/verification.server.ts
@@ -64,7 +64,15 @@ export async function consumeVerification({
 	if (!isValid) return null
 
 	await ensurePrimary()
-	await prisma.verification.delete({ where: { id: verification.id } })
+	try {
+		await prisma.verification.delete({ where: { id: verification.id } })
+	} catch (error: unknown) {
+		// Another request may have consumed/deleted it first.
+		if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
+			return null
+		}
+		throw error
+	}
 
 	return { target: verification.target }
 }
@@ -93,7 +101,15 @@ export async function consumeVerificationForTarget({
 	if (!isValid) return null
 
 	await ensurePrimary()
-	await prisma.verification.delete({ where: { id: verification.id } })
+	try {
+		await prisma.verification.delete({ where: { id: verification.id } })
+	} catch (error: unknown) {
+		// Another request may have consumed/deleted it first.
+		if (error && typeof error === 'object' && 'code' in error && error.code === 'P2025') {
+			return null
+		}
+		throw error
+	}
 
 	return { target: verification.target }
 }

--- a/app/utils/verification.server.ts
+++ b/app/utils/verification.server.ts
@@ -1,0 +1,104 @@
+import crypto from 'node:crypto'
+import bcrypt from 'bcrypt'
+import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
+
+const VERIFICATION_CODE_DIGITS = 6
+const VERIFICATION_CODE_MAX_AGE_MS = 1000 * 60 * 10
+
+export type VerificationType = 'SIGNUP' | 'PASSWORD_RESET'
+
+function generateVerificationCode() {
+	// 000000 - 999999 (left-padded)
+	const code = crypto
+		.randomInt(0, Math.pow(10, VERIFICATION_CODE_DIGITS))
+		.toString()
+		.padStart(VERIFICATION_CODE_DIGITS, '0')
+	return code
+}
+
+export async function createVerification({
+	type,
+	target,
+}: {
+	type: VerificationType
+	target: string
+}) {
+	const code = generateVerificationCode()
+	const codeHash = await bcrypt.hash(code, 10)
+	const expiresAt = new Date(Date.now() + VERIFICATION_CODE_MAX_AGE_MS)
+
+	await ensurePrimary()
+	const verification = await prisma.verification.create({
+		data: {
+			type,
+			target,
+			codeHash,
+			expiresAt,
+		},
+		select: { id: true, expiresAt: true, target: true, type: true },
+	})
+
+	return { verification, code }
+}
+
+export async function consumeVerification({
+	id,
+	code,
+	type,
+}: {
+	id: string
+	code: string
+	type: VerificationType
+}) {
+	const verification = await prisma.verification.findUnique({
+		where: { id },
+		select: { id: true, type: true, target: true, codeHash: true, expiresAt: true },
+	})
+
+	if (!verification) return null
+	if (verification.type !== type) return null
+	if (Date.now() > verification.expiresAt.getTime()) return null
+
+	const isValid = await bcrypt.compare(code, verification.codeHash)
+	if (!isValid) return null
+
+	await ensurePrimary()
+	await prisma.verification.delete({ where: { id: verification.id } })
+
+	return { target: verification.target }
+}
+
+export async function consumeVerificationForTarget({
+	target,
+	code,
+	type,
+}: {
+	target: string
+	code: string
+	type: VerificationType
+}) {
+	const verification = await prisma.verification.findFirst({
+		where: {
+			target,
+			type,
+			expiresAt: { gt: new Date() },
+		},
+		orderBy: { createdAt: 'desc' },
+		select: { id: true, type: true, target: true, codeHash: true, expiresAt: true },
+	})
+	if (!verification) return null
+
+	const isValid = await bcrypt.compare(code, verification.codeHash)
+	if (!isValid) return null
+
+	await ensurePrimary()
+	await prisma.verification.delete({ where: { id: verification.id } })
+
+	return { target: verification.target }
+}
+
+export function getVerificationCodeMaxAgeMs() {
+	return VERIFICATION_CODE_MAX_AGE_MS
+}
+

--- a/app/utils/x.server.ts
+++ b/app/utils/x.server.ts
@@ -19,8 +19,23 @@ type Metadata = {
 	description?: string
 	image?: string
 }
+
+// Note: We intentionally do NOT use AbortSignal/AbortController here.
+// Node.js v24 has a bug where aborting fetch requests can crash the process.
+function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		const id = setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
+		id.unref?.()
+	})
+	return Promise.race([fetch(url), timeoutPromise])
+}
+
 async function getMetadata(url: string): Promise<Metadata> {
-	const html = await fetch(url).then((res) => res.text())
+	// In mocks mode we don't want to make arbitrary external HTTP requests for
+	// link metadata (it can hang CI / e2e test runs and adds nondeterminism).
+	if (process.env.MOCKS === 'true') return {}
+
+	const html = await fetchWithTimeout(url, 2_000).then((res) => res.text())
 	return metascraper({ html, url })
 }
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -25,8 +25,9 @@ test('A new user can create an account', async ({ page }) => {
 	await expect(page).toHaveURL(/.*signup/)
 
 	// request signup verification code
-	await page.getByRole('textbox', { name: /email/i }).fill(emailAddress)
-	await page.getByRole('button', { name: /email me a code/i }).click()
+	const signupMain = page.getByRole('main')
+	await signupMain.getByRole('textbox', { name: /email/i }).fill(emailAddress)
+	await signupMain.getByRole('button', { name: /email me a code/i }).click()
 	await expect(page.getByText(/verification code sent/i)).toBeVisible()
 
 	// read and verify the email

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -9,7 +9,7 @@ test('A new user can create an account', async ({ page }) => {
 		firstName,
 		lastName: faker.person.lastName(),
 		provider: 'example.com',
-	})
+	}).toLowerCase()
 	const password = faker.internet.password({ length: 16 })
 	await page.goto('/')
 	await page

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -69,6 +69,10 @@ const miscHandlers = [
 	http.get('https://verifyright.co/verify/:email', () => {
 		return HttpResponse.json({ status: true })
 	}),
+	http.get('https://api.pwnedpasswords.com/range/:prefix', () => {
+		// Empty response means "not found" for all suffixes.
+		return new HttpResponse('', { status: 200 })
+	}),
 ]
 
 const server = setupServer(

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/bcrypt": "^6.0.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/compression": "^1.8.1",
         "@types/cookie-session": "^2.0.49",
@@ -10272,6 +10273,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/bcrypt": "^6.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/compression": "^1.8.1",
     "@types/cookie-session": "^2.0.49",

--- a/prisma/migrations/20260221204337_password_auth/migration.sql
+++ b/prisma/migrations/20260221204337_password_auth/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "Password" (
+    "hash" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "Password_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Verification" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "type" TEXT NOT NULL,
+    "target" TEXT NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Password_userId_key" ON "Password"("userId");
+
+-- CreateIndex
+CREATE INDEX "Verification_target_type_idx" ON "Verification"("target", "type");
+
+-- CreateIndex
+CREATE INDEX "Verification_expiresAt_idx" ON "Verification"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   kitId     String?
   role      String     @default("MEMBER")
   team      String
+  password  Password?
   passkeys  Passkey[]
   calls     Call[]
   sessions  Session[]
@@ -36,6 +37,27 @@ model User {
   @@index([team])
   @@index([createdAt])
   @@index([role])
+}
+
+model Password {
+  hash      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String @unique
+}
+
+model Verification {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  type      String
+  target    String
+  codeHash  String
+  expiresAt DateTime
+
+  @@index([target, type])
+  @@index([expiresAt])
 }
 
 model Session {

--- a/server/expired-sessions-cleanup.ts
+++ b/server/expired-sessions-cleanup.ts
@@ -1,5 +1,8 @@
 import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
-import { deleteExpiredSessions } from '../app/utils/prisma.server.ts'
+import {
+	deleteExpiredSessions,
+	deleteExpiredVerifications,
+} from '../app/utils/prisma.server.ts'
 
 type CleanupController = {
 	stop: () => Promise<void>
@@ -54,10 +57,11 @@ export function scheduleExpiredSessionsCleanup({
 					await getInstanceInfo()
 				if (!currentIsPrimary) return
 
-				const deletedCount = await deleteExpiredSessions()
-				if (deletedCount > 0) {
+				const deletedSessionsCount = await deleteExpiredSessions()
+				const deletedVerificationsCount = await deleteExpiredVerifications()
+				if (deletedSessionsCount > 0 || deletedVerificationsCount > 0) {
 					console.info(
-						`expired-sessions-cleanup: deleted ${deletedCount} expired sessions (${reason})`,
+						`expired-sessions-cleanup: deleted ${deletedSessionsCount} expired sessions and ${deletedVerificationsCount} expired verifications (${reason})`,
 						{
 							currentInstance,
 							primaryInstance,

--- a/server/expired-sessions-cleanup.ts
+++ b/server/expired-sessions-cleanup.ts
@@ -31,7 +31,7 @@ function randomInt(min: number, max: number) {
 	return Math.floor(Math.random() * (max - min + 1)) + min
 }
 
-export function scheduleExpiredSessionsCleanup({
+export function scheduleExpiredDataCleanup({
 	intervalMs = DAY_MS,
 	startupDelayMs = randomInt(30_000, 5 * 60_000),
 	enabled = process.env.EXPIRED_SESSIONS_CLEANUP_DISABLED !== 'true', // enabled unless explicitly disabled
@@ -61,7 +61,7 @@ export function scheduleExpiredSessionsCleanup({
 				const deletedVerificationsCount = await deleteExpiredVerifications()
 				if (deletedSessionsCount > 0 || deletedVerificationsCount > 0) {
 					console.info(
-						`expired-sessions-cleanup: deleted ${deletedSessionsCount} expired sessions and ${deletedVerificationsCount} expired verifications (${reason})`,
+						`expired-data-cleanup: deleted ${deletedSessionsCount} expired sessions and ${deletedVerificationsCount} expired verifications (${reason})`,
 						{
 							currentInstance,
 							primaryInstance,
@@ -69,7 +69,7 @@ export function scheduleExpiredSessionsCleanup({
 					)
 				}
 			} catch (error: unknown) {
-				console.error(`expired-sessions-cleanup: failed (${reason})`, error)
+				console.error(`expired-data-cleanup: failed (${reason})`, error)
 			} finally {
 				runningPromise = null
 			}

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,7 +22,7 @@ import serverTiming from 'server-timing'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
 import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
-import { scheduleExpiredSessionsCleanup } from './expired-sessions-cleanup.js'
+import { scheduleExpiredDataCleanup } from './expired-sessions-cleanup.js'
 import { createRateLimitingMiddleware } from './rate-limiting.js'
 import {
 	getRedirectsMiddleware,
@@ -105,7 +105,7 @@ const app = express()
 app.set('trust proxy', true)
 app.use(serverTiming())
 
-const expiredSessionsCleanup = scheduleExpiredSessionsCleanup()
+const expiredDataCleanup = scheduleExpiredDataCleanup()
 
 app.get('/img/social', oldImgSocial)
 
@@ -477,7 +477,7 @@ if (process.env.NODE_ENV === 'development') {
 
 closeWithGrace(() => {
 	return Promise.all([
-		expiredSessionsCleanup.stop(),
+		expiredDataCleanup.stop(),
 		new Promise((resolve, reject) => {
 			server.close((e) => (e ? reject(e) : resolve('ok')))
 		}),

--- a/server/rate-limiting.ts
+++ b/server/rate-limiting.ts
@@ -66,6 +66,9 @@ export function createRateLimitingMiddleware(
 		const strongestNonGetPaths = [
 			'/login',
 			'/signup',
+			'/forgot-password',
+			'/reset-password',
+			'/me/password',
 			'/oauth/authorize',
 			// Covers: /calls/admin, /cache/admin, /me/admin, /search/admin
 			'/admin',
@@ -81,7 +84,12 @@ export function createRateLimitingMiddleware(
 		}
 
 		// GET routes that can include sensitive tokens/codes in the query string.
-		const strongestGetPaths = ['/magic', '/discord/callback']
+		const strongestGetPaths = [
+			'/magic',
+			'/discord/callback',
+			'/signup',
+			'/reset-password',
+		]
 		if (strongestGetPaths.some((p) => req.path.includes(p))) {
 			return strongestRateLimit(req, res, next)
 		}


### PR DESCRIPTION
Add password-based authentication, replacing the magic-link flow, to address issue #561.

The existing authentication relied on magic links and passkeys. This PR introduces a `Password` model, bcrypt hashing, and verification code flows for signup and password reset, aligning with the requirements of issue #561 to move to a more traditional email+password login.

---
<p><a href="https://cursor.com/agents?id=bc-27ee2999-2e6a-4607-8337-5658d3dabafd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ee2999-2e6a-4607-8337-5658d3dabafd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core authentication, session handling, and email verification/reset flows, plus introduces new credential storage and validation logic; mistakes could lock users out or weaken account security.
> 
> **Overview**
> Replaces the passwordless magic-link auth flow with **email+password login** and code-based email verification for both signup and password resets.
> 
> Adds new `Password` and `Verification` persistence (Prisma migration/models) plus server utilities for bcrypt hashing, password-strength/common-password checks (HIBP via `fetchWithTimeout`), and verification-code creation/consumption. Introduces new routes for `forgot-password`, `reset-password`, and `/me/password`, rewires `signup` into a verify-then-onboard flow, updates `login` UI/action to accept passwords, and changes `/magic` to a deprecated redirect message.
> 
> Also updates sessions/UI wiring (`loginInfoSession` now tracks `signupEmail`/messages), extends rate limiting and cleanup jobs to cover verification records, and adjusts e2e/mocks accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a02a1ccfa3dc5f0a05aa5dc66b3d42d87fc21f22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-based sign-in, account password management, and verification-code signup/reset flows.

* **Changes**
  * Magic-link login removed; signup and reset use verification codes and require passwords.
  * UI and messaging updated across login, signup, profile, forgot/reset-password, and account pages.
  * Form Field supports optional autocomplete; stronger password validation and common-password checks.
  * Email content now sends verification codes instead of magic links.

* **Tests**
  * Password-breach API mocked for tests.

* **Chores**
  * DB migration and cleanup now include verification records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->