### PR TITLE
CI cache invalidation strategy

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Bump to force-invalidate *all* site-cache entries.
+  SITE_CACHE_VERSION: v2
+
 jobs:
   changes:
     name: 🔎 Determine deployable changes
@@ -109,7 +113,19 @@ jobs:
         uses: actions/cache@v5
         with:
           path: other/cache.db
-          key: site-cache
+          # `other/cache.db` is a derived artifact. Key it off the inputs that can
+          # make it stale (content + cache/MDX code + deps), not `github.sha`.
+          key: >-
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node24-${{ hashFiles(
+              'package-lock.json',
+              'app/utils/cache.server.ts',
+              'app/utils/compile-mdx.server.ts',
+              'app/utils/github.server.ts',
+              'app/utils/markdown.server.ts',
+              'app/utils/mdx.server.ts',
+              'content/**',
+              'mocks/**'
+            ) }}
 
       - name: 😅 Generate Site Cache
         if: steps.site-cache.outputs.cache-hit != 'true'
@@ -161,7 +177,19 @@ jobs:
         uses: actions/cache@v5
         with:
           path: other/cache.db
-          key: site-cache
+          # `other/cache.db` is a derived artifact. Key it off the inputs that can
+          # make it stale (content + cache/MDX code + deps), not `github.sha`.
+          key: >-
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node24-${{ hashFiles(
+              'package-lock.json',
+              'app/utils/cache.server.ts',
+              'app/utils/compile-mdx.server.ts',
+              'app/utils/github.server.ts',
+              'app/utils/markdown.server.ts',
+              'app/utils/mdx.server.ts',
+              'content/**',
+              'mocks/**'
+            ) }}
 
       - name: 😅 Generate Site Cache
         if: steps.site-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -11,8 +11,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Bump to force-invalidate *all* site-cache entries.
-  SITE_CACHE_VERSION: v2
+  # Prefer setting `SITE_CACHE_VERSION` as a repository variable so all workflows
+  # share one knob for invalidation (fallback keeps forks working).
+  SITE_CACHE_VERSION: ${{ vars.SITE_CACHE_VERSION || 'v2' }}
+  NODE_VERSION: 24
 
 jobs:
   changes:
@@ -29,7 +31,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 🔎 Determine deployable changes
         id: changes
@@ -53,7 +55,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1.11.2
@@ -73,7 +75,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1.11.2
@@ -97,7 +99,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1.11.2
@@ -116,7 +118,7 @@ jobs:
           # `other/cache.db` is a derived artifact. Key it off the inputs that can
           # make it stale (content + cache/MDX code + deps), not `github.sha`.
           key: >-
-            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node24-${{ hashFiles(
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-${{ hashFiles(
               'package-lock.json',
               'app/utils/cache.server.ts',
               'app/utils/compile-mdx.server.ts',
@@ -126,6 +128,8 @@ jobs:
               'content/**',
               'mocks/**'
             ) }}
+          restore-keys: |
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
       - name: 😅 Generate Site Cache
         if: steps.site-cache.outputs.cache-hit != 'true'
@@ -153,7 +157,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 🎬 Setup ffmpeg
         uses: FedericoCarboni/setup-ffmpeg@v3
@@ -180,7 +184,7 @@ jobs:
           # `other/cache.db` is a derived artifact. Key it off the inputs that can
           # make it stale (content + cache/MDX code + deps), not `github.sha`.
           key: >-
-            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node24-${{ hashFiles(
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-${{ hashFiles(
               'package-lock.json',
               'app/utils/cache.server.ts',
               'app/utils/compile-mdx.server.ts',
@@ -190,6 +194,8 @@ jobs:
               'content/**',
               'mocks/**'
             ) }}
+          restore-keys: |
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
       - name: 😅 Generate Site Cache
         if: steps.site-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Prefer setting `SITE_CACHE_VERSION` as a repository variable so all workflows
-  # share one knob for invalidation (fallback keeps forks working).
-  SITE_CACHE_VERSION: ${{ vars.SITE_CACHE_VERSION || 'v2' }}
+  # Set `SITE_CACHE_VERSION` as a repository variable so all workflows share one
+  # knob for invalidation.
+  SITE_CACHE_VERSION: ${{ vars.SITE_CACHE_VERSION }}
   NODE_VERSION: 24
 
 jobs:

--- a/.github/workflows/index-semantic-content.yml
+++ b/.github/workflows/index-semantic-content.yml
@@ -16,9 +16,9 @@ on:
       - 'other/semantic-search/**'
 
 env:
-  # Prefer setting `SITE_CACHE_VERSION` as a repository variable so all workflows
-  # share one knob for invalidation (fallback keeps forks working).
-  SITE_CACHE_VERSION: ${{ vars.SITE_CACHE_VERSION || 'v2' }}
+  # Set `SITE_CACHE_VERSION` as a repository variable so all workflows share one
+  # knob for invalidation.
+  SITE_CACHE_VERSION: ${{ vars.SITE_CACHE_VERSION }}
   NODE_VERSION: 24
 
 jobs:

--- a/.github/workflows/index-semantic-content.yml
+++ b/.github/workflows/index-semantic-content.yml
@@ -15,6 +15,10 @@ on:
       - 'app/utils/sitemap.server.ts'
       - 'other/semantic-search/**'
 
+env:
+  # Bump to force-invalidate *all* site-cache entries.
+  SITE_CACHE_VERSION: v2
+
 jobs:
   index:
     name: 🔎 Index Semantic Search (content)
@@ -42,7 +46,19 @@ jobs:
         uses: actions/cache@v5
         with:
           path: other/cache.db
-          key: site-cache
+          # `other/cache.db` is a derived artifact. Key it off the inputs that can
+          # make it stale (content + cache/MDX code + deps), not `github.sha`.
+          key: >-
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node24-${{ hashFiles(
+              'package-lock.json',
+              'app/utils/cache.server.ts',
+              'app/utils/compile-mdx.server.ts',
+              'app/utils/github.server.ts',
+              'app/utils/markdown.server.ts',
+              'app/utils/mdx.server.ts',
+              'content/**',
+              'mocks/**'
+            ) }}
 
       - name: 🏗 Build (production)
         if: steps.site-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/index-semantic-content.yml
+++ b/.github/workflows/index-semantic-content.yml
@@ -16,8 +16,10 @@ on:
       - 'other/semantic-search/**'
 
 env:
-  # Bump to force-invalidate *all* site-cache entries.
-  SITE_CACHE_VERSION: v2
+  # Prefer setting `SITE_CACHE_VERSION` as a repository variable so all workflows
+  # share one knob for invalidation (fallback keeps forks working).
+  SITE_CACHE_VERSION: ${{ vars.SITE_CACHE_VERSION || 'v2' }}
+  NODE_VERSION: 24
 
 jobs:
   index:
@@ -33,7 +35,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1.11.2
@@ -49,7 +51,7 @@ jobs:
           # `other/cache.db` is a derived artifact. Key it off the inputs that can
           # make it stale (content + cache/MDX code + deps), not `github.sha`.
           key: >-
-            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node24-${{ hashFiles(
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-${{ hashFiles(
               'package-lock.json',
               'app/utils/cache.server.ts',
               'app/utils/compile-mdx.server.ts',
@@ -59,6 +61,8 @@ jobs:
               'content/**',
               'mocks/**'
             ) }}
+          restore-keys: |
+            site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
       - name: 🏗 Build (production)
         if: steps.site-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Update CI cache key for `other/cache.db` to invalidate on content and code changes.

The previous cache key was constant (`site-cache`), preventing invalidation when content or related code changed. The new key incorporates hashes of relevant content directories, MDX code, and `package-lock.json`, along with a `SITE_CACHE_VERSION` for manual busts, ensuring the cache refreshes only when necessary.

---
<p><a href="https://cursor.com/agents/bc-49f67081-d058-4a60-99a3-571325b53f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f67081-d058-4a60-99a3-571325b53f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow-only changes that affect caching behavior; main risk is slower builds or unexpected cache misses/hits if the new key inputs are incomplete.
> 
> **Overview**
> Updates GitHub Actions workflows to centralize `NODE_VERSION` and introduce `SITE_CACHE_VERSION` for shared, manual cache busting.
> 
> Replaces the constant `actions/cache` key for `other/cache.db` with a content/deps-derived key (OS + node version + hash of `package-lock.json`, relevant MDX/cache utilities, and `content/**`/`mocks/**`) plus `restore-keys`, ensuring site-cache refreshes when inputs change while still allowing partial restores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f4db3b9eac325d4f1280623e977dede7fb54282. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved site caching: cache keys are now versioned and composite, including runtime version, runner platform, and a hash of relevant inputs to trigger accurate invalidation.
  * Added restore-keys to improve cache recovery.
  * Centralized the runtime version in workflow env and applied the enhanced cache strategy across CI steps (build, health checks, and tests).
  * Comments added to clarify cache-key derivation and regeneration triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->