### PR TITLE
Mermaid diagram themes

### DIFF
--- a/app/components/mermaid.tsx
+++ b/app/components/mermaid.tsx
@@ -1,0 +1,49 @@
+import { Themed } from '#app/utils/theme.tsx'
+
+export function MermaidDiagram({
+	code,
+	lightSvg,
+	darkSvg,
+}: {
+	code: string
+	lightSvg?: string
+	darkSvg?: string
+}) {
+	return (
+		<div className="mermaid not-prose" data-mermaid-diagram>
+			<Themed
+				light={<MermaidSvg code={code} svg={lightSvg} theme="light" />}
+				dark={<MermaidSvg code={code} svg={darkSvg} theme="dark" />}
+			/>
+		</div>
+	)
+}
+
+function MermaidSvg({
+	code,
+	svg,
+	theme,
+}: {
+	code: string
+	svg?: string
+	theme: 'light' | 'dark'
+}) {
+	if (!svg) {
+		return (
+			<pre className="mermaid-fallback" data-theme={theme}>
+				<code>{code}</code>
+			</pre>
+		)
+	}
+
+	// `dangerouslySetInnerHTML` is the whole point here: we want the <svg> to be
+	// present in the server-rendered HTML, not generated client-side.
+	return (
+		<div
+			className="mermaid-svg"
+			data-theme={theme}
+			dangerouslySetInnerHTML={{ __html: svg }}
+		/>
+	)
+}
+

--- a/app/styles/prose.css
+++ b/app/styles/prose.css
@@ -365,6 +365,54 @@ pre {
 	font-size: inherit;
 }
 
+/* Mermaid diagrams are pre-rendered to SVG at MDX compile time (SSR). */
+.prose .mermaid {
+	/* Match code blocks/embeds: full-bleed on mobile. */
+	margin-left: -10vw;
+	margin-right: -10vw;
+}
+
+.prose .mermaid-svg {
+	overflow-x: auto;
+	padding: 1.25rem;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-secondary);
+}
+
+.prose .mermaid-svg svg {
+	display: block;
+	max-width: 100%;
+	height: auto;
+}
+
+.prose .mermaid pre.mermaid-fallback {
+	/* Override `.prose pre` so fallback doesn't go full-bleed twice. */
+	margin: 0;
+	overflow-x: auto;
+	padding: 1.25rem;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-secondary);
+	color: var(--text-primary);
+}
+
+.prose .mermaid pre.mermaid-fallback code {
+	display: block;
+	white-space: pre;
+}
+
+@media (min-width: 1024px) {
+	.prose .mermaid {
+		margin-left: 0;
+		margin-right: 0;
+		grid-column: 2 / span 10;
+	}
+
+	.prose .mermaid-svg,
+	.prose .mermaid pre.mermaid-fallback {
+		border-radius: 0.5rem;
+	}
+}
+
 .codeblock-line {
 	display: block;
 	position: relative;

--- a/app/utils/compile-mdx.server.ts
+++ b/app/utils/compile-mdx.server.ts
@@ -1,8 +1,6 @@
 import { rehypeCodeBlocksShiki } from '@kentcdodds/md-temp'
 import remarkEmbedder, { type TransformerInfo } from '@remark-embedder/core'
 import oembedTransformer from '@remark-embedder/transformer-oembed'
-import type * as H from 'hast'
-import type * as M from 'mdast'
 import { bundleMDX } from 'mdx-bundler'
 import lz from 'lz-string'
 import PQueue from 'p-queue'
@@ -10,10 +8,13 @@ import calculateReadingTime from 'reading-time'
 import remarkAutolinkHeadings from 'remark-autolink-headings'
 import gfm from 'remark-gfm'
 import remarkSlug from 'remark-slug'
-import type * as U from 'unified'
 import { visit } from 'unist-util-visit'
 import { type GitHubFile } from '#app/types.ts'
 import * as x from './x.server.ts'
+
+import type * as H from 'hast'
+import type * as M from 'mdast'
+import type * as U from 'unified'
 
 // Minimal local types so we don't need to depend on `mdast-util-mdx-jsx` directly.
 type MdxJsxAttribute = {

--- a/app/utils/compile-mdx.server.ts
+++ b/app/utils/compile-mdx.server.ts
@@ -326,7 +326,10 @@ function remarkMermaidCodeToThemedSvg() {
 						: []),
 				]
 
-				parent.children[index] = {
+				// `mdast`'s `RootContent` types don't include MDX JSX nodes, but `bundleMDX`
+				// supports them. Cast so we can replace the code block with an MDX JSX
+				// element without a bunch of type churn.
+				;(parent.children as Array<any>)[index] = {
 					type: 'mdxJsxFlowElement',
 					name: 'MermaidDiagram',
 					attributes,

--- a/app/utils/compile-mdx.server.ts
+++ b/app/utils/compile-mdx.server.ts
@@ -3,7 +3,6 @@ import remarkEmbedder, { type TransformerInfo } from '@remark-embedder/core'
 import oembedTransformer from '@remark-embedder/transformer-oembed'
 import type * as H from 'hast'
 import type * as M from 'mdast'
-import { type MdxJsxAttribute, type MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
 import { bundleMDX } from 'mdx-bundler'
 import lz from 'lz-string'
 import PQueue from 'p-queue'
@@ -15,6 +14,20 @@ import type * as U from 'unified'
 import { visit } from 'unist-util-visit'
 import { type GitHubFile } from '#app/types.ts'
 import * as x from './x.server.ts'
+
+// Minimal local types so we don't need to depend on `mdast-util-mdx-jsx` directly.
+type MdxJsxAttribute = {
+	type: 'mdxJsxAttribute'
+	name: string
+	value?: unknown
+}
+
+type MdxJsxFlowElement = {
+	type: 'mdxJsxFlowElement'
+	name: string
+	attributes: Array<MdxJsxAttribute>
+	children: Array<unknown>
+}
 
 function handleEmbedderError({ url }: { url: string }) {
 	return `<p>Error embedding <a href="${url}">${url}</a></p>.`

--- a/app/utils/compile-mdx.server.ts
+++ b/app/utils/compile-mdx.server.ts
@@ -3,7 +3,9 @@ import remarkEmbedder, { type TransformerInfo } from '@remark-embedder/core'
 import oembedTransformer from '@remark-embedder/transformer-oembed'
 import type * as H from 'hast'
 import type * as M from 'mdast'
+import { type MdxJsxAttribute, type MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
 import { bundleMDX } from 'mdx-bundler'
+import lz from 'lz-string'
 import PQueue from 'p-queue'
 import calculateReadingTime from 'reading-time'
 import remarkAutolinkHeadings from 'remark-autolink-headings'
@@ -219,7 +221,113 @@ function removePreContainerDivs() {
 	}
 }
 
+type MermaidTheme = 'dark' | 'default'
+
+function mdxStringExpressionAttribute(
+	name: string,
+	value: string,
+): MdxJsxAttribute {
+	return {
+		type: 'mdxJsxAttribute',
+		name,
+		value: {
+			type: 'mdxJsxAttributeValueExpression',
+			value: JSON.stringify(value),
+			// This hack brought to you by this:
+			// https://github.com/syntax-tree/hast-util-to-estree/blob/e5ccb97e9f42bba90359ea6d0f83a11d74e0dad6/lib/handlers/mdx-expression.js#L35-L38
+			// No idea why we're required to have estree here, but I'm pretty sure
+			// someone is supposed to add it automatically for us and it just never
+			// happens...
+			data: {
+				estree: {
+					type: 'Program',
+					sourceType: 'script',
+					body: [
+						{
+							type: 'ExpressionStatement',
+							expression: {
+								type: 'Literal',
+								value,
+							},
+						},
+					],
+				},
+			},
+		},
+	}
+}
+
+async function getMermaidSvg({
+	code,
+	theme,
+}: {
+	code: string
+	theme: MermaidTheme
+}): Promise<string | null> {
+	const trimmed = code.trim()
+	if (!trimmed) return null
+
+	const compressed = lz.compressToEncodedURIComponent(trimmed)
+	if (!compressed) return null
+
+	const url = new URL('https://mermaid-to-svg.kentcdodds.workers.dev/svg')
+	url.searchParams.set('mermaid', compressed)
+	url.searchParams.set('theme', theme)
+
+	try {
+		const response = await fetch(url)
+		if (!response.ok) return null
+		const svgText = await response.text()
+		if (!svgText || !svgText.startsWith('<svg')) return null
+		return svgText
+	} catch {
+		return null
+	}
+}
+
+function remarkMermaidCodeToThemedSvg() {
+	return async function transformer(tree: M.Root) {
+		const promises: Array<Promise<void>> = []
+		visit(tree, 'code', (node: M.Code, index, parent) => {
+			if (node.lang !== 'mermaid') return
+			if (!parent || typeof index !== 'number') return
+
+			const promise = (async () => {
+				const code = node.value
+				const [lightSvg, darkSvg] = await Promise.all([
+					getMermaidSvg({ code, theme: 'default' }),
+					getMermaidSvg({ code, theme: 'dark' }),
+				])
+
+				// If we can't render either theme at compile time, keep the original
+				// code block so it still shows up as text.
+				if (!lightSvg && !darkSvg) return
+
+				const attributes: Array<MdxJsxAttribute> = [
+					mdxStringExpressionAttribute('code', code),
+					...(lightSvg
+						? [mdxStringExpressionAttribute('lightSvg', lightSvg)]
+						: []),
+					...(darkSvg
+						? [mdxStringExpressionAttribute('darkSvg', darkSvg)]
+						: []),
+				]
+
+				parent.children[index] = {
+					type: 'mdxJsxFlowElement',
+					name: 'MermaidDiagram',
+					attributes,
+					children: [],
+				} satisfies MdxJsxFlowElement
+			})()
+			promises.push(promise)
+		})
+		await Promise.all(promises)
+	}
+}
+
 const remarkPlugins: U.PluggableList = [
+	remarkMermaidCodeToThemedSvg,
 	[
 		remarkEmbedder,
 		{

--- a/app/utils/compile-mdx.server.ts
+++ b/app/utils/compile-mdx.server.ts
@@ -1,20 +1,19 @@
 import { rehypeCodeBlocksShiki } from '@kentcdodds/md-temp'
 import remarkEmbedder, { type TransformerInfo } from '@remark-embedder/core'
 import oembedTransformer from '@remark-embedder/transformer-oembed'
-import { bundleMDX } from 'mdx-bundler'
+import type * as H from 'hast'
 import lz from 'lz-string'
+import type * as M from 'mdast'
+import { bundleMDX } from 'mdx-bundler'
 import PQueue from 'p-queue'
 import calculateReadingTime from 'reading-time'
 import remarkAutolinkHeadings from 'remark-autolink-headings'
 import gfm from 'remark-gfm'
 import remarkSlug from 'remark-slug'
+import type * as U from 'unified'
 import { visit } from 'unist-util-visit'
 import { type GitHubFile } from '#app/types.ts'
 import * as x from './x.server.ts'
-
-import type * as H from 'hast'
-import type * as M from 'mdast'
-import type * as U from 'unified'
 
 // Minimal local types so we don't need to depend on `mdast-util-mdx-jsx` directly.
 type MdxJsxAttribute = {

--- a/app/utils/mdx.tsx
+++ b/app/utils/mdx.tsx
@@ -3,6 +3,7 @@ import * as mdxBundler from 'mdx-bundler/client/index.js'
 import * as React from 'react'
 import { type MetaFunction } from 'react-router'
 import { CloudinaryVideo } from '#app/components/cloudinary-video.tsx'
+import { MermaidDiagram } from '#app/components/mermaid.tsx'
 import {
 	getImageBuilder,
 	getImgProps,
@@ -122,6 +123,7 @@ const mdxComponents = {
 	table: MdxTable,
 	Themed,
 	CloudinaryVideo,
+	MermaidDiagram,
 	ThemedBlogImage,
 	BlogImage,
 	SubscribeForm,

--- a/mocks/mermaid-to-svg.ts
+++ b/mocks/mermaid-to-svg.ts
@@ -1,0 +1,52 @@
+import { http, HttpResponse, passthrough, type HttpHandler } from 'msw'
+import lz from 'lz-string'
+import { isConnectedToTheInternet } from './utils.ts'
+
+function escapeXml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&apos;')
+}
+
+export const mermaidToSvgHandlers: Array<HttpHandler> = [
+	http.get('https://mermaid-to-svg.kentcdodds.workers.dev/svg', async ({ request }) => {
+		// In dev, prefer the real worker when internet is available so diagrams are
+		// accurate. In tests/offline environments, return a deterministic SVG.
+		if (process.env.NODE_ENV !== 'test' && (await isConnectedToTheInternet())) {
+			return passthrough()
+		}
+
+		const url = new URL(request.url)
+		const compressed = url.searchParams.get('mermaid')
+		if (!compressed) {
+			return new HttpResponse('Missing mermaid parameter', { status: 400 })
+		}
+
+		const theme = url.searchParams.get('theme') === 'dark' ? 'dark' : 'default'
+		const mermaidString = lz.decompressFromEncodedURIComponent(compressed) ?? ''
+		const snippet = escapeXml(mermaidString.replace(/\s+/g, ' ').slice(0, 160))
+
+		const fg = theme === 'dark' ? '#e5e7eb' : '#111827'
+		const bg = theme === 'dark' ? '#111827' : '#ffffff'
+		const border = theme === 'dark' ? '#334155' : '#cbd5e1'
+
+		const svg = [
+			`<svg xmlns="http://www.w3.org/2000/svg" width="900" height="220" viewBox="0 0 900 220">`,
+			`<rect x="0.5" y="0.5" width="899" height="219" rx="12" fill="${bg}" stroke="${border}" />`,
+			`<text x="24" y="48" fill="${fg}" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18">Mock mermaid SVG (${theme})</text>`,
+			`<text x="24" y="86" fill="${fg}" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="13">`,
+			`${snippet || '(empty)'}`,
+			`</text>`,
+			`</svg>`,
+		].join('')
+
+		return new HttpResponse(svg, {
+			status: 200,
+			headers: { 'Content-Type': 'image/svg+xml' },
+		})
+	}),
+]
+

--- a/mocks/mermaid-to-svg.ts
+++ b/mocks/mermaid-to-svg.ts
@@ -1,5 +1,5 @@
-import { http, HttpResponse, passthrough, type HttpHandler } from 'msw'
 import lz from 'lz-string'
+import { http, HttpResponse, passthrough, type HttpHandler } from 'msw'
 import { isConnectedToTheInternet } from './utils.ts'
 
 function escapeXml(value: string) {

--- a/mocks/msw-handlers.ts
+++ b/mocks/msw-handlers.ts
@@ -4,6 +4,7 @@ import { cloudflareHandlers } from './cloudflare.ts'
 import { discordHandlers } from './discord.ts'
 import { githubHandlers } from './github.ts'
 import { kitHandlers } from './kit.ts'
+import { mermaidToSvgHandlers } from './mermaid-to-svg.ts'
 import { oauthHandlers } from './oauth.ts'
 import { oembedHandlers } from './oembed.ts'
 import { simplecastHandlers } from './simplecast.ts'
@@ -99,5 +100,6 @@ export const mswHandlers: Array<HttpHandler> = [
 	...simplecastHandlers,
 	...cloudflareHandlers,
 	...cloudflareR2Handlers,
+	...mermaidToSvgHandlers,
 	...miscHandlers,
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "litefs-js": "^2.0.2",
         "lodash": "^4.17.23",
         "lru-cache": "^11.2.6",
+        "lz-string": "^1.5.0",
         "match-sorter": "^8.2.0",
         "md5-hash": "^1.0.1",
         "mdast-util-to-hast": "^13.2.1",
@@ -20833,6 +20834,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "litefs-js": "^2.0.2",
     "lodash": "^4.17.23",
     "lru-cache": "^11.2.6",
+    "lz-string": "^1.5.0",
     "match-sorter": "^8.2.0",
     "md5-hash": "^1.0.1",
     "mdast-util-to-hast": "^13.2.1",


### PR DESCRIPTION
Add server-rendered Mermaid diagram support with light/dark theme variants.

Mermaid code blocks are now compiled into SVG at build time via a remark plugin, generating both light and dark versions. A new MDX component uses existing theme utilities to display the appropriate SVG, ensuring diagrams are server-rendered and theme-aware.

---
<p><a href="https://cursor.com/agents/bc-ce5452df-3d45-46af-8cbb-417f5f49ed5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce5452df-3d45-46af-8cbb-417f5f49ed5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an external network dependency during MDX compilation and injects returned SVG via `dangerouslySetInnerHTML`, so reliability and content-safety of the rendering endpoint matter.
> 
> **Overview**
> Adds compile-time rendering of Mermaid `mermaid` code blocks into *server-rendered* SVGs (both light/default and dark themes) via a new `remarkMermaidCodeToThemedSvg` plugin that fetches pre-rendered SVGs from an external worker.
> 
> Introduces an MDX component `MermaidDiagram` that swaps the appropriate themed SVG (or falls back to the original code block), plus new prose styles for diagram layout/scrolling; updates MSW mocks to stub the SVG worker in tests/offline and adds `lz-string` for diagram compression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b285b1f719d74198055a66d69e303e049a8aaf5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mermaid diagram rendering capabilities with automatic light and dark theme support.
  * Diagrams are server-rendered for improved performance in markdown content.

* **Dependencies**
  * Added lz-string library for diagram processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->