### PR TITLE
Page load time regression

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -137,16 +137,11 @@ export async function loader({ request }: Route.LoaderArgs) {
 		getLoginInfoSession(request),
 		getInstanceInfo().then((i) => i.primaryInstance),
 		time(
-			withTimeout(
-				getLatestPodcastSeasonLinks({ request, timings }).catch(
-					() => PODCAST_LINKS_FALLBACK,
-				),
-				{
-					timeoutMs: 2000,
-					fallback: PODCAST_LINKS_FALLBACK,
-					label: 'root:podcast-season-links',
-				},
-			),
+			withTimeout(getLatestPodcastSeasonLinks({ request, timings }), {
+				timeoutMs: 2000,
+				fallback: PODCAST_LINKS_FALLBACK,
+				label: 'root:podcast-season-links',
+			}),
 			{
 				timings,
 				type: 'root:podcast-season-links',

--- a/app/utils/abort-utils.server.ts
+++ b/app/utils/abort-utils.server.ts
@@ -16,7 +16,7 @@ function throwIfAborted(signal?: AbortSignal) {
 }
 
 function isAbortError(error: unknown) {
-	return error instanceof Error && error.name === 'AbortError'
+	return typeof error === 'object' && error !== null && (error as any).name === 'AbortError'
 }
 
 async function waitForDelay({

--- a/app/utils/abort-utils.server.ts
+++ b/app/utils/abort-utils.server.ts
@@ -1,0 +1,78 @@
+type Sleep = (ms: number) => Promise<void>
+
+const defaultSleep: Sleep = async (ms) => {
+	await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function createAbortError() {
+	const error = new Error('Operation aborted')
+	error.name = 'AbortError'
+	return error
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+	if (!signal?.aborted) return
+	throw createAbortError()
+}
+
+function isAbortError(error: unknown) {
+	return error instanceof Error && error.name === 'AbortError'
+}
+
+async function waitForDelay({
+	sleep,
+	delayMs,
+	signal,
+}: {
+	sleep?: Sleep
+	delayMs: number
+	signal?: AbortSignal
+}) {
+	if (!signal) {
+		const activeSleep = sleep ?? defaultSleep
+		await activeSleep(delayMs)
+		return
+	}
+	throwIfAborted(signal)
+	if (!sleep) {
+		await new Promise<void>((resolve, reject) => {
+			const timeoutId = setTimeout(() => {
+				signal.removeEventListener('abort', onAbort)
+				resolve()
+			}, delayMs)
+			const onAbort = () => {
+				clearTimeout(timeoutId)
+				signal.removeEventListener('abort', onAbort)
+				reject(createAbortError())
+			}
+			signal.addEventListener('abort', onAbort, { once: true })
+		})
+		return
+	}
+	await new Promise<void>((resolve, reject) => {
+		let settled = false
+		const onAbort = () => {
+			if (settled) return
+			settled = true
+			signal.removeEventListener('abort', onAbort)
+			reject(createAbortError())
+		}
+		signal.addEventListener('abort', onAbort, { once: true })
+		sleep(delayMs).then(
+			() => {
+				if (settled) return
+				settled = true
+				signal.removeEventListener('abort', onAbort)
+				resolve()
+			},
+			(error) => {
+				if (settled) return
+				settled = true
+				signal.removeEventListener('abort', onAbort)
+				reject(error)
+			},
+		)
+	})
+}
+
+export { defaultSleep, isAbortError, throwIfAborted, waitForDelay, type Sleep }

--- a/app/utils/podcast-latest-season.server.ts
+++ b/app/utils/podcast-latest-season.server.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { isAbortError, throwIfAborted } from './abort-utils.server.ts'
 import { cache, cachified } from './cache.server.ts'
 import { type Timings } from './timing.server.ts'
 
@@ -12,17 +13,6 @@ const latestPodcastSeasonLinksSchema = z.object({
 		latestSeasonPath: z.string().min(1),
 	}),
 })
-
-function isAbortError(error: unknown) {
-	return error instanceof Error && error.name === 'AbortError'
-}
-
-function throwIfAborted(signal?: AbortSignal) {
-	if (!signal?.aborted) return
-	const error = new Error('Operation aborted')
-	error.name = 'AbortError'
-	throw error
-}
 
 function formatSeasonParam(seasonNumber: number) {
 	return String(seasonNumber).padStart(2, '0')

--- a/app/utils/simplecast.server.ts
+++ b/app/utils/simplecast.server.ts
@@ -14,6 +14,7 @@ import { visit } from 'unist-util-visit'
 import { z } from 'zod'
 import { type CWKEpisode, type CWKSeason } from '#app/types.ts'
 import { omit, sortBy } from '#app/utils/cjs/lodash.ts'
+import { isAbortError, throwIfAborted } from './abort-utils.server.ts'
 import { cache, cachified } from './cache.server.ts'
 import { getEnv } from './env.server.ts'
 import { fetchJsonWithRetryAfter } from './fetch-json-with-retry-after.server.ts'
@@ -38,21 +39,6 @@ function getSimplecastConfig() {
 // Episodes can be fetched concurrently from multiple seasons (and from multiple
 // requests). Cap the total in-flight episode-detail requests to reduce 429s.
 const simplecastEpisodeDetailsLimit = pLimit(3)
-
-function createAbortError() {
-	const error = new Error('Operation aborted')
-	error.name = 'AbortError'
-	return error
-}
-
-function throwIfAborted(signal?: AbortSignal) {
-	if (!signal?.aborted) return
-	throw createAbortError()
-}
-
-function isAbortError(error: unknown) {
-	return error instanceof Error && error.name === 'AbortError'
-}
 
 const cwkCachedLinkSchema = z
 	.object({

--- a/app/utils/timing.server.ts
+++ b/app/utils/timing.server.ts
@@ -38,15 +38,22 @@ export async function withTimeout<T>(
 		timeoutMs,
 		fallback,
 		label = 'operation',
+		onTimeout,
 	}: {
 		timeoutMs: number
 		fallback: T
 		label?: string
+		onTimeout?: () => void
 	},
 ): Promise<T> {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined
 	const timeoutPromise = new Promise<never>((_, reject) => {
 		timeoutId = setTimeout(() => {
+			try {
+				onTimeout?.()
+			} catch (error) {
+				console.error(`${label}: onTimeout hook failed`, error)
+			}
 			reject(new Error(`${label} timed out after ${timeoutMs}ms`))
 		}, timeoutMs)
 	})

--- a/server/index.ts
+++ b/server/index.ts
@@ -392,11 +392,20 @@ async function getRequestHandler(): Promise<RequestHandler> {
 }
 
 app.use((req, res, next) => {
+	const metricName = 'middleware-request-handler'
 	startServerMetric(
 		res,
-		'middleware-request-handler',
+		metricName,
 		'time spent in react-router request handling',
 	)
+	let metricEnded = false
+	const finishMetric = () => {
+		if (metricEnded) return
+		metricEnded = true
+		endServerMetric(res, metricName)
+	}
+	res.once('finish', finishMetric)
+	res.once('close', finishMetric)
 	next()
 })
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -96,6 +96,23 @@ const app = express()
 app.set('trust proxy', true)
 app.use(serverTiming())
 
+type ServerTimingResponse = {
+	startTime?: (name: string, description: string) => void
+	endTime?: (name: string) => void
+}
+
+const startServerMetric = (
+	res: ServerTimingResponse,
+	name: string,
+	description: string,
+) => {
+	res.startTime?.(name, description)
+}
+
+const endServerMetric = (res: ServerTimingResponse, name: string) => {
+	res.endTime?.(name)
+}
+
 const expiredDataCleanup = scheduleExpiredDataCleanup()
 
 app.get('/img/social', oldImgSocial)
@@ -107,6 +124,8 @@ app.post('/__metronome', (req: any, res: any) => {
 })
 
 app.use((req, res, next) => {
+	const metricName = 'middleware-get-instance-info'
+	startServerMetric(res, metricName, 'populate fly response headers')
 	getInstanceInfo()
 		.then(({ currentInstance, primaryInstance }) => {
 			res.set('X-Powered-By', 'Kody the Koala')
@@ -128,9 +147,10 @@ app.use((req, res, next) => {
 				'Strict-Transport-Security',
 				`max-age=${60 * 60 * 24 * 365 * 100}`,
 			)
-			next()
 		})
+		.then(() => next())
 		.catch(next)
+		.finally(() => endServerMetric(res, metricName))
 })
 
 app.use((req, res, next) => {
@@ -370,6 +390,15 @@ async function getRequestHandler(): Promise<RequestHandler> {
 		getLoadContext,
 	})
 }
+
+app.use((req, res, next) => {
+	startServerMetric(
+		res,
+		'middleware-request-handler',
+		'time spent in react-router request handling',
+	)
+	next()
+})
 
 app.all('{*splat}', await getRequestHandler())
 


### PR DESCRIPTION
Add a timeout to podcast link fetching and enhance `Server-Timing` headers to fix intermittent cold-cache page-load slowdowns.

The slowdown was traced to blocking calls in the `root_podcast-season-links` loader during cold-cache requests. A 2-second timeout ensures non-critical link fetching doesn't block the main page load, and new `Server-Timing` metrics provide better visibility into middleware and handler execution times in production.

---
<p><a href="https://cursor.com/agents/bc-620f499e-5b2b-4ed5-af27-27885f9f3e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-620f499e-5b2b-4ed5-af27-27885f9f3e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request/loader execution and external API fetching behavior; incorrect timeout/abort propagation could hide failures or change nav-link freshness, but fallbacks limit user impact.
> 
> **Overview**
> Caps `root` loader latency by wrapping podcast season-link fetching in a 2s `withTimeout` with an abort signal and deterministic fallback, and records both the sub-operation timing and total `root:loader` duration in `Server-Timing`.
> 
> Introduces shared abort helpers (`abort-utils.server.ts`) and threads `AbortSignal` support through `fetchJsonWithRetryAfter`, Simplecast/Transistor fetching, and latest-season resolution, including abortable retry delays and new tests for abort behavior.
> 
> Adds Express `server-timing` instrumentation around instance-header middleware and the React Router request handler to improve production diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95cc015dae92a08a13418cad0b87f064854015dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Reliability**
  * Added timeout protection with fallback to prevent slow loader hangs and improve responsiveness.
  * Broadened abort/cancellation support and introduced abortable delays across external fetches to reduce wasted work.

* **Monitoring**
  * Added end-to-end loader timing and enhanced Server-Timing headers for better production diagnostics.
  * Added per-request timing instrumentation to capture request handling metrics.

* **New Features**
  * Introduced a reusable promise timeout utility that returns a fallback on timeout or error and supports an on-timeout hook.

* **Tests**
  * Added abort-related tests to ensure cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->