### PR TITLE
Last deployment failure

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -131,6 +131,10 @@ jobs:
           restore-keys: |
             site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
+      - name: 🛠 Setup Database (migrations)
+        if: steps.site-cache.outputs.cache-hit != 'true'
+        run: npx prisma migrate deploy
+
       - name: 😅 Generate Site Cache
         if: steps.site-cache.outputs.cache-hit != 'true'
         run: npm run prime-cache:mocks

--- a/.github/workflows/index-semantic-content.yml
+++ b/.github/workflows/index-semantic-content.yml
@@ -64,6 +64,10 @@ jobs:
           restore-keys: |
             site-cache-mocks-${{ env.SITE_CACHE_VERSION }}-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
+      - name: 🛠 Setup Database (migrations)
+        if: steps.site-cache.outputs.cache-hit != 'true'
+        run: npx prisma migrate deploy
+
       - name: 🏗 Build (production)
         if: steps.site-cache.outputs.cache-hit != 'true'
         run: npm run build


### PR DESCRIPTION
Run Prisma migrations before priming the cache in CI to fix deployment failures due to missing database tables.

---
<p><a href="https://cursor.com/agents/bc-ac2efb79-380c-41c3-bfa3-c5c576426805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac2efb79-380c-41c3-bfa3-c5c576426805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a deterministic migration step; main risk is longer CI runs or unexpected migration failures in these jobs.
> 
> **Overview**
> Fixes CI/deployment failures caused by priming the site cache against an unmigrated database.
> 
> Both `deployment.yml` (pre-deploy health check) and `index-semantic-content.yml` now run `npx prisma migrate deploy` when the site-cache is a miss, before running `prime-cache:mocks` (and before the production build in the indexing workflow).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5839c7f87d3dd6d89884bdc8905b31d9bf354663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated database migration step to CI/CD workflows that runs on cache misses to ensure database schema is synchronized before deployment and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->