### PR TITLE
Podcast latest season links

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -119,7 +119,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 		getClientSession(request, session.getUser({ timings })),
 		getLoginInfoSession(request),
 		getInstanceInfo().then((i) => i.primaryInstance),
-		getLatestPodcastSeasonLinks({ request, timings }),
+		getLatestPodcastSeasonLinks({ request, timings }).catch(() => ({
+			chats: { latestSeasonNumber: null, latestSeasonPath: '/chats' },
+			calls: { latestSeasonNumber: null, latestSeasonPath: '/calls' },
+		})),
 	])
 
 	const randomFooterImageKeys = Object.keys(illustrationImages)

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -37,6 +37,7 @@ import { getClientSession } from './utils/client.server.ts'
 import { getEnv } from './utils/env.server.ts'
 import { getLoginInfoSession } from './utils/login.server.ts'
 import { useNonce } from './utils/nonce-provider.ts'
+import { getLatestPodcastSeasonLinks } from './utils/podcast-latest-season.server.ts'
 import { getSocialMetas } from './utils/seo.ts'
 import { getSession } from './utils/session.server.ts'
 import { TeamProvider, useTeam } from './utils/team-provider.tsx'
@@ -44,7 +45,6 @@ import { getTheme } from './utils/theme.server.ts'
 import { useTheme } from './utils/theme.tsx'
 import { getServerTimeHeader } from './utils/timing.server.ts'
 import { getUserInfo } from './utils/user-info.server.ts'
-import { getLatestPodcastSeasonLinks } from './utils/podcast-latest-season.server.ts'
 
 export const handle: KCDHandle & { id: string } = {
 	id: 'root',

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -44,6 +44,7 @@ import { getTheme } from './utils/theme.server.ts'
 import { useTheme } from './utils/theme.tsx'
 import { getServerTimeHeader } from './utils/timing.server.ts'
 import { getUserInfo } from './utils/user-info.server.ts'
+import { getLatestPodcastSeasonLinks } from './utils/podcast-latest-season.server.ts'
 
 export const handle: KCDHandle & { id: string } = {
 	id: 'root',
@@ -107,11 +108,18 @@ export const links: LinksFunction = () => {
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
 	const session = await getSession(request)
-	const [user, clientSession, loginInfoSession, primaryInstance] = await Promise.all([
+	const [
+		user,
+		clientSession,
+		loginInfoSession,
+		primaryInstance,
+		latestPodcastSeasonLinks,
+	] = await Promise.all([
 		session.getUser({ timings }),
 		getClientSession(request, session.getUser({ timings })),
 		getLoginInfoSession(request),
 		getInstanceInfo().then((i) => i.primaryInstance),
+		getLatestPodcastSeasonLinks({ request, timings }),
 	])
 
 	const randomFooterImageKeys = Object.keys(illustrationImages)
@@ -122,6 +130,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const data = {
 		user,
 		userInfo: user ? await getUserInfo(user, { request, timings }) : null,
+		latestPodcastSeasonLinks,
 		ENV: getEnv(),
 		randomFooterImageKey,
 		requestInfo: {

--- a/app/utils/podcast-latest-season.server.ts
+++ b/app/utils/podcast-latest-season.server.ts
@@ -29,7 +29,7 @@ async function getLatestChatsSeasonNumber({
 		const { getSeasonListItems } = await import('./simplecast.server.ts')
 		const seasons = await getSeasonListItems({ request, timings })
 		const latestSeasonNumber = seasons.reduce(
-			(max, s) => Math.max(max, s.seasonNumber),
+			(max, s) => Math.max(max, s.seasonNumber ?? 0),
 			0,
 		)
 		return latestSeasonNumber || null

--- a/app/utils/podcast-latest-season.server.ts
+++ b/app/utils/podcast-latest-season.server.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod'
+import { cache, cachified } from './cache.server.ts'
+import { type Timings } from './timing.server.ts'
+
+const latestPodcastSeasonLinksSchema = z.object({
+	chats: z.object({
+		latestSeasonNumber: z.number().nullable(),
+		latestSeasonPath: z.string().min(1),
+	}),
+	calls: z.object({
+		latestSeasonNumber: z.number().nullable(),
+		latestSeasonPath: z.string().min(1),
+	}),
+})
+
+function formatSeasonParam(seasonNumber: number) {
+	return String(seasonNumber).padStart(2, '0')
+}
+
+async function getLatestChatsSeasonNumber({
+	request,
+	timings,
+}: {
+	request: Request
+	timings?: Timings
+}) {
+	try {
+		// Dynamic import so missing podcast env vars don't crash the whole app.
+		const { getSeasonListItems } = await import('./simplecast.server.ts')
+		const seasons = await getSeasonListItems({ request, timings })
+		const latestSeasonNumber = seasons.reduce(
+			(max, s) => Math.max(max, s.seasonNumber),
+			0,
+		)
+		return latestSeasonNumber || null
+	} catch (error: unknown) {
+		console.error('podcast-latest-season: failed to load chats seasons', error)
+		return null
+	}
+}
+
+async function getLatestCallsSeasonNumber({
+	request,
+	timings,
+}: {
+	request: Request
+	timings?: Timings
+}) {
+	try {
+		// Dynamic import so missing podcast env vars don't crash the whole app.
+		const { getEpisodes } = await import('./transistor.server.ts')
+		const episodes = await getEpisodes({ request, timings })
+		const latestSeasonNumber = episodes.reduce(
+			(max, e) => Math.max(max, e.seasonNumber ?? 0),
+			0,
+		)
+		return latestSeasonNumber || null
+	} catch (error: unknown) {
+		console.error('podcast-latest-season: failed to load calls episodes', error)
+		return null
+	}
+}
+
+export async function getLatestPodcastSeasonLinks({
+	request,
+	timings,
+}: {
+	request: Request
+	timings?: Timings
+}) {
+	return cachified({
+		cache,
+		request,
+		timings,
+		key: 'podcasts:latest-season-links',
+		// Keep this fairly fresh; it’s used on every page load for nav links.
+		ttl: 1000 * 60 * 5,
+		staleWhileRevalidate: 1000 * 60 * 60 * 24,
+		checkValue: latestPodcastSeasonLinksSchema,
+		getFreshValue: async () => {
+			const [latestChatsSeasonNumber, latestCallsSeasonNumber] =
+				await Promise.all([
+					getLatestChatsSeasonNumber({ request, timings }),
+					getLatestCallsSeasonNumber({ request, timings }),
+				])
+
+			return {
+				chats: {
+					latestSeasonNumber: latestChatsSeasonNumber,
+					latestSeasonPath: latestChatsSeasonNumber
+						? `/chats/${formatSeasonParam(latestChatsSeasonNumber)}`
+						: '/chats',
+				},
+				calls: {
+					latestSeasonNumber: latestCallsSeasonNumber,
+					latestSeasonPath: latestCallsSeasonNumber
+						? `/calls/${formatSeasonParam(latestCallsSeasonNumber)}`
+						: '/calls',
+				},
+			}
+		},
+	})
+}
+

--- a/app/utils/podcast-latest-season.server.ts
+++ b/app/utils/podcast-latest-season.server.ts
@@ -73,7 +73,7 @@ export async function getLatestPodcastSeasonLinks({
 		request,
 		timings,
 		key: 'podcasts:latest-season-links',
-		// Keep this fairly fresh; it’s used on every page load for nav links.
+		// Keep this fairly fresh; it's used on every page load for nav links.
 		ttl: 1000 * 60 * 5,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
 		checkValue: latestPodcastSeasonLinksSchema,


### PR DESCRIPTION
Update podcast navigation links to dynamically point to the latest season.

This ensures users are always directed to the most current podcast content and avoids outdated hardcoded links in the navigation.

---
<p><a href="https://cursor.com/agents?id=bc-011bea21-3231-4a8a-a738-08ddbebf94d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-011bea21-3231-4a8a-a738-08ddbebf94d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the root loader and adds server-side calls to external podcast providers (even though cached and guarded), so failures/perf regressions could affect all page loads and nav routing.
> 
> **Overview**
> Navbar `Chats`/`Calls` links are now derived at runtime to point to the latest podcast season instead of hardcoded season routes, with mobile and desktop menus sharing this computed link set.
> 
> Root loader now fetches and exposes `latestPodcastSeasonLinks`, backed by a new cached server utility that queries Simplecast/Transistor, validates shape with `zod`, and falls back to base `/chats`/`/calls` paths on failure. Active nav highlighting was adjusted via an `activeTo` prefix so season-specific links still show active for all `/chats/*` and `/calls/*` routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02aa4f66ab4559c1526af79694988b2e14760be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navbar and mobile menu now build links dynamically and route to the latest podcast season when available
  * Improved active-route detection so navigation highlights match broader or nested routes more accurately

* **Performance**
  * Latest podcast season info is fetched and cached to reduce load and improve responsiveness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->