### PR TITLE
Tts audio cache

### DIFF
--- a/app/routes/resources/calls/__tests__/text-to-speech-cache.test.ts
+++ b/app/routes/resources/calls/__tests__/text-to-speech-cache.test.ts
@@ -94,10 +94,15 @@ test('validates normalized question text before synthesis', async () => {
 		text: 'hello               you',
 		voice: 'luna',
 	})
-	const res = (await action({ request: req } as any)) as Response
+	const result = (await action({ request: req } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
 
-	expect(res.status).toBe(400)
-	expect(await res.json()).toEqual({
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(400)
+	expect(result.data).toEqual({
 		error: 'Question text must be at least 20 characters',
 	})
 	expect(synthesizeSpeechWithWorkersAi).not.toHaveBeenCalled()

--- a/app/routes/resources/calls/__tests__/text-to-speech-cache.test.ts
+++ b/app/routes/resources/calls/__tests__/text-to-speech-cache.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, test, vi } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { AI_VOICE_DISCLOSURE_PREFIX } from '#app/utils/call-kent-text-to-speech.ts'
 
 const synthesizeSpeechWithWorkersAi = vi.fn(
@@ -26,25 +26,6 @@ vi.mock('#app/utils/cloudflare-ai-text-to-speech.server.ts', () => {
 	return {
 		synthesizeSpeechWithWorkersAi,
 	}
-})
-
-const memory = new Map<string, unknown>()
-const testCache = {
-	name: 'test-cache',
-	get(key: string) {
-		return (memory.get(key) as any) ?? null
-	},
-	async set(key: string, entry: unknown) {
-		memory.set(key, entry)
-	},
-	async delete(key: string) {
-		memory.delete(key)
-	},
-}
-
-vi.mock('#app/utils/cache.server.ts', async () => {
-	const { cachified } = await import('@epic-web/cachified')
-	return { cachified, cache: testCache }
 })
 
 vi.mock('#app/utils/session.server.ts', () => {
@@ -74,47 +55,31 @@ function makeRequest({ text, voice }: { text: string; voice: string }) {
 	})
 }
 
-describe('/resources/calls/text-to-speech cache', () => {
-	test('caches audio by normalized text + voice + model (skips paid call on hit)', async () => {
-		memory.clear()
-		synthesizeSpeechWithWorkersAi.mockClear()
-		rateLimit.mockClear()
+test('does not cache audio bytes; repeated requests invoke workers ai', async () => {
+	synthesizeSpeechWithWorkersAi.mockClear()
+	rateLimit.mockClear()
 
-		const { action } = await import('../text-to-speech.tsx')
+	const { action } = await import('../text-to-speech.tsx')
 
-		const req1 = makeRequest({
-			text: 'Hello from the cache test message.',
-			voice: 'luna',
-		})
-		const res1 = (await action({ request: req1 } as any)) as Response
-		expect(res1.ok).toBe(true)
-		const bytes1 = new Uint8Array(await res1.arrayBuffer())
-		const firstCallArgs = synthesizeSpeechWithWorkersAi.mock.calls[0]?.[0]
-		expect(firstCallArgs?.text?.startsWith(AI_VOICE_DISCLOSURE_PREFIX)).toBe(
-			true,
-		)
-
-		// Same content, different whitespace: should hit cache.
-		const req2 = makeRequest({
-			text: '  Hello   from  the  cache   test message.  ',
-			voice: 'luna',
-		})
-		const res2 = (await action({ request: req2 } as any)) as Response
-		expect(res2.ok).toBe(true)
-		const bytes2 = new Uint8Array(await res2.arrayBuffer())
-
-		expect(bytes2).toEqual(bytes1)
-		expect(synthesizeSpeechWithWorkersAi).toHaveBeenCalledTimes(1)
-		expect(rateLimit).toHaveBeenCalledTimes(1)
-
-		// Different voice should be a different cache key.
-		const req3 = makeRequest({
-			text: 'Hello from the cache test message.',
-			voice: 'orion',
-		})
-		const res3 = (await action({ request: req3 } as any)) as Response
-		expect(res3.ok).toBe(true)
-		expect(synthesizeSpeechWithWorkersAi).toHaveBeenCalledTimes(2)
-		expect(rateLimit).toHaveBeenCalledTimes(2)
+	const req1 = makeRequest({
+		text: 'Hello from the cache test message.',
+		voice: 'luna',
 	})
+	const res1 = (await action({ request: req1 } as any)) as Response
+	expect(res1.ok).toBe(true)
+	const firstCallArgs = synthesizeSpeechWithWorkersAi.mock.calls[0]?.[0]
+	expect(firstCallArgs?.text?.startsWith(AI_VOICE_DISCLOSURE_PREFIX)).toBe(true)
+
+	const req2 = makeRequest({
+		text: 'Hello from the cache test message.',
+		voice: 'luna',
+	})
+	const res2 = (await action({ request: req2 } as any)) as Response
+	expect(res2.ok).toBe(true)
+
+	expect(synthesizeSpeechWithWorkersAi).toHaveBeenCalledTimes(2)
+	expect(rateLimit).toHaveBeenCalledTimes(2)
+	expect(synthesizeSpeechWithWorkersAi.mock.calls[1]?.[0]).toEqual(
+		synthesizeSpeechWithWorkersAi.mock.calls[0]?.[0],
+	)
 })


### PR DESCRIPTION
Removes the text-to-speech audio byte cache to ensure fresh audio generation for every call submission.

---
<p><a href="https://cursor.com/agents/bc-ae3b9d6f-10a1-4d19-a3da-c9f91011f56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae3b9d6f-10a1-4d19-a3da-c9f91011f56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every TTS request now triggers a paid Workers AI synthesis and rate-limit is charged up-front, which can change cost/throughput behavior and error handling under load.
> 
> **Overview**
> Removes the text-to-speech audio byte cache from `resources/calls/text-to-speech`, so **every request** now calls Workers AI and is rate-limited per request (429 returned directly when over quota).
> 
> Tightens input handling by normalizing whitespace *before* validation, and hardens responses by defaulting `Content-Type` to `audio/mpeg` when Workers AI omits it. Tests were rewritten to drop cache mocking and assert repeated requests re-synthesize, normalized-text validation rejects short input, and content-type fallback works.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3902ad896041060bad0718ccda2d075bbbfefa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced per-request rate limiting up-front for text-to-speech; excess requests return 429 with Retry-After.

* **Behavior Changes**
  * Text-to-speech no longer uses a cache — every request triggers live synthesis and responses use a derived audio content type (defaults to audio/mpeg).
  * Input normalization and validation tightened; quota is checked and consumed before synthesis.

* **Tests**
  * Simplified tests to remove cache mocking and verify live synthesis per request; added validation and content-type fallback checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->