### PR TITLE
Email artwork image size

### DIFF
--- a/app/routes/resources/calls/save.tsx
+++ b/app/routes/resources/calls/save.tsx
@@ -23,6 +23,7 @@ import {
 	getStringFormValue,
 } from '#app/utils/misc.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
+import { getPublishedCallKentEpisodeEmail } from '#app/utils/call-kent-published-email.ts'
 import { sendEmail } from '#app/utils/send-email.server.ts'
 import { requireAdminUser, requireUser } from '#app/utils/session.server.ts'
 import { teamEmoji } from '#app/utils/team-provider.tsx'
@@ -302,20 +303,18 @@ async function publishCall({
 
 		if (published.episodeUrl) {
 			try {
-				const episodeMarkdown = published.imageUrl
-					? `[![${title}](${published.imageUrl})](${published.episodeUrl})`
-					: `[${title}](${published.episodeUrl})`
+				const email = getPublishedCallKentEpisodeEmail({
+					firstName: call.user.firstName,
+					episodeTitle: title,
+					episodeUrl: published.episodeUrl,
+					imageUrl: published.imageUrl,
+				})
 				void sendEmail({
 					to: call.user.email,
 					from: `"Kent C. Dodds" <hello+calls@kentcdodds.com>`,
 					subject: `Your "Call Kent" episode has been published`,
-					text: `
-Hi ${call.user.firstName},
-
-Thanks for your call. Kent just replied and the episode has been published to the podcast!
-
-${episodeMarkdown}
-          `.trim(),
+					text: email.text,
+					html: email.html,
 				})
 			} catch (error: unknown) {
 				console.error(

--- a/app/routes/resources/calls/save.tsx
+++ b/app/routes/resources/calls/save.tsx
@@ -8,6 +8,7 @@ import {
 	putCallAudioFromDataUrl,
 } from '#app/utils/call-kent-audio-storage.server.ts'
 import { startCallKentEpisodeDraftProcessing } from '#app/utils/call-kent-episode-draft.server.ts'
+import { getPublishedCallKentEpisodeEmail } from '#app/utils/call-kent-published-email.ts'
 import {
 	getErrorForAudio,
 	getErrorForTitle,
@@ -23,7 +24,6 @@ import {
 	getStringFormValue,
 } from '#app/utils/misc.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
-import { getPublishedCallKentEpisodeEmail } from '#app/utils/call-kent-published-email.ts'
 import { sendEmail } from '#app/utils/send-email.server.ts'
 import { requireAdminUser, requireUser } from '#app/utils/session.server.ts'
 import { teamEmoji } from '#app/utils/team-provider.tsx'

--- a/app/utils/__tests__/call-kent-published-email.test.ts
+++ b/app/utils/__tests__/call-kent-published-email.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import { getPublishedCallKentEpisodeEmail } from '../call-kent-published-email.ts'
+
+test('includes fixed 200x200 artwork dimensions in published episode email html', () => {
+	const email = getPublishedCallKentEpisodeEmail({
+		firstName: 'Ada',
+		episodeTitle: 'Episode 12',
+		episodeUrl: 'https://kentcdodds.com/calls/12/34/episode-12',
+		imageUrl: 'https://images.example.com/call-kent-art.jpg',
+	})
+
+	expect(email.text).toContain('Episode 12')
+	expect(email.text).toContain('https://kentcdodds.com/calls/12/34/episode-12')
+	expect(email.html).toContain('width="200"')
+	expect(email.html).toContain('height="200"')
+	expect(email.html).toContain('width: 200px;')
+	expect(email.html).toContain('height: 200px;')
+	expect(email.html).toContain('https://images.example.com/call-kent-art.jpg')
+})
+
+test('escapes user-provided content and omits artwork markup when image is missing', () => {
+	const email = getPublishedCallKentEpisodeEmail({
+		firstName: '<Ada & Co>',
+		episodeTitle: '<Episode "12">',
+		episodeUrl: 'https://kentcdodds.com/calls?x=1&y=2',
+		imageUrl: null,
+	})
+
+	expect(email.html).toContain('Hi &lt;Ada &amp; Co&gt;,')
+	expect(email.html).toContain('&lt;Episode &quot;12&quot;&gt;')
+	expect(email.html).toContain('href="https://kentcdodds.com/calls?x=1&amp;y=2"')
+	expect(email.html).not.toContain('<img')
+})

--- a/app/utils/call-kent-published-email.ts
+++ b/app/utils/call-kent-published-email.ts
@@ -1,0 +1,77 @@
+const callKentEpisodeArtworkSize = 200
+
+type GetPublishedCallKentEpisodeEmailParams = {
+	firstName: string
+	episodeTitle: string
+	episodeUrl: string
+	imageUrl?: string | null
+}
+
+function escapeHtml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;')
+}
+
+function getPublishedCallKentEpisodeEmail({
+	firstName,
+	episodeTitle,
+	episodeUrl,
+	imageUrl,
+}: GetPublishedCallKentEpisodeEmailParams) {
+	const safeFirstName = escapeHtml(firstName)
+	const safeEpisodeTitle = escapeHtml(episodeTitle)
+	const safeEpisodeUrl = escapeHtml(episodeUrl)
+	const safeImageUrl = imageUrl ? escapeHtml(imageUrl) : null
+
+	const text = `
+Hi ${firstName},
+
+Thanks for your call. Kent just replied and the episode has been published to the podcast!
+
+${episodeTitle}
+${episodeUrl}
+`.trim()
+
+	const artworkMarkup = safeImageUrl
+		? `
+      <p style="margin: 16px 0;">
+        <a href="${safeEpisodeUrl}" style="display: inline-block; text-decoration: none;">
+          <img
+            src="${safeImageUrl}"
+            alt="Call Kent episode artwork for ${safeEpisodeTitle}"
+            width="${callKentEpisodeArtworkSize}"
+            height="${callKentEpisodeArtworkSize}"
+            style="display: block; width: ${callKentEpisodeArtworkSize}px; height: ${callKentEpisodeArtworkSize}px; object-fit: cover; border-radius: 8px; border: 0;"
+          />
+        </a>
+      </p>
+    `.trim()
+		: ''
+
+	const html = `
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body style="font-family: ui-sans-serif, sans-serif; line-height: 1.5; color: #111827;">
+    <p style="margin: 0 0 12px;">Hi ${safeFirstName},</p>
+    <p style="margin: 0 0 12px;">
+      Thanks for your call. Kent just replied and the episode has been published to the podcast!
+    </p>
+    ${artworkMarkup}
+    <p style="margin: 0;">
+      <a href="${safeEpisodeUrl}" style="color: #2563eb;">${safeEpisodeTitle}</a>
+    </p>
+  </body>
+</html>
+`.trim()
+
+	return { text, html }
+}
+
+export { getPublishedCallKentEpisodeEmail }


### PR DESCRIPTION
Constrain the episode artwork in the published email to 200x200 to prevent it from rendering excessively large.

The previous implementation used Markdown for image embedding, which resulted in unconstrained image dimensions in some email clients. This PR introduces a dedicated email formatter to explicitly set the artwork size in the HTML body.

---
<p><a href="https://cursor.com/agents/bc-7e6cacec-443e-4768-93bb-1db75609696f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e6cacec-443e-4768-93bb-1db75609696f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to outbound email formatting and a small call-site update; no auth, persistence, or core business logic changes.
> 
> **Overview**
> When a "Call Kent" episode is published, the notification email is now generated via a dedicated formatter that produces both text and HTML, instead of embedding artwork via Markdown.
> 
> The new HTML explicitly constrains episode artwork to a fixed **200×200** size (and omits the image when unavailable) and escapes user-provided fields; added tests cover sizing, escaping, and the no-image case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5cbd7244efd23c50f399bfa4f4e86eae954c9df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email formatting and security for published episode notifications with proper content escaping.

* **Tests**
  * Added unit tests for published episode email generation to verify proper formatting and content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->