### PR TITLE
Semantic search caching

### DIFF
--- a/app/utils/__tests__/semantic-search-cache.server.test.ts
+++ b/app/utils/__tests__/semantic-search-cache.server.test.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, vi } from 'vitest'
+import { semanticSearchKCD } from '../semantic-search.server.ts'
+
+test('semanticSearchKCD caches by normalized query + topK (skips network on hit)', async () => {
+	const id = randomUUID()
+	const noisyQuery = `  zz   semantic   cache test   ${id}  `
+	const normalizedQuery = `zz semantic cache test ${id}`
+
+	const fetchSpy = vi.spyOn(globalThis, 'fetch')
+	try {
+		fetchSpy.mockClear()
+		await semanticSearchKCD({ query: noisyQuery, topK: 3 })
+		expect(fetchSpy).toHaveBeenCalled()
+
+		// Same semantic query, different whitespace: should hit cache.
+		fetchSpy.mockClear()
+		await semanticSearchKCD({ query: normalizedQuery, topK: 3 })
+		expect(fetchSpy).not.toHaveBeenCalled()
+
+		// Different topK should be a different cache key.
+		fetchSpy.mockClear()
+		await semanticSearchKCD({ query: normalizedQuery, topK: 4 })
+		expect(fetchSpy).toHaveBeenCalled()
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})
+


### PR DESCRIPTION
Add an in-memory LRU+TTL cache to semantic search to prevent repeated Workers AI and Vectorize calls.

---
<p><a href="https://cursor.com/agents/bc-49841db2-060d-41da-836f-8f91b469669c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49841db2-060d-41da-836f-8f91b469669c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

