### PR TITLE
Anonymous image pending state

### DIFF
--- a/app/components/calls/__tests__/episode-artwork-preview.test.tsx
+++ b/app/components/calls/__tests__/episode-artwork-preview.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { expect, test } from 'vitest'
+import { EpisodeArtworkPreview } from '#app/components/calls/episode-artwork-preview.tsx'
+
+test('publish anonymously tooltip opens on hover', async () => {
+	const user = userEvent.setup()
+	render(
+		<EpisodeArtworkPreview
+			title="My episode title"
+			email="person@example.com"
+			firstName="Jane"
+			team="BLUE"
+			origin="https://kentcdodds.com"
+			hasGravatar={false}
+			isAnonymous={false}
+			onAnonymousChange={() => {}}
+		/>,
+	)
+
+	const tooltipButton = screen.getByRole('button', {
+		name: 'What does publish anonymously mean?',
+	})
+
+	expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+	await user.hover(tooltipButton)
+	expect(screen.getByRole('tooltip')).toHaveTextContent('If you check this')
+	await user.unhover(tooltipButton)
+	expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+})
+
+test('episode artwork preview dims while loading and resets when src changes', async () => {
+	const props = {
+		email: 'person@example.com',
+		firstName: 'Jane',
+		team: 'BLUE',
+		origin: 'https://kentcdodds.com',
+		hasGravatar: false,
+		onAnonymousChange: () => {},
+	} as const
+
+	const { rerender } = render(
+		<EpisodeArtworkPreview title="My episode title" isAnonymous={false} {...props} />,
+	)
+
+	const img = screen.getByAltText('Episode artwork preview')
+	expect(img).toHaveClass('opacity-60')
+	fireEvent.load(img)
+	await waitFor(() => expect(img).toHaveClass('opacity-100'))
+
+	rerender(
+		<EpisodeArtworkPreview title="My episode title" isAnonymous={true} {...props} />,
+	)
+	await waitFor(() =>
+		expect(screen.getByAltText('Episode artwork preview')).toHaveClass('opacity-60'),
+	)
+})
+

--- a/app/components/calls/__tests__/episode-artwork-preview.test.tsx
+++ b/app/components/calls/__tests__/episode-artwork-preview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { expect, test, vi } from 'vitest'
@@ -32,8 +32,6 @@ test('publish anonymously tooltip opens on hover', async () => {
 
 test('episode artwork preview dims while the next image suspends', async () => {
 	vi.useFakeTimers()
-	const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-
 	class TestImage {
 		onload: null | (() => void) = null
 		onerror: null | ((error: unknown) => void) = null
@@ -69,12 +67,12 @@ test('episode artwork preview dims while the next image suspends', async () => {
 		const previewWrapper = previewImg.parentElement
 		expect(previewWrapper).not.toBeNull()
 
-		const clickPromise = user.click(checkbox)
-		await vi.advanceTimersByTimeAsync(200)
-
-		expect(previewWrapper).toHaveClass('opacity-60')
-		await vi.advanceTimersByTimeAsync(1500)
-		await clickPromise
+		await act(async () => {
+			fireEvent.click(checkbox)
+			await vi.advanceTimersByTimeAsync(200)
+			expect(previewWrapper).toHaveClass('opacity-60')
+			await vi.advanceTimersByTimeAsync(1500)
+		})
 		expect(previewWrapper).toHaveClass('opacity-100')
 	} finally {
 		vi.unstubAllGlobals()

--- a/app/components/calls/__tests__/episode-artwork-preview.test.tsx
+++ b/app/components/calls/__tests__/episode-artwork-preview.test.tsx
@@ -63,18 +63,23 @@ test('episode artwork preview dims while the next image suspends', async () => {
 		render(<Example />)
 
 		const checkbox = screen.getByRole('checkbox', { name: /publish anonymously/i })
-		const previewImg = screen.getByAltText('Episode artwork preview')
-		const previewWrapper = previewImg.parentElement
-		expect(previewWrapper).not.toBeNull()
+		const initialImg = screen.getByAltText('Episode artwork preview')
+		const initialSrc = initialImg.getAttribute('src')
+		expect(initialSrc).toBeTruthy()
 
 		await act(async () => {
 			fireEvent.click(checkbox)
 			expect(checkbox).toBeChecked()
-			await vi.advanceTimersByTimeAsync(200)
-			expect(previewWrapper).toHaveClass('opacity-60')
+
+			const pendingImg = screen.getByAltText('Episode artwork preview')
+			expect(pendingImg).toHaveClass('opacity-60')
+			expect(pendingImg).toHaveAttribute('src', initialSrc)
+
 			await vi.advanceTimersByTimeAsync(1500)
 		})
-		expect(previewWrapper).toHaveClass('opacity-100')
+		const loadedImg = screen.getByAltText('Episode artwork preview')
+		expect(loadedImg).toHaveClass('opacity-100')
+		expect(loadedImg.getAttribute('src')).not.toBe(initialSrc)
 	} finally {
 		vi.unstubAllGlobals()
 		vi.useRealTimers()

--- a/app/components/calls/__tests__/episode-artwork-preview.test.tsx
+++ b/app/components/calls/__tests__/episode-artwork-preview.test.tsx
@@ -69,6 +69,7 @@ test('episode artwork preview dims while the next image suspends', async () => {
 
 		await act(async () => {
 			fireEvent.click(checkbox)
+			expect(checkbox).toBeChecked()
 			await vi.advanceTimersByTimeAsync(200)
 			expect(previewWrapper).toHaveClass('opacity-60')
 			await vi.advanceTimersByTimeAsync(1500)

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import { clsx } from 'clsx'
+import * as React from 'react'
 import {
 	getCallKentEpisodeArtworkAvatar,
 	getCallKentEpisodeArtworkUrl,

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -40,13 +40,13 @@ export function EpisodeArtworkPreview({
 	onAnonymousChange: (next: boolean) => void
 }) {
 	const [debouncedTitle, setDebouncedTitle] = React.useState(title)
-	const [isTransitionPending, startTransition] = React.useTransition()
-	const showPending = useSpinDelay(isTransitionPending, {
+	const [, startTransition] = React.useTransition()
+	const [enableSuspenseImage, setEnableSuspenseImage] = React.useState(false)
+	const [previewIsAnonymous, setPreviewIsAnonymous] = React.useState(isAnonymous)
+	const showPending = useSpinDelay(previewIsAnonymous !== isAnonymous, {
 		delay: 150,
 		minDuration: 250,
 	})
-	const [enableSuspenseImage, setEnableSuspenseImage] = React.useState(false)
-	const [previewIsAnonymous, setPreviewIsAnonymous] = React.useState(isAnonymous)
 
 	React.useEffect(() => {
 		const timeout = setTimeout(() => {

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -236,11 +236,19 @@ function EpisodeArtworkImg({
 		setFallbackSrc(resolvedSrc)
 	}
 
+	function handlePreloadError() {
+		handleResolved(safeSrc)
+	}
+
 	return (
 		<>
 			<img src={fallbackSrc} {...props} className={imgClassName} />
 			{isPending ? (
-				<ErrorBoundary resetKeys={[safeSrc]} fallback={null}>
+				<ErrorBoundary
+					resetKeys={[safeSrc]}
+					onError={handlePreloadError}
+					fallback={null}
+				>
 					<React.Suspense fallback={null}>
 						<PreloadImage src={safeSrc} onResolved={handleResolved} />
 					</React.Suspense>

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -246,7 +246,7 @@ function EpisodeArtworkImg({
 }: { enableSuspense: boolean } & React.ComponentProps<'img'>) {
 	const safeSrc = src ?? ''
 	return (
-		<ErrorBoundary fallback={<img src={safeSrc} {...props} />} key={safeSrc}>
+		<ErrorBoundary fallback={<img src={safeSrc} {...props} />} resetKeys={[safeSrc]}>
 			<React.Suspense fallback={<img src={safeSrc} {...props} />}>
 				{enableSuspense ? (
 					<Img src={safeSrc} {...props} />

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -237,6 +237,10 @@ function EpisodeArtworkImg({
 		setFallbackSrc(resolvedSrc)
 	}
 
+	if (!isReplacing) {
+		return <img src={safeSrc} {...props} className={loadedClassName} />
+	}
+
 	return (
 		<ErrorBoundary
 			resetKeys={[safeSrc]}
@@ -275,13 +279,12 @@ function Img({
 }: React.ComponentProps<'img'> & {
 	onSrcResolved?: (resolvedSrc: string) => void
 }) {
-	if (typeof document === 'undefined') {
-		return <img src={src} {...props} />
-	}
-	const loadedSrc = React.use(imgSrc(src))
+	const isServer = typeof document === 'undefined'
+	const loadedSrc = isServer ? src : React.use(imgSrc(src))
 	React.useEffect(() => {
+		if (isServer) return
 		onSrcResolved?.(loadedSrc)
-	}, [loadedSrc, onSrcResolved])
+	}, [isServer, loadedSrc, onSrcResolved])
 	return <img src={loadedSrc} {...props} />
 }
 

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -220,9 +220,9 @@ function EpisodeArtworkImg({
 	const [fallbackSrc, setFallbackSrc] = React.useState(safeSrc)
 	const latestSrcRef = React.useRef(safeSrc)
 
-	React.useEffect(() => {
+	if (latestSrcRef.current !== safeSrc) {
 		latestSrcRef.current = safeSrc
-	}, [safeSrc])
+	}
 
 	const isReplacing = fallbackSrc !== safeSrc
 	const fallbackClassName = clsx(

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -46,12 +46,15 @@ export function EpisodeArtworkPreview({
 		minDuration: 250,
 	})
 	const [enableSuspenseImage, setEnableSuspenseImage] = React.useState(false)
+	const [previewIsAnonymous, setPreviewIsAnonymous] = React.useState(isAnonymous)
 
 	React.useEffect(() => {
-		const timeout = setTimeout(
-			() => startTransition(() => setDebouncedTitle(title)),
-			350,
-		)
+		const timeout = setTimeout(() => {
+			startTransition(() => {
+				setEnableSuspenseImage(true)
+				setDebouncedTitle(title)
+			})
+		}, 350)
 		return () => clearTimeout(timeout)
 	}, [title, startTransition])
 
@@ -61,26 +64,26 @@ export function EpisodeArtworkPreview({
 	const avatar = React.useMemo(
 		() =>
 			getCallKentEpisodeArtworkAvatar({
-				isAnonymous,
+				isAnonymous: previewIsAnonymous,
 				team,
 				gravatarUrl: hasGravatar
 					? getAvatar(email, { size: AVATAR_SIZE, fallback: null })
 					: null,
 			}),
-		[email, team, hasGravatar, isAnonymous],
+		[email, team, hasGravatar, previewIsAnonymous],
 	)
 
 	const artworkUrl = React.useMemo(() => {
 		return getCallKentEpisodeArtworkUrl({
 			title: titleForPreview,
 			url: `${host}/calls/00/00`,
-			name: isAnonymous ? '- Anonymous' : `- ${firstName}`,
+			name: previewIsAnonymous ? '- Anonymous' : `- ${firstName}`,
 			avatar,
-			avatarIsRound: hasGravatar && !isAnonymous,
+			avatarIsRound: hasGravatar && !previewIsAnonymous,
 			// 2x for a crisp UI preview (the element is ~260px wide).
 			size: 520,
 		})
-	}, [titleForPreview, host, firstName, avatar, hasGravatar, isAnonymous])
+	}, [titleForPreview, host, firstName, avatar, hasGravatar, previewIsAnonymous])
 
 	const tooltip = isAnonymous
 		? `Anonymous is enabled. Your call still shows up in Kent's admin with your info, but the published episode artwork uses a generic Kody avatar instead of your photo.`
@@ -153,9 +156,10 @@ export function EpisodeArtworkPreview({
 							checked={isAnonymous}
 							onChange={(e) => {
 								const next = e.currentTarget.checked
+								onAnonymousChange(next)
 								startTransition(() => {
 									setEnableSuspenseImage(true)
-									onAnonymousChange(next)
+									setPreviewIsAnonymous(next)
 								})
 							}}
 						/>

--- a/app/components/calls/episode-artwork-preview.tsx
+++ b/app/components/calls/episode-artwork-preview.tsx
@@ -6,8 +6,8 @@ import {
 	getCallKentEpisodeArtworkAvatar,
 	getCallKentEpisodeArtworkUrl,
 } from '#app/utils/call-kent-artwork.ts'
-import { imgSrc } from '#app/utils/suspense-image.ts'
 import { getAvatar } from '#app/utils/misc-react.tsx'
+import { imgSrc } from '#app/utils/suspense-image.ts'
 
 const AVATAR_SIZE = 1400
 

--- a/app/utils/suspense-image.ts
+++ b/app/utils/suspense-image.ts
@@ -25,12 +25,19 @@ function preloadImage(src: string) {
 	// SSR-safe: callers should generally only use this in the browser, but guard
 	// anyway so we never throw on `new Image()` during server rendering.
 	if (typeof Image === 'undefined') return Promise.resolve(src)
+	if (!src) return Promise.resolve(src)
 
 	return new Promise<string>((resolve, reject) => {
 		const img = new Image()
-		img.src = src
 		img.onload = () => resolve(src)
 		img.onerror = reject
+		img.src = src
+
+		// If the image is already in cache, `complete` can be true immediately.
+		if (img.complete) {
+			if (img.naturalWidth > 0) resolve(src)
+			else reject(new Error(`Failed to preload image: ${src}`))
+		}
 	})
 }
 

--- a/app/utils/suspense-image.ts
+++ b/app/utils/suspense-image.ts
@@ -8,6 +8,9 @@ export function imgSrc(src: string) {
 
 	const promise = preloadImage(src)
 	imgCache.set(src, promise)
+	promise.catch(() => {
+		if (imgCache.get(src) === promise) imgCache.delete(src)
+	})
 
 	// Keep this cache bounded; artwork URLs can be unique per keystroke.
 	if (imgCache.size > MAX_CACHE_ENTRIES) {

--- a/app/utils/suspense-image.ts
+++ b/app/utils/suspense-image.ts
@@ -1,0 +1,33 @@
+const MAX_CACHE_ENTRIES = 50
+
+const imgCache = new Map<string, Promise<string>>()
+
+export function imgSrc(src: string) {
+	const cached = imgCache.get(src)
+	if (cached) return cached
+
+	const promise = preloadImage(src)
+	imgCache.set(src, promise)
+
+	// Keep this cache bounded; artwork URLs can be unique per keystroke.
+	if (imgCache.size > MAX_CACHE_ENTRIES) {
+		const oldestKey = imgCache.keys().next().value
+		if (typeof oldestKey === 'string') imgCache.delete(oldestKey)
+	}
+
+	return promise
+}
+
+function preloadImage(src: string) {
+	// SSR-safe: callers should generally only use this in the browser, but guard
+	// anyway so we never throw on `new Image()` during server rendering.
+	if (typeof Image === 'undefined') return Promise.resolve(src)
+
+	return new Promise<string>((resolve, reject) => {
+		const img = new Image()
+		img.src = src
+		img.onload = () => resolve(src)
+		img.onerror = reject
+	})
+}
+


### PR DESCRIPTION
Add image loading pending state and change tooltip trigger to hover for anonymous publishing.

---
<p><a href="https://cursor.com/agents/bc-8ef7cfec-c1d7-44f5-b299-9aef62baa1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ef7cfec-c1d7-44f5-b299-9aef62baa1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive UI behavior and introduces Suspense-based image preloading/caching; main risk is regressions in tooltip accessibility/closing logic or unexpected image loading behavior across browsers/SSR.
> 
> **Overview**
> Improves the call submission artwork preview by preloading updated artwork URLs via Suspense, keeping the previous image visible and **dimming it** until the next image finishes loading (with an SSR-safe, size-bounded preload cache in new `utils/suspense-image.ts`).
> 
> Updates the **"Publish anonymously"** tooltip to open on hover/focus and close on pointer leave/blur/outside click (instead of toggling on click), and adds new tests covering tooltip hover behavior and the preview’s pending/loaded opacity transition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10ef86d38cd4c65e969e0e467c9ad1db72afe5bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progressive, suspense-backed artwork loading with client-side caching, graceful fallbacks, and visible dim/loading state for smoother artwork updates
  * Improved tooltip activation (opens on click) with enhanced pointer and keyboard handling for the anonymous-publish control

* **Tests**
  * New test suite covering artwork preview interactions, tooltip behavior, and loading-state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->