### PR TITLE
404 page mobile layout

### DIFF
--- a/app/components/error-boundary.tsx
+++ b/app/components/error-boundary.tsx
@@ -33,14 +33,23 @@ export function GeneralErrorBoundary({
 		console.error(error)
 	}
 
+	// Most of our route-specific status handlers render full-page experiences
+	// (like the 404 hero). Wrapping those in a padded container makes mobile
+	// layouts extremely narrow, so only wrap the fallback/simple handlers.
+	if (isRouteErrorResponse(error)) {
+		const statusHandler = statusHandlers?.[error.status]
+		const content = (statusHandler ?? defaultStatusHandler)({ error, params })
+		if (statusHandler) return <>{content}</>
+		return (
+			<div className="text-h2 container mx-auto flex items-center justify-center p-6 sm:p-12 lg:p-20">
+				{content}
+			</div>
+		)
+	}
+
 	return (
-		<div className="text-h2 container mx-auto flex items-center justify-center p-20">
-			{isRouteErrorResponse(error)
-				? (statusHandlers?.[error.status] ?? defaultStatusHandler)({
-						error,
-						params,
-					})
-				: unexpectedErrorHandler(error)}
+		<div className="text-h2 container mx-auto flex items-center justify-center p-6 sm:p-12 lg:p-20">
+			{unexpectedErrorHandler(error)}
 		</div>
 	)
 }


### PR DESCRIPTION
Remove heavily padded wrapper from custom 404/400 error pages to fix squished mobile layout.

---
<p><a href="https://cursor.com/agents/bc-ca441cf5-4fe6-40d7-9ba4-28bf9f98ca4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca441cf5-4fe6-40d7-9ba4-28bf9f98ca4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

