### PR TITLE
Podcast transcript formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,11 @@ CLOUDFLARE_AI_TRANSCRIPTION_MODEL=MOCK_CLOUDFLARE_AI_TRANSCRIPTION_MODEL
 # Optional (defaults to CLOUDFLARE_AI_TEXT_MODEL)
 CLOUDFLARE_AI_CALL_KENT_METADATA_MODEL=MOCK_CLOUDFLARE_AI_CALL_KENT_METADATA_MODEL
 
+# Feature: /calls/admin (LLM transcript paragraph formatting)
+# Mocked: yes (when MOCKS=true)
+# Optional (defaults to CLOUDFLARE_AI_TEXT_MODEL)
+CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL=MOCK_CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL
+
 # Feature: /calls/record (typed question -> AI TTS via Cloudflare Workers AI)
 # Mocked: yes (when MOCKS=true)
 # Optional (defaults to @cf/deepgram/aura-2-en)

--- a/app/utils/__tests__/call-kent-transcript-format.server.test.ts
+++ b/app/utils/__tests__/call-kent-transcript-format.server.test.ts
@@ -1,6 +1,12 @@
 import { expect, test } from 'vitest'
 import { formatCallKentTranscriptWithWorkersAi } from '#app/utils/cloudflare-ai-call-kent-transcript-format.server.ts'
 
+test('formatCallKentTranscriptWithWorkersAi rejects empty transcripts', async () => {
+	await expect(
+		formatCallKentTranscriptWithWorkersAi({ transcript: '' }),
+	).rejects.toThrow(/missing transcript input/i)
+})
+
 test('formatCallKentTranscriptWithWorkersAi returns paragraphs and preserves separators', async () => {
 	const transcript = `
 Announcer: You're listening to the Call Kent Podcast. Now let's hear the call.
@@ -29,6 +35,26 @@ Announcer: This has been the Call Kent Podcast. Thanks for listening.
 	expect(formattedSepCount).toBe(originalSepCount)
 
 	// The mock formatter inserts a blank line after sentence-ending punctuation.
+	expect(formatted).toMatch(/[.!?]\n\n/)
+})
+
+test('formatCallKentTranscriptWithWorkersAi works without --- separators', async () => {
+	const transcript = `Caller: Hi Kent. This is a single block transcript. It should still get paragraph breaks.`
+	const formatted = await formatCallKentTranscriptWithWorkersAi({ transcript })
+	expect(formatted).toContain('Caller:')
+	expect(formatted).toMatch(/[.!?]\n\n/)
+})
+
+test('formatCallKentTranscriptWithWorkersAi does not truncate long transcripts', async () => {
+	const longBody = Array.from(
+		{ length: 600 },
+		(_, i) => `Sentence ${i + 1}.`,
+	).join(' ')
+	const transcript = `Kent: ${longBody}`
+
+	const formatted = await formatCallKentTranscriptWithWorkersAi({ transcript })
+	expect(formatted).toContain('Kent:')
+	expect(formatted).toContain('Sentence 600.')
 	expect(formatted).toMatch(/[.!?]\n\n/)
 })
 

--- a/app/utils/__tests__/call-kent-transcript-format.server.test.ts
+++ b/app/utils/__tests__/call-kent-transcript-format.server.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+import { formatCallKentTranscriptWithWorkersAi } from '#app/utils/cloudflare-ai-call-kent-transcript-format.server.ts'
+
+test('formatCallKentTranscriptWithWorkersAi returns paragraphs and preserves separators', async () => {
+	const transcript = `
+Announcer: You're listening to the Call Kent Podcast. Now let's hear the call.
+
+---
+
+Caller: Hi Kent. I have a question about loaders. I keep seeing double fetching.
+
+---
+
+Kent: Great question. Let's talk about it. First, loaders run on the server.
+
+---
+
+Announcer: This has been the Call Kent Podcast. Thanks for listening.
+`.trim()
+
+	const formatted = await formatCallKentTranscriptWithWorkersAi({ transcript })
+
+	expect(formatted).toContain('Announcer:')
+	expect(formatted).toContain('Caller:')
+	expect(formatted).toContain('Kent:')
+
+	const originalSepCount = (transcript.match(/^---$/gm) ?? []).length
+	const formattedSepCount = (formatted.match(/^---$/gm) ?? []).length
+	expect(formattedSepCount).toBe(originalSepCount)
+
+	// The mock formatter inserts a blank line after sentence-ending punctuation.
+	expect(formatted).toMatch(/[.!?]\n\n/)
+})
+

--- a/app/utils/cloudflare-ai-call-kent-metadata.server.ts
+++ b/app/utils/cloudflare-ai-call-kent-metadata.server.ts
@@ -1,16 +1,13 @@
+import {
+	getWorkersAiRunUrl,
+	unwrapWorkersAiText,
+} from './cloudflare-ai-utils.server.ts'
 import { getEnv } from './env.server.ts'
 
 type CallKentEpisodeMetadata = {
 	title: string
 	description: string
 	keywords: string
-}
-
-function getWorkersAiRunUrl({ model }: { model: string }) {
-	// Cloudflare's REST route expects the model as path segments (with `/`), so do
-	// not URL-encode the model string (encoding can yield "No route for that URI").
-	const env = getEnv()
-	return `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_AI_GATEWAY_ID}/workers-ai/${model}`
 }
 
 function extractJsonObjectFromText(text: string) {
@@ -39,20 +36,6 @@ function clampTitle(title: string) {
 	const cleaned = title.trim().replace(/\s+/g, ' ')
 	// Keep title reasonable for UI + Transistor.
 	return cleaned.length > 80 ? `${cleaned.slice(0, 77).trimEnd()}...` : cleaned
-}
-
-function unwrapWorkersAiText(result: any): string | null {
-	if (!result) return null
-	if (typeof result === 'string') return result
-	if (typeof result.response === 'string') return result.response
-	if (typeof result.output === 'string') return result.output
-	if (typeof result.text === 'string') return result.text
-
-	// OpenAI-ish shape (some models / gateways).
-	const choiceContent = result?.choices?.[0]?.message?.content
-	if (typeof choiceContent === 'string') return choiceContent
-
-	return null
 }
 
 export async function generateCallKentEpisodeMetadataWithWorkersAi({

--- a/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
+++ b/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
@@ -1,0 +1,168 @@
+import { getEnv } from './env.server.ts'
+
+function getWorkersAiRunUrl(model: string) {
+	// Cloudflare's REST route expects the model as path segments (with `/`), so do
+	// not URL-encode the model string (encoding can yield "No route for that URI").
+	const env = getEnv()
+	return `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_AI_GATEWAY_ID}/workers-ai/${model}`
+}
+
+function unwrapWorkersAiText(result: any): string | null {
+	if (!result) return null
+	if (typeof result === 'string') return result
+	if (typeof result.response === 'string') return result.response
+	if (typeof result.output === 'string') return result.output
+	if (typeof result.text === 'string') return result.text
+
+	// OpenAI-ish shape (some models / gateways).
+	const choiceContent = result?.choices?.[0]?.message?.content
+	if (typeof choiceContent === 'string') return choiceContent
+
+	return null
+}
+
+function stripSingleMarkdownCodeFence(text: string) {
+	const trimmed = text.trim()
+	const match = /^```(?:text|markdown)?\s*\n([\s\S]*?)\n```$/i.exec(trimmed)
+	return match ? match[1].trim() : text
+}
+
+function extractBetweenMarkers({
+	text,
+	startMarker,
+	endMarker,
+}: {
+	text: string
+	startMarker: string
+	endMarker: string
+}) {
+	const start = text.indexOf(startMarker)
+	if (start === -1) return null
+	const end = text.indexOf(endMarker, start + startMarker.length)
+	if (end === -1) return null
+	return text.slice(start + startMarker.length, end).trim()
+}
+
+function countSeparatorLines(text: string) {
+	return (text.match(/^---$/gm) ?? []).length
+}
+
+export async function formatCallKentTranscriptWithWorkersAi({
+	transcript,
+	callTitle,
+	callerNotes,
+	callerName,
+	model,
+}: {
+	transcript: string
+	callTitle?: string | null
+	callerNotes?: string | null
+	callerName?: string
+	model?: string
+}): Promise<string> {
+	const env = getEnv()
+	const apiToken = env.CLOUDFLARE_API_TOKEN
+	const modelToUse = model ?? env.CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL
+
+	const input = transcript.trim()
+	if (!input) {
+		throw new Error('Missing transcript input for transcript formatting.')
+	}
+
+	const startMarker = '<<<TRANSCRIPT>>>'
+	const endMarker = '<<<END TRANSCRIPT>>>'
+
+	const system = `
+You format transcripts for the "Call Kent Podcast", hosted by Kent C. Dodds.
+
+Your job is to improve readability by inserting paragraph breaks (blank lines) and normalizing whitespace.
+Do NOT add, remove, or reorder any words. Do NOT change speaker labels.
+
+If the transcript includes separator lines containing only "---", keep those lines exactly as-is and on their own line.
+
+Output only the final formatted transcript as plain text.
+Do not include commentary, headings, JSON, or Markdown code fences.
+`.trim()
+
+	const contextLines = [
+		callTitle?.trim() ? `Episode title: ${callTitle.trim()}` : null,
+		callerNotes?.trim() ? `Caller notes: ${callerNotes.trim()}` : null,
+		callerName?.trim() ? `Caller first name: ${callerName.trim()}` : null,
+	].filter(Boolean)
+
+	const user = `
+${contextLines.length ? `${contextLines.join('\n')}\n\n` : ''}Format this transcript into readable paragraphs.
+
+${startMarker}
+${input}
+${endMarker}
+`.trim()
+
+	const url = getWorkersAiRunUrl(modelToUse)
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${apiToken}`,
+			'cf-aig-authorization': `Bearer ${env.CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			messages: [
+				{ role: 'system', content: system },
+				{ role: 'user', content: user },
+			],
+			// Needs to be large enough to return the full transcript, but still keep
+			// Workers AI outputs bounded.
+			max_tokens: 4096,
+		}),
+	})
+
+	if (!res.ok) {
+		const bodyText = await res.text().catch(() => '')
+		throw new Error(
+			`Cloudflare Workers AI transcript formatting failed: ${res.status} ${res.statusText}${bodyText ? `\n${bodyText}` : ''}`,
+		)
+	}
+
+	const json = (await res.json()) as any
+	const result = (json?.result ?? json) as any
+	const text = unwrapWorkersAiText(result)
+	if (!text) {
+		throw new Error('Unexpected transcript formatting response shape from Workers AI')
+	}
+
+	let formatted = stripSingleMarkdownCodeFence(text).trim()
+	const extracted = extractBetweenMarkers({
+		text: formatted,
+		startMarker,
+		endMarker,
+	})
+	if (extracted) formatted = extracted
+
+	// Safety checks: we never want to persist "metadata JSON" as the transcript.
+	if (
+		formatted.startsWith('{') &&
+		/"title"\s*:/.test(formatted) &&
+		/"description"\s*:/.test(formatted) &&
+		/"keywords"\s*:/.test(formatted)
+	) {
+		throw new Error('Transcript formatter returned metadata JSON unexpectedly.')
+	}
+
+	if (!formatted) {
+		throw new Error('Transcript formatter returned an empty transcript.')
+	}
+
+	const originalSepCount = countSeparatorLines(input)
+	if (originalSepCount > 0) {
+		const formattedSepCount = countSeparatorLines(formatted)
+		if (formattedSepCount !== originalSepCount) {
+			throw new Error(
+				`Transcript formatter changed separator count (${originalSepCount} -> ${formattedSepCount}).`,
+			)
+		}
+	}
+
+	return formatted
+}
+

--- a/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
+++ b/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
@@ -24,7 +24,7 @@ function unwrapWorkersAiText(result: any): string | null {
 function stripSingleMarkdownCodeFence(text: string) {
 	const trimmed = text.trim()
 	const match = /^```(?:text|markdown)?\s*\n([\s\S]*?)\n```$/i.exec(trimmed)
-	return match ? match[1].trim() : text
+	return match?.[1] ? match[1].trim() : text
 }
 
 function extractBetweenMarkers({

--- a/app/utils/cloudflare-ai-text-to-speech.server.ts
+++ b/app/utils/cloudflare-ai-text-to-speech.server.ts
@@ -1,11 +1,5 @@
+import { getWorkersAiRunUrl } from './cloudflare-ai-utils.server.ts'
 import { getEnv } from './env.server.ts'
-
-function getWorkersAiRunUrl(model: string) {
-	// Cloudflare's REST route expects the model as path segments (with `/`), so do
-	// not URL-encode the model string (encoding can yield "No route for that URI").
-	const env = getEnv()
-	return `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_AI_GATEWAY_ID}/workers-ai/${model}`
-}
 
 type WorkersAiTextToSpeechResponse = {
 	// Some models return base64 audio within JSON.

--- a/app/utils/cloudflare-ai-transcription.server.ts
+++ b/app/utils/cloudflare-ai-transcription.server.ts
@@ -4,14 +4,8 @@ type WhisperTranscriptionResponse = {
 }
 
 import { Buffer } from 'node:buffer'
+import { getWorkersAiRunUrl } from './cloudflare-ai-utils.server.ts'
 import { getEnv } from './env.server.ts'
-
-function getWorkersAiRunUrl(model: string) {
-	// Cloudflare's REST route expects the model as path segments (with `/`), so do
-	// not URL-encode the model string (encoding can yield "No route for that URI").
-	const env = getEnv()
-	return `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_AI_GATEWAY_ID}/workers-ai/${model}`
-}
 
 export async function transcribeMp3WithWorkersAi({
 	mp3,

--- a/app/utils/cloudflare-ai-utils.server.ts
+++ b/app/utils/cloudflare-ai-utils.server.ts
@@ -1,0 +1,32 @@
+import { getEnv } from './env.server.ts'
+
+type WorkersAiRunUrlOptions = {
+	model: string
+	accountId?: string
+	gatewayId?: string
+}
+
+export function getWorkersAiRunUrl(options: string | WorkersAiRunUrlOptions) {
+	const { model, accountId, gatewayId } =
+		typeof options === 'string' ? { model: options } : options
+	// Cloudflare's REST route expects the model as path segments (with `/`), so do
+	// not URL-encode the model string (encoding can yield "No route for that URI").
+	const env = getEnv()
+	const resolvedAccountId = accountId ?? env.CLOUDFLARE_ACCOUNT_ID
+	const resolvedGatewayId = gatewayId ?? env.CLOUDFLARE_AI_GATEWAY_ID
+	return `https://gateway.ai.cloudflare.com/v1/${resolvedAccountId}/${resolvedGatewayId}/workers-ai/${model}`
+}
+
+export function unwrapWorkersAiText(result: any): string | null {
+	if (!result) return null
+	if (typeof result === 'string') return result
+	if (typeof result.response === 'string') return result.response
+	if (typeof result.output === 'string') return result.output
+	if (typeof result.text === 'string') return result.text
+
+	// OpenAI-ish shape (some models / gateways).
+	const choiceContent = result?.choices?.[0]?.message?.content
+	if (typeof choiceContent === 'string') return choiceContent
+
+	return null
+}

--- a/app/utils/cloudflare-ai-utils.server.ts
+++ b/app/utils/cloudflare-ai-utils.server.ts
@@ -20,6 +20,12 @@ export function getWorkersAiRunUrl(options: string | WorkersAiRunUrlOptions) {
 export function unwrapWorkersAiText(result: any): string | null {
 	if (!result) return null
 	if (typeof result === 'string') return result
+	// Allow raw REST payloads that wrap the real response in `result`.
+	const nested = (result as any).result
+	if (nested && nested !== result) {
+		const unwrapped = unwrapWorkersAiText(nested)
+		if (unwrapped) return unwrapped
+	}
 	if (typeof result.response === 'string') return result.response
 	if (typeof result.output === 'string') return result.output
 	if (typeof result.text === 'string') return result.text

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -93,6 +93,7 @@ const schemaBase = z.object({
 		.optional()
 		.default('@cf/meta/llama-3.1-8b-instruct'),
 	CLOUDFLARE_AI_CALL_KENT_METADATA_MODEL: z.string().trim().optional(),
+	CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL: z.string().trim().optional(),
 
 	// Semantic search admin tooling (R2 manifests + ignore list).
 	R2_BUCKET: nonEmptyString,
@@ -167,6 +168,11 @@ export type Env = Omit<
 	 * text model by default.
 	 */
 	CLOUDFLARE_AI_CALL_KENT_METADATA_MODEL: string
+	/**
+	 * Defaults to `CLOUDFLARE_AI_TEXT_MODEL` when not explicitly set.
+	 * Used to format generated Call Kent transcripts into readable paragraphs.
+	 */
+	CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL: string
 	/** Derived from CLOUDFLARE_ACCOUNT_ID when not explicitly set. */
 	R2_ENDPOINT: string
 }
@@ -237,6 +243,9 @@ export function getEnv(): Env {
 		R2_ENDPOINT: derivedR2Endpoint,
 		CLOUDFLARE_AI_CALL_KENT_METADATA_MODEL:
 			values.CLOUDFLARE_AI_CALL_KENT_METADATA_MODEL ??
+			values.CLOUDFLARE_AI_TEXT_MODEL,
+		CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL:
+			values.CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL ??
 			values.CLOUDFLARE_AI_TEXT_MODEL,
 	}
 

--- a/app/utils/semantic-search.server.ts
+++ b/app/utils/semantic-search.server.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import { cache, cachified } from '#app/utils/cache.server.ts'
+import { getWorkersAiRunUrl } from '#app/utils/cloudflare-ai-utils.server.ts'
 import { getEnv } from '#app/utils/env.server.ts'
 import { getSemanticSearchPresentation } from '#app/utils/semantic-search-presentation.server.ts'
 import { type Timings } from '#app/utils/timing.server.ts'
@@ -173,20 +174,6 @@ function getRequiredSemanticSearchEnv() {
 
 function getCloudflareApiBaseUrl() {
 	return 'https://api.cloudflare.com/client/v4'
-}
-
-function getWorkersAiRunUrl({
-	accountId,
-	gatewayId,
-	model,
-}: {
-	accountId: string
-	gatewayId: string
-	model: string
-}) {
-	// Cloudflare's REST route expects the model as path segments (with `/`), so do
-	// not URL-encode the model string (encoding can yield "No route for that URI").
-	return `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/workers-ai/${model}`
 }
 
 async function cloudflareFetch(
@@ -466,7 +453,6 @@ export async function semanticSearchKCD({
 }): Promise<Array<SemanticSearchResult>> {
 	const cleanedQuery = normalizeSemanticSearchQueryForCache(query)
 	if (!cleanedQuery) return []
-
 	const {
 		accountId,
 		apiToken,


### PR DESCRIPTION
Add LLM-based formatting for Call Kent podcast transcripts to introduce paragraphs.

This change passes generated Call Kent podcast transcripts through an LLM to get them nicely formatted with paragraphs, preserving speaker labels and separators.

---
<p><a href="https://cursor.com/agents/bc-cb93f002-a700-4d89-9c4d-53c407e6f723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb93f002-a700-4d89-9c4d-53c407e6f723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new LLM call in the episode-draft processing pipeline and persists its output; failures fall back to the raw transcript but model/output-shape changes could still affect draft quality or processing reliability.
> 
> **Overview**
> Call Kent episode draft processing now runs newly-generated transcripts through a Workers AI formatter to insert paragraph breaks while preserving speaker labels and `---` separators, with a logged fallback to the raw transcript if formatting fails.
> 
> Adds a dedicated transcript-formatting utility with safeguards (marker extraction, code-fence stripping, separator-count and truncation checks) plus unit tests, a new optional `CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL` env var (defaulting to the site text model), and shared `cloudflare-ai-utils` helpers reused by metadata/TTS/transcription/semantic-search and updated Cloudflare mocks to return formatted transcript text when markers are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b6486de051404c2db31896b198e9fc61addcf43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call Kent podcast episodes now include AI-powered transcript formatting to improve readability and structure.
  * Configurable model support added via new environment variable for transcript formatting customization.

* **Refactor**
  * Consolidated Cloudflare AI utility functions to enhance code organization and reusability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->