### PR TITLE
Simplecast 429 backoff

### DIFF
--- a/app/utils/__tests__/fetch-json-with-retry-after.server.test.ts
+++ b/app/utils/__tests__/fetch-json-with-retry-after.server.test.ts
@@ -1,0 +1,60 @@
+import { expect, test, vi } from 'vitest'
+import {
+	fetchJsonWithRetryAfter,
+	getRetryDelayMsFromResponse,
+} from '../fetch-json-with-retry-after.server.ts'
+
+test('fetchJsonWithRetryAfter waits Retry-After seconds on 429 then retries', async () => {
+	const sleep = vi.fn(async () => {})
+	const fetchImpl = vi
+		.fn()
+		.mockResolvedValueOnce(
+			new Response(JSON.stringify({ error: 'too_many_requests' }), {
+				status: 429,
+				headers: { 'Retry-After': '2', 'Content-Type': 'application/json' },
+			}),
+		)
+		.mockResolvedValueOnce(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		)
+
+	const json = await fetchJsonWithRetryAfter<{ ok: boolean }>(
+		'https://example.com/test',
+		{
+			label: 'test',
+			maxRetries: 1,
+			fetchImpl: fetchImpl as any,
+			sleep,
+		},
+	)
+
+	expect(json.ok).toBe(true)
+	expect(fetchImpl).toHaveBeenCalledTimes(2)
+	expect(sleep).toHaveBeenCalledTimes(1)
+	expect(sleep).toHaveBeenCalledWith(2000)
+})
+
+test('getRetryDelayMsFromResponse parses Retry-After HTTP-date', () => {
+	const nowMs = Date.parse('2026-02-23T00:00:00.000Z')
+	const retryAfter = new Date(nowMs + 5000).toUTCString()
+	const res = new Response(null, { status: 429, headers: { 'Retry-After': retryAfter } })
+
+	const delay = getRetryDelayMsFromResponse(res, { nowMs })
+	expect(delay.reason).toBe('retry-after')
+	expect(delay.delayMs).toBe(5000)
+})
+
+test('getRetryDelayMsFromResponse falls back to default delay when header is missing', () => {
+	const res = new Response(null, { status: 429 })
+	const delay = getRetryDelayMsFromResponse(res, {
+		nowMs: 0,
+		defaultDelayMs: 1234,
+		maxDelayMs: 10_000,
+	})
+	expect(delay.reason).toBe('default')
+	expect(delay.delayMs).toBe(1234)
+})
+

--- a/app/utils/__tests__/fetch-json-with-retry-after.server.test.ts
+++ b/app/utils/__tests__/fetch-json-with-retry-after.server.test.ts
@@ -7,6 +7,9 @@ import {
 } from '../fetch-json-with-retry-after.server.ts'
 
 let requestCount = 0
+let always429Count = 0
+let flaky500Count = 0
+let networkErrorCount = 0
 const server = setupServer(
 	http.get('https://example.com/test', () => {
 		requestCount++
@@ -21,6 +24,36 @@ const server = setupServer(
 		}
 		return HttpResponse.json({ ok: true })
 	}),
+	http.get('https://example.com/always-429', () => {
+		always429Count++
+		return HttpResponse.json(
+			{ error: 'too_many_requests' },
+			{
+				status: 429,
+				headers: { 'Retry-After': '1' },
+			},
+		)
+	}),
+	http.get('https://example.com/flaky-500', () => {
+		flaky500Count++
+		if (flaky500Count === 1) {
+			return HttpResponse.json({ error: 'server' }, { status: 500 })
+		}
+		return HttpResponse.json({ ok: true })
+	}),
+	http.get('https://example.com/network-error', () => {
+		networkErrorCount++
+		if (networkErrorCount === 1) {
+			return HttpResponse.error()
+		}
+		return HttpResponse.json({ ok: true })
+	}),
+	http.get('https://example.com/bad-json', () => {
+		return HttpResponse.text('not-json', {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		})
+	}),
 )
 
 beforeAll(() => {
@@ -29,6 +62,9 @@ beforeAll(() => {
 
 beforeEach(() => {
 	requestCount = 0
+	always429Count = 0
+	flaky500Count = 0
+	networkErrorCount = 0
 })
 
 afterAll(() => {
@@ -72,5 +108,78 @@ test('getRetryDelayMsFromResponse falls back to default delay when header is mis
 	})
 	expect(delay.reason).toBe('default')
 	expect(delay.delayMs).toBe(1234)
+})
+
+test('getRetryDelayMsFromResponse uses RateLimit-Reset epoch seconds when present', () => {
+	const nowMs = 1700000000 * 1000
+	const res = new Response(null, {
+		status: 429,
+		headers: { 'RateLimit-Reset': String(1700000005) },
+	})
+	const delay = getRetryDelayMsFromResponse(res, { nowMs })
+	expect(delay.reason).toBe('rate-limit-reset')
+	expect(delay.delayMs).toBe(5000)
+})
+
+test('fetchJsonWithRetryAfter throws after exhausting 429 retries', async () => {
+	const sleep = vi.fn(async () => {})
+
+	await expect(
+		fetchJsonWithRetryAfter('https://example.com/always-429', {
+			label: 'always-429',
+			maxRetries: 1,
+			sleep,
+		}),
+	).rejects.toThrow(/always-429: 429 Too Many Requests/i)
+
+	expect(always429Count).toBe(2)
+	expect(sleep).toHaveBeenCalledTimes(1)
+})
+
+test('fetchJsonWithRetryAfter retries 5xx when retryOn5xx is enabled', async () => {
+	const sleep = vi.fn(async () => {})
+	const json = await fetchJsonWithRetryAfter<{ ok: boolean }>(
+		'https://example.com/flaky-500',
+		{
+			label: 'flaky-500',
+			maxRetries: 1,
+			defaultDelayMs: 123,
+			retryOn5xx: true,
+			sleep,
+		},
+	)
+
+	expect(json.ok).toBe(true)
+	expect(flaky500Count).toBe(2)
+	expect(sleep).toHaveBeenCalledWith(123)
+})
+
+test('fetchJsonWithRetryAfter retries when fetch throws (network error / abort)', async () => {
+	const sleep = vi.fn(async () => {})
+	const json = await fetchJsonWithRetryAfter<{ ok: boolean }>(
+		'https://example.com/network-error',
+		{
+			label: 'network-error',
+			maxRetries: 1,
+			defaultDelayMs: 456,
+			sleep,
+		},
+	)
+
+	expect(json.ok).toBe(true)
+	expect(networkErrorCount).toBe(2)
+	expect(sleep).toHaveBeenCalledWith(456)
+})
+
+test('fetchJsonWithRetryAfter throws a labeled error on malformed JSON', async () => {
+	const sleep = vi.fn(async () => {})
+	await expect(
+		fetchJsonWithRetryAfter('https://example.com/bad-json', {
+			label: 'bad-json',
+			sleep,
+		}),
+	).rejects.toThrow(/bad-json: failed to parse JSON \(200 OK\)/i)
+
+	expect(sleep).not.toHaveBeenCalled()
 })
 

--- a/app/utils/__tests__/simplecast-api-schema.server.test.ts
+++ b/app/utils/__tests__/simplecast-api-schema.server.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest'
+import {
+	simplecastEpisodeSchema,
+	simplecastEpisodesListResponseSchema,
+	simplecastSeasonsResponseSchema,
+} from '../simplecast-api-schema.server.ts'
+
+test('simplecastSeasonsResponseSchema parses collection items we use', () => {
+	const parsed = simplecastSeasonsResponseSchema.parse({
+		collection: [
+			{ href: 'https://api.simplecast.com/seasons/abc123', number: 7, extra: 1 },
+		],
+		ignoredTopLevel: true,
+	})
+
+	expect(parsed.collection).toHaveLength(1)
+	expect(parsed.collection[0]).toEqual({
+		href: 'https://api.simplecast.com/seasons/abc123',
+		number: 7,
+	})
+})
+
+test('simplecastEpisodesListResponseSchema parses episode list items we use', () => {
+	const parsed = simplecastEpisodesListResponseSchema.parse({
+		collection: [
+			{
+				id: 'ep_1',
+				status: 'published',
+				is_hidden: false,
+				extra: 'ignored',
+			},
+		],
+	})
+
+	expect(parsed.collection[0]).toEqual({
+		id: 'ep_1',
+		status: 'published',
+		is_hidden: false,
+	})
+})
+
+test('simplecastEpisodeSchema allows optional/nullable fields we handle', () => {
+	const parsed = simplecastEpisodeSchema.parse({
+		id: 'ep_1',
+		is_published: true,
+		published_at: null,
+		updated_at: '2026-02-23T00:00:00.000Z',
+		slug: 'episode-slug',
+		transcription: null,
+		long_description: null,
+		// description is optional and may be null
+		description: null,
+		image_url: 'https://example.com/image.png',
+		number: 1,
+		duration: 1234,
+		title: 'Episode title',
+		season: { number: 2, extra: 'ignored' },
+		keywords: { collection: [{ value: 'react', extra: true }] },
+		enclosure_url: 'https://cdn.simplecast.com/audio/ep_1.mp3',
+		extra: { ignored: true },
+	})
+
+	expect(parsed.season.number).toBe(2)
+	expect(parsed.keywords?.collection.map((k) => k.value)).toEqual(['react'])
+})
+

--- a/app/utils/fetch-json-with-retry-after.server.ts
+++ b/app/utils/fetch-json-with-retry-after.server.ts
@@ -54,7 +54,7 @@ export function getRetryDelayMsFromResponse(
 	{
 		nowMs = Date.now(),
 		defaultDelayMs = 1000,
-		maxDelayMs = 1000 * 60,
+		maxDelayMs = 1000 * 60 * 10,
 	}: {
 		nowMs?: number
 		defaultDelayMs?: number
@@ -91,7 +91,7 @@ export async function fetchJsonWithRetryAfter<JsonResponse>(
 		headers,
 		maxRetries = 5,
 		defaultDelayMs = 750,
-		maxDelayMs = 1000 * 60,
+		maxDelayMs = 1000 * 60 * 10,
 		label,
 		sleep = defaultSleep,
 		fetchImpl = fetch,

--- a/app/utils/fetch-json-with-retry-after.server.ts
+++ b/app/utils/fetch-json-with-retry-after.server.ts
@@ -1,0 +1,163 @@
+type Sleep = (ms: number) => Promise<void>
+
+const defaultSleep: Sleep = async (ms) => {
+	await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+type RetryDelayReason = 'retry-after' | 'rate-limit-reset' | 'default'
+
+type RetryDelay = {
+	delayMs: number
+	reason: RetryDelayReason
+}
+
+function clampMs(ms: number, maxDelayMs: number) {
+	if (ms <= 0) return 0
+	return Math.min(ms, maxDelayMs)
+}
+
+function parseRetryAfterMs(retryAfterHeader: string, nowMs: number) {
+	const value = retryAfterHeader.trim()
+	if (!value) return null
+
+	// Per RFC 9110, Retry-After can be delta-seconds or an HTTP-date.
+	const asNumber = Number(value)
+	if (Number.isFinite(asNumber) && asNumber >= 0) {
+		return Math.round(asNumber * 1000)
+	}
+
+	const asDateMs = Date.parse(value)
+	if (Number.isFinite(asDateMs)) {
+		return Math.max(0, asDateMs - nowMs)
+	}
+
+	return null
+}
+
+function parseRateLimitResetMs(resetHeader: string, nowMs: number) {
+	const value = resetHeader.trim()
+	if (!value) return null
+
+	const n = Number(value)
+	if (!Number.isFinite(n) || n < 0) return null
+
+	// Common shapes:
+	// - RFC 9230 RateLimit-Reset: delta seconds until reset
+	// - X-RateLimit-Reset: epoch seconds (some APIs) or epoch ms (rare)
+	if (n > 1e12) return Math.max(0, n - nowMs) // epoch ms
+	if (n > 1e9) return Math.max(0, n * 1000 - nowMs) // epoch seconds
+	return Math.round(n * 1000) // delta seconds
+}
+
+export function getRetryDelayMsFromResponse(
+	res: Pick<Response, 'headers'>,
+	{
+		nowMs = Date.now(),
+		defaultDelayMs = 1000,
+		maxDelayMs = 1000 * 60,
+	}: {
+		nowMs?: number
+		defaultDelayMs?: number
+		maxDelayMs?: number
+	} = {},
+): RetryDelay {
+	const retryAfterHeader = res.headers.get('Retry-After')
+	if (retryAfterHeader) {
+		const parsed = parseRetryAfterMs(retryAfterHeader, nowMs)
+		if (parsed !== null) {
+			return { delayMs: clampMs(parsed, maxDelayMs), reason: 'retry-after' }
+		}
+	}
+
+	// Best-effort support for rate-limit reset headers.
+	const resetHeader =
+		res.headers.get('RateLimit-Reset') ?? res.headers.get('X-RateLimit-Reset')
+	if (resetHeader) {
+		const parsed = parseRateLimitResetMs(resetHeader, nowMs)
+		if (parsed !== null) {
+			return { delayMs: clampMs(parsed, maxDelayMs), reason: 'rate-limit-reset' }
+		}
+	}
+
+	return {
+		delayMs: clampMs(defaultDelayMs, maxDelayMs),
+		reason: 'default',
+	}
+}
+
+export async function fetchJsonWithRetryAfter<JsonResponse>(
+	url: string,
+	{
+		headers,
+		maxRetries = 5,
+		defaultDelayMs = 750,
+		maxDelayMs = 1000 * 60,
+		label,
+		sleep = defaultSleep,
+		fetchImpl = fetch,
+		retryOn5xx = false,
+	}: {
+		headers?: Record<string, string>
+		maxRetries?: number
+		defaultDelayMs?: number
+		maxDelayMs?: number
+		label?: string
+		sleep?: Sleep
+		fetchImpl?: typeof fetch
+		retryOn5xx?: boolean
+	} = {},
+): Promise<JsonResponse> {
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		const res = await fetchImpl(url, { headers })
+
+		if (res.status === 429) {
+			if (attempt >= maxRetries) {
+				throw new Error(`${label ?? 'request'}: 429 Too Many Requests`)
+			}
+
+			const { delayMs, reason } = getRetryDelayMsFromResponse(res, {
+				defaultDelayMs: defaultDelayMs * (attempt + 1),
+				maxDelayMs,
+			})
+			console.warn(
+				`${label ?? 'request'}: 429 (attempt ${attempt + 1}/${maxRetries + 1}), waiting ${Math.round(
+					delayMs,
+				)}ms (${reason})`,
+			)
+			await sleep(delayMs)
+			continue
+		}
+
+		if (!res.ok) {
+			// Optionally retry transient 5xx.
+			if (retryOn5xx && res.status >= 500 && attempt < maxRetries) {
+				const delayMs = clampMs(defaultDelayMs * (attempt + 1), maxDelayMs)
+				console.warn(
+					`${label ?? 'request'}: ${res.status} (attempt ${attempt + 1}/${
+						maxRetries + 1
+					}), waiting ${Math.round(delayMs)}ms`,
+				)
+				await sleep(delayMs)
+				continue
+			}
+
+			let bodyText = ''
+			try {
+				bodyText = await res.text()
+			} catch {
+				// ignore
+			}
+			throw new Error(
+				`${label ?? 'request'}: ${res.status} ${res.statusText}${
+					bodyText ? ` - ${bodyText}` : ''
+				}`,
+			)
+		}
+
+		return (await res.json()) as JsonResponse
+	}
+
+	// This should be unreachable, but keep a deterministic error.
+	throw new Error(`${label ?? 'request'}: exceeded max retries`)
+}
+

--- a/app/utils/fetch-json-with-retry-after.server.ts
+++ b/app/utils/fetch-json-with-retry-after.server.ts
@@ -1,3 +1,5 @@
+import { fetchWithTimeout } from './fetch-with-timeout.server'
+
 type Sleep = (ms: number) => Promise<void>
 
 const defaultSleep: Sleep = async (ms) => {
@@ -110,10 +112,9 @@ export async function fetchJsonWithRetryAfter<JsonResponse>(
 	for (let attempt = 0; attempt <= maxRetries; attempt++) {
 		let res: Response
 		try {
-			res = await fetch(url, {
-				headers,
-				signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,
-			})
+			res = timeoutMs
+				? await fetchWithTimeout(url, { headers }, timeoutMs)
+				: await fetch(url, { headers })
 		} catch (cause) {
 			if (attempt < maxRetries) {
 				const delayMs = clampMs(defaultDelayMs * (attempt + 1), maxDelayMs)

--- a/app/utils/fetch-json-with-retry-after.server.ts
+++ b/app/utils/fetch-json-with-retry-after.server.ts
@@ -94,7 +94,6 @@ export async function fetchJsonWithRetryAfter<JsonResponse>(
 		maxDelayMs = 1000 * 60 * 10,
 		label,
 		sleep = defaultSleep,
-		fetchImpl = fetch,
 		retryOn5xx = false,
 	}: {
 		headers?: Record<string, string>
@@ -103,12 +102,11 @@ export async function fetchJsonWithRetryAfter<JsonResponse>(
 		maxDelayMs?: number
 		label?: string
 		sleep?: Sleep
-		fetchImpl?: typeof fetch
 		retryOn5xx?: boolean
 	} = {},
 ): Promise<JsonResponse> {
 	for (let attempt = 0; attempt <= maxRetries; attempt++) {
-		const res = await fetchImpl(url, { headers })
+		const res = await fetch(url, { headers })
 
 		if (res.status === 429) {
 			if (attempt >= maxRetries) {

--- a/app/utils/simplecast-api-schema.server.ts
+++ b/app/utils/simplecast-api-schema.server.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod'
+
+const simplecastCollectionResponseSchema = <ItemSchema extends z.ZodTypeAny>(
+	itemSchema: ItemSchema,
+) =>
+	z.object({
+		collection: z.array(itemSchema),
+	})
+
+// --- /podcasts/:podcastId/seasons ---
+export const simplecastSeasonListItemSchema = z.object({
+	href: z.string().min(1),
+	number: z.number(),
+})
+
+export const simplecastSeasonsResponseSchema = simplecastCollectionResponseSchema(
+	simplecastSeasonListItemSchema,
+)
+
+export type SimplecastSeasonListItem = z.infer<typeof simplecastSeasonListItemSchema>
+
+// --- /seasons/:seasonId/episodes ---
+export const simplecastEpisodeListItemSchema = z.object({
+	id: z.string().min(1),
+	status: z.string().min(1),
+	is_hidden: z.boolean(),
+})
+
+export const simplecastEpisodesListResponseSchema =
+	simplecastCollectionResponseSchema(simplecastEpisodeListItemSchema)
+
+export type SimplecastEpisodeListItem = z.infer<typeof simplecastEpisodeListItemSchema>
+
+// --- /episodes/:episodeId ---
+export const simplecastEpisodeSchema = z.object({
+	id: z.string().min(1),
+	is_published: z.boolean(),
+	published_at: z.string().min(1).nullable().optional(),
+	updated_at: z.string().min(1),
+	slug: z.string().min(1),
+	transcription: z.string().nullable().optional(),
+	long_description: z.string().nullable().optional(),
+	description: z.string().nullable().optional(),
+	image_url: z.string().min(1),
+	number: z.number(),
+	duration: z.number(),
+	title: z.string().min(1),
+	season: z.object({
+		number: z.number(),
+	}),
+	keywords: z
+		.object({
+			collection: z.array(
+				z.object({
+					value: z.string().min(1),
+				}),
+			),
+		})
+		.optional(),
+	enclosure_url: z.string().min(1),
+})
+
+export type SimplecastEpisode = z.infer<typeof simplecastEpisodeSchema>
+

--- a/app/utils/simplecast.server.ts
+++ b/app/utils/simplecast.server.ts
@@ -11,6 +11,7 @@ import { unified } from 'unified'
 import type * as U from 'unist'
 import { visit } from 'unist-util-visit'
 import { z } from 'zod'
+import pLimit from 'p-limit'
 import {
 	type CWKEpisode,
 	type CWKSeason,
@@ -18,11 +19,11 @@ import {
 	type SimplecastCollectionResponse,
 	type SimplecastEpisode,
 	type SimplecastEpisodeListItem,
-	type SimplecastTooManyRequests,
 } from '#app/types.ts'
 import { omit, sortBy } from '#app/utils/cjs/lodash.ts'
 import { cache, cachified } from './cache.server.ts'
 import { getEnv } from './env.server.ts'
+import { fetchJsonWithRetryAfter } from './fetch-json-with-retry-after.server.ts'
 import { markdownToHtml, stripHtml } from './markdown.server.ts'
 import { typedBoolean } from './misc.ts'
 import { type Timings } from './timing.server.ts'
@@ -91,14 +92,6 @@ const cwkCachedSeasonsSchema = z.array(
 		.passthrough(),
 )
 
-function isTooManyRequests(json: unknown): json is SimplecastTooManyRequests {
-	return (
-		typeof json === 'object' &&
-		json !== null &&
-		json.hasOwnProperty('too_many_requests')
-	)
-}
-
 const getCachedSeasons = async ({
 	request,
 	forceFresh,
@@ -159,36 +152,35 @@ async function getSeasons({
 	timings?: Timings
 }) {
 	const { podcastId, headers } = getSimplecastConfig()
-	const res = await fetch(
-		`https://api.simplecast.com/podcasts/${podcastId}/seasons`,
-		{ headers },
-	)
-	const json = (await res.json()) as
-		| SimplecastCollectionResponse<SimpelcastSeasonListItem>
-		| SimplecastTooManyRequests
-	if (isTooManyRequests(json)) {
-		return []
-	}
-	const { collection } = json
+	const { collection } = await fetchJsonWithRetryAfter<
+		SimplecastCollectionResponse<SimpelcastSeasonListItem>
+	>(`https://api.simplecast.com/podcasts/${podcastId}/seasons`, {
+		headers,
+		label: `simplecast seasons (${podcastId})`,
+		retryOn5xx: true,
+	})
 
+	const limit = pLimit(2)
 	const seasons = await Promise.all(
-		collection.map(async ({ href, number }) => {
-			const seasonId = new URL(href).pathname.split('/').slice(-1)[0]
-			if (!seasonId) {
-				console.error(
-					`Could not determine seasonId from ${href} for season ${number}`,
-				)
-				return
-			}
-			const episodes = await getEpisodes(seasonId, {
-				request,
-				forceFresh,
-				timings,
-			})
-			if (!episodes.length) return null
+		collection.map(({ href, number }) =>
+			limit(async () => {
+				const seasonId = new URL(href).pathname.split('/').slice(-1)[0]
+				if (!seasonId) {
+					console.error(
+						`Could not determine seasonId from ${href} for season ${number}`,
+					)
+					return
+				}
+				const episodes = await getEpisodes(seasonId, {
+					request,
+					forceFresh,
+					timings,
+				})
+				if (!episodes.length) return null
 
-			return { seasonNumber: number, episodes }
-		}),
+				return { seasonNumber: number, episodes }
+			}),
+		),
 	).then((s) => s.filter(typedBoolean))
 
 	return sortBy(seasons, (s) => Number(s.seasonNumber))
@@ -209,34 +201,36 @@ async function getEpisodes(
 	const { headers } = getSimplecastConfig()
 	const url = new URL(`https://api.simplecast.com/seasons/${seasonId}/episodes`)
 	url.searchParams.set('limit', '300')
-	const res = await fetch(url.toString(), { headers })
-	const json = (await res.json()) as
-		| SimplecastCollectionResponse<SimplecastEpisodeListItem>
-		| SimplecastTooManyRequests
-	if (isTooManyRequests(json)) {
-		return []
-	}
+	const { collection } = await fetchJsonWithRetryAfter<
+		SimplecastCollectionResponse<SimplecastEpisodeListItem>
+	>(url.toString(), {
+		headers,
+		label: `simplecast season ${seasonId} episodes list`,
+		retryOn5xx: true,
+	})
 
-	const { collection } = json
+	// Fetch episode details with limited concurrency to reduce 429s.
+	const limit = pLimit(3)
 	const episodes = await Promise.all(
 		collection
 			.filter(({ status, is_hidden }) => status === 'published' && !is_hidden)
-			.map(({ id }) => getCachedEpisode(id, { request, forceFresh, timings })),
+			.map(({ id }) =>
+				limit(() => getCachedEpisode(id, { request, forceFresh, timings })),
+			),
 	)
 	return episodes.filter(typedBoolean)
 }
 
 async function getEpisode(episodeId: string) {
 	const { headers } = getSimplecastConfig()
-	const res = await fetch(`https://api.simplecast.com/episodes/${episodeId}`, {
-		headers,
-	})
-	const json = (await res.json()) as
-		| SimplecastEpisode
-		| SimplecastTooManyRequests
-	if (isTooManyRequests(json)) {
-		return null
-	}
+	const json = await fetchJsonWithRetryAfter<SimplecastEpisode>(
+		`https://api.simplecast.com/episodes/${episodeId}`,
+		{
+			headers,
+			label: `simplecast episode ${episodeId}`,
+			retryOn5xx: true,
+		},
+	)
 
 	const {
 		id,

--- a/app/utils/simplecast.server.ts
+++ b/app/utils/simplecast.server.ts
@@ -219,14 +219,12 @@ async function getEpisodes(
 	)
 	const { collection } = listJson
 
-	// Fetch episode details with limited concurrency to reduce 429s.
-	const limit = pLimit(3)
+	// Fetch episode details. Cached reads are fast; network refreshes are capped
+	// globally in `getEpisode` via `simplecastEpisodeDetailsLimit`.
 	const episodes = await Promise.all(
 		collection
 			.filter(({ status, is_hidden }) => status === 'published' && !is_hidden)
-			.map(({ id }) =>
-				limit(() => getCachedEpisode(id, { request, forceFresh, timings })),
-			),
+			.map(({ id }) => getCachedEpisode(id, { request, forceFresh, timings })),
 	)
 	return episodes.filter(typedBoolean)
 }


### PR DESCRIPTION
Add `Retry-After` aware retry logic for Simplecast API calls to gracefully handle 429s.

Previously, 429 responses from Simplecast could lead to `cachified` background refreshes overwriting valid cached data with empty results. This change implements a retry mechanism that respects the `Retry-After` header, ensuring we wait the specified duration before retrying, thus preserving data integrity.

---
<p><a href="https://cursor.com/agents/bc-2c3548b7-84e8-462b-9b46-8d9b5513de23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c3548b7-84e8-462b-9b46-8d9b5513de23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/retry and concurrency behavior for Simplecast fetching and cached refresh paths, which could affect load and failure modes if the new backoff/validation is mis-tuned.
> 
> **Overview**
> Adds a new `fetchJsonWithRetryAfter` helper that retries failed JSON fetches with bounded backoff, honoring `Retry-After` (delta-seconds or HTTP-date) and `RateLimit-Reset`/`X-RateLimit-Reset`, optionally retrying 5xx and handling network errors with clearer labeled exceptions.
> 
> Updates Simplecast fetching to use this retry logic and Zod-validated response schemas, removes the previous "return empty on 429" behavior, and adds concurrency limits for season and episode-detail requests to reduce rate limiting; includes new unit tests for retry timing and Simplecast schema parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bd2e08f6accf7e35f80df2eb1189cde8dcd25f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved data fetching reliability with header-aware retry delays, clearer retry errors, configurable retry behavior, and controlled concurrency for season/episode requests.
  * Added validated schemas for Simplecast API responses for safer, more predictable data handling.

* **Tests**
  * Added unit tests covering retry logic (Retry-After/RateLimit parsing, 5xx and network retries, default delays, exhausted retries, malformed JSON) and Simplecast API schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->