### PR TITLE
Sentry sourcemap 404

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -87,11 +87,17 @@ const getHost = (req: { get: (key: string) => string | undefined }) =>
 
 const MODE = process.env.NODE_ENV
 
-if (MODE === 'production' && process.env.SENTRY_DSN) {
+const SHOULD_INIT_SENTRY =
+	MODE === 'production' &&
+	Boolean(process.env.SENTRY_DSN) &&
+	// `start:mocks` (used in CI + local e2e) runs with `MOCKS=true`.
+	process.env.MOCKS !== 'true'
+
+if (SHOULD_INIT_SENTRY) {
 	void import('./utils/monitoring.js').then(({ init }) => init())
 }
 
-if (MODE === 'production') {
+if (SHOULD_INIT_SENTRY) {
 	sentryInit({
 		dsn: process.env.SENTRY_DSN,
 		tracesSampleRate: 0.3,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,8 @@ if (SENTRY_UPLOAD && MODE === 'production') {
 	const authToken = process.env.SENTRY_AUTH_TOKEN
 	const project = process.env.SENTRY_PROJECT
 	const org = process.env.SENTRY_ORG
+	// New-style Sentry auth tokens (prefix "sntrys_") embed the org, so SENTRY_ORG
+	// is not required when using one.
 	const tokenImpliesOrg = Boolean(authToken?.startsWith('sntrys_'))
 
 	// If upload is "on" but required settings are missing, the Sentry plugin will
@@ -66,6 +68,10 @@ export default defineConfig(async () => {
 				: null,
 		],
 		build: {
+			// This is an OSS project, so it's fine to generate "regular" sourcemaps.
+			// If we ever want sourcemaps upload without exposing them publicly, switch
+			// to `sourcemap: 'hidden'` (and keep uploading to Sentry).
+			sourcemap: true,
 			cssMinify: MODE === 'production',
 			rollupOptions: {
 				external: [/node:.*/, 'stream', 'crypto'],


### PR DESCRIPTION
Prevent Sentry sourcemap upload failures from silently deleting map files and returning 404 HTML, by making failures fatal and fixing `filesToDeleteAfterUpload` globs.

The Sentry Vite plugin was configured to delete sourcemap files even if the upload failed, leading to Sentry receiving the application's 404 HTML page when it tried to fetch the maps. This change ensures that upload failures halt the build and that sourcemaps are only deleted after a successful upload.

---
<p><a href="https://cursor.com/agents?id=bc-3879de35-455f-4b48-8e7e-c0118e2e8429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3879de35-455f-4b48-8e7e-c0118e2e8429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/deploy behavior changes: production builds can now fail on missing/invalid Sentry configuration and sourcemap handling changes may affect artifact size and CI/release pipelines.
> 
> **Overview**
> Tightens Sentry behavior across server and build: Sentry initialization is now gated behind a single `SHOULD_INIT_SENTRY` flag (production + DSN present + not `MOCKS=true`), preventing Sentry setup during mocked CI/e2e runs.
> 
> On the Vite build side, `SENTRY_UPLOAD` is normalized to a strict boolean and production builds now **fail fast** when upload is enabled but required Sentry env vars are missing; the Sentry Vite plugin is configured to throw on upload/release errors and the build always generates sourcemaps (`build.sourcemap: true`) rather than managing deletion via `filesToDeleteAfterUpload` globs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e806864fbd875d422d165726b68e17a2cf8c858f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build now fails when Sentry upload/release errors occur, surfacing symbolication issues earlier.
  * Sentry/monitoring is skipped in mock/CI scenarios to avoid unintended initialization.

* **Chores**
  * Stronger validation of required Sentry settings in production builds.
  * Standard sourcemap generation enabled and source map cleanup logic simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->