### PR TITLE
Calls page favorite icon size

### DIFF
--- a/app/routes/resources/favorite.tsx
+++ b/app/routes/resources/favorite.tsx
@@ -83,10 +83,13 @@ export function FavoriteToggle({
 	const nextIntent = isFavorite ? 'remove' : 'add'
 	const isBusy = fetcher.state !== 'idle'
 
+	// Icon-only buttons sit next to other 24px icons (ex: 𝕏 on calls pages),
+	// so bump the icon size in `mode="icon"` to match.
+	const iconSize = mode === 'icon' ? 24 : 18
 	const icon = isBusy ? (
-		<SpinnerIcon size={18} className="animate-spin" />
+		<SpinnerIcon size={iconSize} className="animate-spin" />
 	) : (
-		<StarIcon size={18} filled={isFavorite} />
+		<StarIcon size={iconSize} filled={isFavorite} />
 	)
 
 	const text = isFavorite ? 'Favorited' : label


### PR DESCRIPTION
Increase the size of the favorite icon on the calls page to match the adjacent 𝕏 icon.

---
<p><a href="https://cursor.com/agents?id=bc-47330c70-b083-44fc-8790-f1cbb4f591cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47330c70-b083-44fc-8790-f1cbb4f591cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI sizing tweak with no changes to data flow, server behavior, or state management.
> 
> **Overview**
> Adjusts `FavoriteToggle` so the star/spinner icon scales to `24px` when `mode="icon"` (instead of always `18px`), aligning icon-only favorites with other 24px controls on pages like Calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f764e0596493786b91c3a1eccab0a8dfe799fed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon sizing to properly scale based on display mode, ensuring consistent sizing across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->