### PR TITLE
404 content matching

### DIFF
--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -3,9 +3,9 @@ import errorStack from 'error-stack-parser'
 import * as React from 'react'
 import { useFetcher, useMatches } from 'react-router'
 import { type MdxListItem } from '#app/types.ts'
+import { getErrorMessage } from '#app/utils/misc.ts'
 import { type NotFoundMatch, sortNotFoundMatches } from '#app/utils/not-found-matches.ts'
 import { notFoundQueryFromPathname } from '#app/utils/not-found-query.ts'
-import { getErrorMessage } from '#app/utils/misc.ts'
 import { ArrowLink } from './arrow-button.tsx'
 import { Grid } from './grid.tsx'
 import { Facepalm, Grimmacing, MissingSomething } from './kifs.tsx'
@@ -246,7 +246,9 @@ function FourOhFour({
 		if (!effectiveQuery) return
 		if (requestedQueryRef.current === effectiveQuery) return
 		requestedQueryRef.current = effectiveQuery
-		fetcher.load(`/resources/search?query=${encodeURIComponent(effectiveQuery)}`)
+		void fetcher.load(
+			`/resources/search?query=${encodeURIComponent(effectiveQuery)}`,
+		)
 	}, [effectiveQuery, fetcher, possibleMatchesProp])
 
 	const fetchedMatches = React.useMemo(() => {

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -69,17 +69,11 @@ function ErrorPage({
 	possibleMatchesQuery?: string
 	heroProps: HeroSectionProps
 }) {
-	if (possibleMatches?.length) {
-		Object.assign(heroProps, {
-			arrowUrl: '#possible-matches',
-			arrowLabel: 'Possible matches',
-		})
-	} else if (articles?.length) {
-		Object.assign(heroProps, {
-			arrowUrl: '#articles',
-			arrowLabel: 'But wait, there is more!',
-		})
-	}
+	const resolvedHeroProps: HeroSectionProps = possibleMatches?.length
+		? { ...heroProps, arrowUrl: '#possible-matches', arrowLabel: 'Possible matches' }
+		: articles?.length
+			? { ...heroProps, arrowUrl: '#articles', arrowLabel: 'But wait, there is more!' }
+			: heroProps
 	return (
 		<>
 			<noscript>
@@ -101,7 +95,7 @@ function ErrorPage({
 				{error && import.meta.env.MODE === 'development' ? (
 					<RedBox error={error} />
 				) : null}
-				<HeroSection {...heroProps} />
+				<HeroSection {...resolvedHeroProps} />
 
 				{possibleMatchesQuery && !possibleMatches?.length ? (
 					// Ensure in-page links to `#possible-matches` have a target even

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -4,7 +4,11 @@ import * as React from 'react'
 import { useFetcher, useMatches } from 'react-router'
 import { type MdxListItem } from '#app/types.ts'
 import { getErrorMessage } from '#app/utils/misc.ts'
-import { type NotFoundMatch, sortNotFoundMatches } from '#app/utils/not-found-matches.ts'
+import {
+	normalizeNotFoundUrl,
+	type NotFoundMatch,
+	sortNotFoundMatches,
+} from '#app/utils/not-found-matches.ts'
 import { notFoundQueryFromPathname } from '#app/utils/not-found-query.ts'
 import { ArrowLink } from './arrow-button.tsx'
 import { Grid } from './grid.tsx'
@@ -219,23 +223,6 @@ function asNotFoundMatchFromResourceSearch(value: unknown): NotFoundMatch | null
 		imageUrl: imageUrlRaw || undefined,
 		imageAlt: imageAltRaw || undefined,
 	}
-}
-
-function normalizeNotFoundUrl(rawUrl: string) {
-	const url = rawUrl.trim()
-	if (!url) return ''
-	// Only allow internal app paths. This also keeps client/server rendering consistent
-	// when `/resources/search` returns absolute URLs.
-	if (url.startsWith('/')) return url
-	if (/^https?:\/\//i.test(url)) {
-		try {
-			const u = new URL(url)
-			return `${u.pathname}${u.search}${u.hash}`
-		} catch {
-			return ''
-		}
-	}
-	return ''
 }
 
 function FourOhFour({

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -229,14 +229,16 @@ function FourOhFour({
 	articles,
 	possibleMatches: possibleMatchesProp,
 	possibleMatchesQuery,
+	pathname: pathnameProp,
 }: {
 	articles?: Array<MdxListItem>
 	possibleMatches?: Array<NotFoundMatch>
 	possibleMatchesQuery?: string
+	pathname?: string
 }) {
 	const routeMatches = useMatches()
 	const last = routeMatches[routeMatches.length - 1]
-	const pathname = last?.pathname
+	const pathname = typeof pathnameProp === 'string' ? pathnameProp : last?.pathname
 	const derivedQuery = notFoundQueryFromPathname(pathname ?? '/')
 	const effectiveQuery =
 		typeof possibleMatchesQuery === 'string' && possibleMatchesQuery.trim()

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -1,14 +1,19 @@
 import { clsx } from 'clsx'
 import errorStack from 'error-stack-parser'
 import * as React from 'react'
-import { useMatches } from 'react-router'
+import { useFetcher, useMatches } from 'react-router'
 import { type MdxListItem } from '#app/types.ts'
+import { type NotFoundMatch, sortNotFoundMatches } from '#app/utils/not-found-matches.ts'
+import { notFoundQueryFromPathname } from '#app/utils/not-found-query.ts'
 import { getErrorMessage } from '#app/utils/misc.ts'
 import { ArrowLink } from './arrow-button.tsx'
+import { Grid } from './grid.tsx'
 import { Facepalm, Grimmacing, MissingSomething } from './kifs.tsx'
 import { BlogSection } from './sections/blog-section.tsx'
+import { HeaderSection } from './sections/header-section.tsx'
 import { HeroSection, type HeroSectionProps } from './sections/hero-section.tsx'
-import { H2, H6 } from './typography.tsx'
+import { Spacer } from './spacer.tsx'
+import { H2, H4, H6 } from './typography.tsx'
 
 function RedBox({ error }: { error: Error }) {
 	const [isVisible, setIsVisible] = React.useState(true)
@@ -54,13 +59,22 @@ function RedBox({ error }: { error: Error }) {
 function ErrorPage({
 	error,
 	articles,
+	possibleMatches,
+	possibleMatchesQuery,
 	heroProps,
 }: {
 	error?: Error
 	articles?: Array<MdxListItem>
+	possibleMatches?: Array<NotFoundMatch>
+	possibleMatchesQuery?: string
 	heroProps: HeroSectionProps
 }) {
-	if (articles?.length) {
+	if (possibleMatches?.length) {
+		Object.assign(heroProps, {
+			arrowUrl: '#possible-matches',
+			arrowLabel: 'Possible matches',
+		})
+	} else if (articles?.length) {
 		Object.assign(heroProps, {
 			arrowUrl: '#articles',
 			arrowLabel: 'But wait, there is more!',
@@ -89,6 +103,13 @@ function ErrorPage({
 				) : null}
 				<HeroSection {...heroProps} />
 
+				{possibleMatches?.length ? (
+					<PossibleMatchesSection
+						matches={possibleMatches}
+						query={possibleMatchesQuery}
+					/>
+				) : null}
+
 				{articles?.length ? (
 					<>
 						<div id="articles" />
@@ -104,14 +125,145 @@ function ErrorPage({
 	)
 }
 
-function FourOhFour({ articles }: { articles?: Array<MdxListItem> }) {
-	const matches = useMatches()
-	const last = matches[matches.length - 1]
+function PossibleMatchesSection({
+	matches,
+	query,
+}: {
+	matches: Array<NotFoundMatch>
+	query?: string
+}) {
+	const q = typeof query === 'string' ? query.trim() : ''
+	const searchUrl = q ? `/search?q=${encodeURIComponent(q)}` : '/search'
+	const sorted = sortNotFoundMatches(matches)
+
+	return (
+		<>
+			<div id="possible-matches" />
+			<HeaderSection
+				title="Possible matches"
+				subTitle={q ? `Semantic search for "${q}"` : 'Semantic search results.'}
+				cta="Search the site"
+				ctaUrl={searchUrl}
+			/>
+			<Spacer size="2xs" />
+			<Grid>
+				<div className="col-span-full lg:col-span-8 lg:col-start-3">
+					<ul className="space-y-6">
+						{sorted.slice(0, 8).map((m) => (
+							<li
+								key={`${m.type}:${m.url}`}
+								className="rounded-lg bg-gray-100 p-6 dark:bg-gray-800"
+							>
+								<div className="flex items-start gap-4">
+									<div className="shrink-0">
+										{m.imageUrl ? (
+											<img
+												src={m.imageUrl}
+												alt={m.imageAlt ?? ''}
+												className="h-16 w-16 rounded-lg object-cover"
+												loading="lazy"
+											/>
+										) : (
+											<div className="h-16 w-16 rounded-lg bg-gray-200 dark:bg-gray-700" />
+										)}
+									</div>
+									<div className="min-w-0 flex-1">
+										<H4 className="truncate">
+											<a href={m.url} className="hover:underline">
+												{m.title}
+											</a>
+										</H4>
+										<div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm text-slate-500">
+											<span>{m.type}</span>
+											<span className="truncate">{m.url}</span>
+										</div>
+										{m.summary ? (
+											<p className="mt-3 line-clamp-3 text-base text-slate-600 dark:text-slate-400">
+												{m.summary}
+											</p>
+										) : null}
+									</div>
+								</div>
+							</li>
+						))}
+					</ul>
+					{sorted.length > 8 ? (
+						<p className="mt-4 text-sm text-slate-500">
+							<a href={searchUrl} className="underlined">
+								See all results
+							</a>
+						</p>
+					) : null}
+				</div>
+			</Grid>
+		</>
+	)
+}
+
+function asNotFoundMatchFromResourceSearch(value: unknown): NotFoundMatch | null {
+	if (!value || typeof value !== 'object') return null
+	const v = value as Record<string, unknown>
+	const url = typeof v.url === 'string' ? v.url.trim() : ''
+	if (!url) return null
+	const titleRaw = typeof v.title === 'string' ? v.title.trim() : ''
+	const segmentRaw = typeof v.segment === 'string' ? v.segment.trim() : ''
+	const summaryRaw = typeof v.summary === 'string' ? v.summary.trim() : ''
+	const imageUrlRaw = typeof v.imageUrl === 'string' ? v.imageUrl.trim() : ''
+	const imageAltRaw = typeof v.imageAlt === 'string' ? v.imageAlt.trim() : ''
+	return {
+		url,
+		type: segmentRaw || 'result',
+		title: titleRaw || url,
+		summary: summaryRaw || undefined,
+		imageUrl: imageUrlRaw || undefined,
+		imageAlt: imageAltRaw || undefined,
+	}
+}
+
+function FourOhFour({
+	articles,
+	possibleMatches: possibleMatchesProp,
+	possibleMatchesQuery,
+}: {
+	articles?: Array<MdxListItem>
+	possibleMatches?: Array<NotFoundMatch>
+	possibleMatchesQuery?: string
+}) {
+	const routeMatches = useMatches()
+	const last = routeMatches[routeMatches.length - 1]
 	const pathname = last?.pathname
+	const derivedQuery = notFoundQueryFromPathname(pathname ?? '/')
+	const effectiveQuery =
+		typeof possibleMatchesQuery === 'string' && possibleMatchesQuery.trim()
+			? possibleMatchesQuery.trim()
+			: derivedQuery
+
+	const fetcher = useFetcher({ key: 'four-oh-four-possible-matches' })
+	const requestedQueryRef = React.useRef<string>('')
+
+	React.useEffect(() => {
+		if (possibleMatchesProp != null) return
+		if (!effectiveQuery) return
+		if (requestedQueryRef.current === effectiveQuery) return
+		requestedQueryRef.current = effectiveQuery
+		fetcher.load(`/resources/search?query=${encodeURIComponent(effectiveQuery)}`)
+	}, [effectiveQuery, fetcher, possibleMatchesProp])
+
+	const fetchedMatches = React.useMemo(() => {
+		const data = fetcher.data
+		if (!Array.isArray(data)) return undefined
+		return data
+			.map((v) => asNotFoundMatchFromResourceSearch(v))
+			.filter((v): v is NotFoundMatch => Boolean(v))
+	}, [fetcher.data])
+
+	const possibleMatches = possibleMatchesProp ?? fetchedMatches
 
 	return (
 		<ErrorPage
 			articles={articles}
+			possibleMatches={possibleMatches}
+			possibleMatchesQuery={effectiveQuery}
 			heroProps={{
 				title: "404 - Oh no, you found a page that's missing stuff.",
 				subtitle: `"${pathname}" is not a page on kentcdodds.com. So sorry.`,

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -103,6 +103,12 @@ function ErrorPage({
 				) : null}
 				<HeroSection {...heroProps} />
 
+				{possibleMatchesQuery && !possibleMatches?.length ? (
+					// Ensure in-page links to `#possible-matches` have a target even
+					// before semantic results load.
+					<div id="possible-matches" />
+				) : null}
+
 				{possibleMatches?.length ? (
 					<PossibleMatchesSection
 						matches={possibleMatches}
@@ -270,7 +276,7 @@ function FourOhFour({
 				title: "404 - Oh no, you found a page that's missing stuff.",
 				subtitle: `"${pathname}" is not a page on kentcdodds.com. So sorry.`,
 				image: <MissingSomething className="rounded-lg" aspectRatio="3:4" />,
-				action: <ArrowLink href="/">Go home</ArrowLink>,
+				action: <ArrowLink to="#possible-matches">Possible matches</ArrowLink>,
 			}}
 		/>
 	)

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -437,7 +437,7 @@ export function ErrorBoundary() {
 		if (error.status === 404) {
 			return (
 				<ErrorDoc>
-					<FourOhFour />
+					<FourOhFour pathname={location.pathname} />
 				</ErrorDoc>
 			)
 		}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -30,9 +30,9 @@ import {
 import { type Route } from './+types/root'
 import { AppHotkeys } from './components/app-hotkeys.tsx'
 import { ArrowLink } from './components/arrow-button.tsx'
-import { ErrorPage, FourHundred } from './components/errors.tsx'
+import { ErrorPage, FourHundred, FourOhFour } from './components/errors.tsx'
 import { Footer } from './components/footer.tsx'
-import { Grimmacing, MissingSomething } from './components/kifs.tsx'
+import { Grimmacing } from './components/kifs.tsx'
 import { Navbar } from './components/navbar.tsx'
 import { NotificationMessage } from './components/notification-message.tsx'
 import { Spacer } from './components/spacer.tsx'
@@ -437,16 +437,7 @@ export function ErrorBoundary() {
 		if (error.status === 404) {
 			return (
 				<ErrorDoc>
-					<ErrorPage
-						heroProps={{
-							title: "404 - Oh no, you found a page that's missing stuff.",
-							subtitle: `"${location.pathname}" is not a page on kentcdodds.com. So sorry.`,
-							image: (
-								<MissingSomething className="rounded-lg" aspectRatio="3:4" />
-							),
-							action: <ArrowLink href="/">Go home</ArrowLink>,
-						}}
-					/>
+					<FourOhFour />
 				</ErrorDoc>
 			)
 		}

--- a/app/routes/$slug.tsx
+++ b/app/routes/$slug.tsx
@@ -18,8 +18,8 @@ import {
 	mdxPageMeta,
 	useMdxComponent,
 } from '#app/utils/mdx.tsx'
-import { type NotFoundMatch } from '#app/utils/not-found-matches.ts'
 import { requireValidSlug, reuseUsefulLoaderHeaders } from '#app/utils/misc.ts'
+import { type NotFoundMatch } from '#app/utils/not-found-matches.ts'
 import { getNotFoundSuggestions } from '#app/utils/not-found-suggestions.server.ts'
 import { getServerTimeHeader } from '#app/utils/timing.server.ts'
 import { type Route } from './+types/$slug'

--- a/app/routes/blog_/$slug.tsx
+++ b/app/routes/blog_/$slug.tsx
@@ -27,8 +27,6 @@ import {
 	getBlogRecommendations,
 	getTotalPostReads,
 } from '#app/utils/blog.server.ts'
-import { type NotFoundMatch } from '#app/utils/not-found-matches.ts'
-import { getNotFoundSuggestions } from '#app/utils/not-found-suggestions.server.ts'
 import { getRankingLeader } from '#app/utils/blog.ts'
 import { getBlogMdxListItems, getMdxPage } from '#app/utils/mdx.server.ts'
 import {
@@ -42,6 +40,8 @@ import {
 	requireValidSlug,
 	reuseUsefulLoaderHeaders,
 } from '#app/utils/misc.ts'
+import { type NotFoundMatch } from '#app/utils/not-found-matches.ts'
+import { getNotFoundSuggestions } from '#app/utils/not-found-suggestions.server.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { getUser } from '#app/utils/session.server.ts'
 import { teamEmoji, useTeam } from '#app/utils/team-provider.tsx'

--- a/app/utils/__tests__/not-found-matches.test.ts
+++ b/app/utils/__tests__/not-found-matches.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import { normalizeNotFoundUrl } from '../not-found-matches.ts'
+
+describe('normalizeNotFoundUrl', () => {
+	test('keeps internal paths as-is', () => {
+		expect(normalizeNotFoundUrl('/blog/react')).toBe('/blog/react')
+	})
+
+	test('strips origin from absolute http(s) URLs', () => {
+		expect(
+			normalizeNotFoundUrl('https://kentcdodds.com/blog/react?q=1#hash'),
+		).toBe('/blog/react?q=1#hash')
+	})
+
+	test('rejects protocol-relative URLs', () => {
+		expect(normalizeNotFoundUrl('//evil.com/pwned')).toBe('')
+		expect(normalizeNotFoundUrl('https://example.com//evil.com/pwned')).toBe('')
+	})
+
+	test('rejects non-http schemes', () => {
+		expect(normalizeNotFoundUrl('javascript:alert(1)')).toBe('')
+		expect(normalizeNotFoundUrl('data:text/html;base64,PHNjcmlwdD4=')).toBe('')
+	})
+})
+

--- a/app/utils/not-found-matches.ts
+++ b/app/utils/not-found-matches.ts
@@ -1,0 +1,45 @@
+export type NotFoundMatch = {
+	url: string
+	type: string
+	title: string
+	summary?: string
+	imageUrl?: string
+	imageAlt?: string
+}
+
+function normalizeType(type: string) {
+	// Keep UI labels simple and consistent.
+	if (type === 'jsx-page') return 'page'
+	return type
+}
+
+function getTypePriority(type: string, priorities: ReadonlyArray<string>) {
+	const normalized = normalizeType(type)
+	const idx = priorities.indexOf(normalized)
+	return idx === -1 ? Number.POSITIVE_INFINITY : idx
+}
+
+/**
+ * Stable sort that keeps semantic ranking within each type group.
+ */
+export function sortNotFoundMatches(
+	matches: ReadonlyArray<NotFoundMatch>,
+	{
+		priorities = ['blog', 'page'],
+	}: {
+		priorities?: ReadonlyArray<string>
+	} = {},
+): Array<NotFoundMatch> {
+	return matches
+		.map((m, index) => ({
+			m: { ...m, type: normalizeType(m.type) },
+			index,
+			priority: getTypePriority(m.type, priorities),
+		}))
+		.sort((a, b) => {
+			if (a.priority !== b.priority) return a.priority - b.priority
+			return a.index - b.index
+		})
+		.map((x) => x.m)
+}
+

--- a/app/utils/not-found-matches.ts
+++ b/app/utils/not-found-matches.ts
@@ -7,6 +7,23 @@ export type NotFoundMatch = {
 	imageAlt?: string
 }
 
+export function normalizeNotFoundUrl(rawUrl: string) {
+	const url = rawUrl.trim()
+	if (!url) return ''
+	// Only allow internal app paths. This also keeps client/server rendering consistent
+	// when `/resources/search` returns absolute URLs.
+	if (url.startsWith('/')) return url
+	if (/^https?:\/\//i.test(url)) {
+		try {
+			const u = new URL(url)
+			return `${u.pathname}${u.search}${u.hash}`
+		} catch {
+			return ''
+		}
+	}
+	return ''
+}
+
 function normalizeType(type: string) {
 	// Keep UI labels simple and consistent.
 	if (type === 'jsx-page') return 'page'

--- a/app/utils/not-found-matches.ts
+++ b/app/utils/not-found-matches.ts
@@ -7,16 +7,22 @@ export type NotFoundMatch = {
 	imageAlt?: string
 }
 
+function isSafeInternalPath(path: string) {
+	// Reject protocol-relative URLs (`//evil.com/...`) which browsers treat as absolute.
+	return path.startsWith('/') && !path.startsWith('//')
+}
+
 export function normalizeNotFoundUrl(rawUrl: string) {
 	const url = rawUrl.trim()
 	if (!url) return ''
 	// Only allow internal app paths. This also keeps client/server rendering consistent
 	// when `/resources/search` returns absolute URLs.
-	if (url.startsWith('/')) return url
+	if (isSafeInternalPath(url)) return url
 	if (/^https?:\/\//i.test(url)) {
 		try {
 			const u = new URL(url)
-			return `${u.pathname}${u.search}${u.hash}`
+			const path = `${u.pathname}${u.search}${u.hash}`
+			return isSafeInternalPath(path) ? path : ''
 		} catch {
 			return ''
 		}

--- a/app/utils/not-found-query.ts
+++ b/app/utils/not-found-query.ts
@@ -1,0 +1,34 @@
+function safeDecodeURIComponent(value: string) {
+	try {
+		return decodeURIComponent(value)
+	} catch {
+		return value
+	}
+}
+
+/**
+ * Convert a missing pathname into a semantic-search-friendly query string.
+ *
+ * Example: `/blog/react-testing-library` -> `blog react testing library`
+ */
+export function notFoundQueryFromPathname(pathname: string) {
+	const cleaned = (pathname ?? '').split(/[?#]/)[0] ?? ''
+	const segments = cleaned.split('/').filter(Boolean)
+	if (segments.length === 0) return ''
+
+	const words = segments
+		.map((segment) => {
+			let text = safeDecodeURIComponent(segment)
+			text = text.replace(/[-_.]+/g, ' ')
+			// Split simple camelCase boundaries.
+			text = text.replace(/([a-z])([A-Z])/g, '$1 $2')
+			return text
+		})
+		.join(' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+
+	// Keep queries reasonably small; embeddings don't benefit from very long URL-ish strings.
+	return words.length > 120 ? words.slice(0, 120).trim() : words
+}
+

--- a/app/utils/not-found-suggestions.server.ts
+++ b/app/utils/not-found-suggestions.server.ts
@@ -1,9 +1,6 @@
 import { sortNotFoundMatches, type NotFoundMatch } from './not-found-matches.ts'
 import { notFoundQueryFromPathname } from './not-found-query.ts'
-import {
-	isSemanticSearchConfigured,
-	semanticSearchKCD,
-} from './semantic-search.server.ts'
+import { semanticSearchKCD } from './semantic-search.server.ts'
 
 function requestWantsHtml(request: Request) {
 	// Avoid expensive semantic search for asset/API requests.
@@ -48,7 +45,6 @@ export async function getNotFoundSuggestions({
 	if (process.env.NODE_ENV === 'test') return null
 	if (request.method.toUpperCase() !== 'GET') return null
 	if (!requestWantsHtml(request)) return null
-	if (!isSemanticSearchConfigured()) return null
 
 	const resolvedPathname = normalizePathname(
 		typeof pathname === 'string' && pathname ? pathname : new URL(request.url).pathname,

--- a/app/utils/not-found-suggestions.server.ts
+++ b/app/utils/not-found-suggestions.server.ts
@@ -28,6 +28,21 @@ function toUrlKey(url: string) {
 	}
 }
 
+function normalizeNotFoundUrl(rawUrl: string) {
+	const url = rawUrl.trim()
+	if (!url) return ''
+	if (url.startsWith('/')) return url
+	if (/^https?:\/\//i.test(url)) {
+		try {
+			const u = new URL(url)
+			return `${u.pathname}${u.search}${u.hash}`
+		} catch {
+			return ''
+		}
+	}
+	return ''
+}
+
 export async function getNotFoundSuggestions({
 	request,
 	pathname,
@@ -57,12 +72,13 @@ export async function getNotFoundSuggestions({
 		const byUrl = new Map<string, NotFoundMatch>()
 
 		for (const r of results) {
-			const url =
+			const rawUrl =
 				typeof r.url === 'string' && r.url.trim()
 					? r.url.trim()
 					: typeof r.id === 'string' && r.id.startsWith('/')
 						? r.id
 						: ''
+			const url = rawUrl ? normalizeNotFoundUrl(rawUrl) : ''
 			if (!url) continue
 
 			// Skip suggesting the missing URL itself.

--- a/app/utils/not-found-suggestions.server.ts
+++ b/app/utils/not-found-suggestions.server.ts
@@ -1,5 +1,5 @@
-import { notFoundQueryFromPathname } from './not-found-query.ts'
 import { sortNotFoundMatches, type NotFoundMatch } from './not-found-matches.ts'
+import { notFoundQueryFromPathname } from './not-found-query.ts'
 import {
 	isSemanticSearchConfigured,
 	semanticSearchKCD,

--- a/app/utils/not-found-suggestions.server.ts
+++ b/app/utils/not-found-suggestions.server.ts
@@ -1,4 +1,8 @@
-import { sortNotFoundMatches, type NotFoundMatch } from './not-found-matches.ts'
+import {
+	normalizeNotFoundUrl,
+	sortNotFoundMatches,
+	type NotFoundMatch,
+} from './not-found-matches.ts'
 import { notFoundQueryFromPathname } from './not-found-query.ts'
 import { semanticSearchKCD } from './semantic-search.server.ts'
 
@@ -26,21 +30,6 @@ function toUrlKey(url: string) {
 	} catch {
 		return url
 	}
-}
-
-function normalizeNotFoundUrl(rawUrl: string) {
-	const url = rawUrl.trim()
-	if (!url) return ''
-	if (url.startsWith('/')) return url
-	if (/^https?:\/\//i.test(url)) {
-		try {
-			const u = new URL(url)
-			return `${u.pathname}${u.search}${u.hash}`
-		} catch {
-			return ''
-		}
-	}
-	return ''
 }
 
 export async function getNotFoundSuggestions({

--- a/app/utils/not-found-suggestions.server.ts
+++ b/app/utils/not-found-suggestions.server.ts
@@ -1,0 +1,114 @@
+import { notFoundQueryFromPathname } from './not-found-query.ts'
+import { sortNotFoundMatches, type NotFoundMatch } from './not-found-matches.ts'
+import {
+	isSemanticSearchConfigured,
+	semanticSearchKCD,
+} from './semantic-search.server.ts'
+
+function requestWantsHtml(request: Request) {
+	// Avoid expensive semantic search for asset/API requests.
+	const accept = request.headers.get('accept') ?? ''
+	return (
+		accept.includes('text/html') ||
+		accept.includes('application/xhtml+xml')
+	)
+}
+
+function normalizePathname(pathname: string) {
+	const cleaned = (pathname.split(/[?#]/)[0] ?? '').trim()
+	if (!cleaned) return '/'
+	if (cleaned === '/') return '/'
+	return cleaned.replace(/\/+$/, '') || '/'
+}
+
+function toUrlKey(url: string) {
+	// Normalize relative and absolute URLs for dedupe.
+	try {
+		const u = new URL(url, 'https://kentcdodds.com')
+		return `${u.pathname}${u.search}`
+	} catch {
+		return url
+	}
+}
+
+export async function getNotFoundSuggestions({
+	request,
+	pathname,
+	limit = 8,
+	topK = 15,
+	priorities,
+}: {
+	request: Request
+	pathname?: string
+	limit?: number
+	topK?: number
+	priorities?: ReadonlyArray<string>
+}): Promise<{ query: string; matches: Array<NotFoundMatch> } | null> {
+	// Unit tests don't load MSW handlers; avoid real network calls.
+	if (process.env.NODE_ENV === 'test') return null
+	if (request.method.toUpperCase() !== 'GET') return null
+	if (!requestWantsHtml(request)) return null
+	if (!isSemanticSearchConfigured()) return null
+
+	const resolvedPathname = normalizePathname(
+		typeof pathname === 'string' && pathname ? pathname : new URL(request.url).pathname,
+	)
+	const query = notFoundQueryFromPathname(resolvedPathname)
+	if (!query || query.length < 3) return null
+
+	try {
+		const results = await semanticSearchKCD({ query, topK })
+		const byUrl = new Map<string, NotFoundMatch>()
+
+		for (const r of results) {
+			const url =
+				typeof r.url === 'string' && r.url.trim()
+					? r.url.trim()
+					: typeof r.id === 'string' && r.id.startsWith('/')
+						? r.id
+						: ''
+			if (!url) continue
+
+			// Skip suggesting the missing URL itself.
+			if (normalizePathname(url) === resolvedPathname) continue
+
+			const key = toUrlKey(url)
+			if (byUrl.has(key)) continue
+
+			byUrl.set(key, {
+				url,
+				type: typeof r.type === 'string' && r.type.trim() ? r.type.trim() : 'result',
+				title:
+					typeof r.title === 'string' && r.title.trim()
+						? r.title.trim()
+						: url,
+				summary:
+					typeof r.summary === 'string' && r.summary.trim()
+						? r.summary.trim()
+						: typeof r.snippet === 'string' && r.snippet.trim()
+							? r.snippet.trim()
+							: undefined,
+				imageUrl:
+					typeof r.imageUrl === 'string' && r.imageUrl.trim()
+						? r.imageUrl.trim()
+						: undefined,
+				imageAlt:
+					typeof r.imageAlt === 'string' && r.imageAlt.trim()
+						? r.imageAlt.trim()
+						: undefined,
+			})
+		}
+
+		const matches = sortNotFoundMatches([...byUrl.values()], { priorities }).slice(
+			0,
+			Math.max(0, Math.floor(limit)),
+		)
+
+		return { query, matches }
+	} catch (error: unknown) {
+		// 404 pages should never fail the request because semantic search failed.
+		console.error('Semantic search failed while rendering 404 suggestions', error)
+		return null
+	}
+}
+


### PR DESCRIPTION
Add semantic search "Possible matches" to 404 pages, prioritizing blog posts, to improve user experience.

---
<p><a href="https://cursor.com/agents/bc-21342b24-c631-49a0-a9bc-fa5936988f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21342b24-c631-49a0-a9bc-fa5936988f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple 404 loader/error-boundary paths and introduces a new server-side semantic search call (network/perf dependency), though it’s gated by request type, short timeouts, and fails open to the existing 404 UX.
> 
> **Overview**
> 404 pages now optionally show a new **“Possible matches”** section populated via server-side semantic search, with results sorted (blog/pages prioritized), deduped, and linked to an on-site search query derived from the missing pathname.
> 
> Not-found loaders (`routes/$.tsx`, `routes/$slug.tsx`, `routes/blog_/$slug.tsx`) now fetch suggestions for HTML GET requests only, return them in 404 JSON payloads with short-lived private caching, and render them through an enhanced `FourOhFour`/`ErrorPage` flow (including hero CTA/anchor behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e006f96e06039c140ad3c6acbc940538e91132. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 404 pages now show a "Possible matches" section (image, title, type, summary) with a "See all results" CTA and hero action that jumps to the section or search.
  * A unified FourOhFour component surfaces remote semantic suggestions when available.

* **Improvements**
  * Suggestions are derived from the requested path, fetched and memoized when appropriate, deduplicated and deterministically ranked for more relevant results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->