### PR TITLE
404 no matches spacing

### DIFF
--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -72,9 +72,10 @@ function ErrorPage({
 	possibleMatchesQuery?: string
 	heroProps: HeroSectionProps
 }) {
-	// Only inject the "arrow down" helper link when the caller didn't provide an
-	// explicit action. Otherwise, it can create duplicate CTAs (notably on 404s).
-	const resolvedHeroProps: HeroSectionProps = heroProps.action
+	// Only inject the "arrow down" helper link when the caller leaves `action`
+	// undefined. This lets callers intentionally pass `null` to suppress all
+	// hero CTAs for specific states (for example, 404 no-match).
+	const resolvedHeroProps: HeroSectionProps = heroProps.action !== undefined
 		? heroProps
 		: possibleMatches?.length
 			? {
@@ -232,14 +233,13 @@ function FourOhFour({
 			? possibleMatchesQuery.trim()
 			: derivedQuery
 
-	const q = effectiveQuery ? effectiveQuery.trim() : ''
-	const searchUrl = q ? `/search?q=${encodeURIComponent(q)}` : '/search'
 	const hasPossibleMatches =
 		Array.isArray(possibleMatchesProp) && possibleMatchesProp.length > 0
-	const heroActionTo = hasPossibleMatches ? '#possible-matches' : searchUrl
-	const heroActionLabel = hasPossibleMatches
-		? 'Possible matches'
-		: 'Search the site'
+	const heroAction = hasPossibleMatches ? (
+		<ArrowLink to="#possible-matches" className="whitespace-nowrap">
+			Possible matches
+		</ArrowLink>
+	) : null
 
 	// Most pages intentionally use the global `mx-10vw` gutter (it’s part of the
 	// overall site layout). The 404 view reads better on mobile when it’s a bit
@@ -258,11 +258,7 @@ function FourOhFour({
 					title: "404 - Oh no, you found a page that's missing stuff.",
 					subtitle: `"${pathname}" is not a page on kentcdodds.com. So sorry.`,
 					image: <MissingSomething className="rounded-lg" aspectRatio="3:4" />,
-					action: (
-						<ArrowLink to={heroActionTo} className="whitespace-nowrap">
-							{heroActionLabel}
-						</ArrowLink>
-					),
+					action: heroAction,
 				}}
 			/>
 		</div>

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -157,9 +157,7 @@ function PossibleMatchesSection({
 						? q
 							? `Closest matches for "${q}"`
 							: 'Closest matches.'
-						: q
-							? `We couldn't find close matches for "${q}".`
-							: "We couldn't find close matches."
+						: undefined
 				}
 			/>
 			<Spacer size="2xs" />

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -233,13 +233,21 @@ function FourOhFour({
 			? possibleMatchesQuery.trim()
 			: derivedQuery
 
+	const hasPossibleMatchesList = Array.isArray(possibleMatchesProp)
 	const hasPossibleMatches =
-		Array.isArray(possibleMatchesProp) && possibleMatchesProp.length > 0
+		hasPossibleMatchesList && possibleMatchesProp.length > 0
+	const searchUrl = effectiveQuery
+		? `/search?q=${encodeURIComponent(effectiveQuery)}`
+		: '/search'
 	const heroAction = hasPossibleMatches ? (
 		<ArrowLink to="#possible-matches" className="whitespace-nowrap">
 			Possible matches
 		</ArrowLink>
-	) : null
+	) : hasPossibleMatchesList ? null : (
+		<ArrowLink to={searchUrl} className="whitespace-nowrap">
+			Search the site
+		</ArrowLink>
+	)
 
 	// Most pages intentionally use the global `mx-10vw` gutter (it’s part of the
 	// overall site layout). The 404 view reads better on mobile when it’s a bit

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -121,6 +121,7 @@ function ErrorPage({
 
 				{articles?.length ? (
 					<>
+						{possibleMatches?.length === 0 ? <Spacer size="lg" /> : null}
 						<div id="articles" />
 						<BlogSection
 							articles={articles}
@@ -150,8 +151,16 @@ function PossibleMatchesSection({
 		<>
 			<div id="possible-matches" />
 			<HeaderSection
-				title="Possible matches"
-				subTitle={q ? `Closest matches for "${q}"` : 'Closest matches.'}
+				title={hasMatches ? 'Possible matches' : 'No close matches found'}
+				subTitle={
+					hasMatches
+						? q
+							? `Closest matches for "${q}"`
+							: 'Closest matches.'
+						: q
+							? `We couldn't find close matches for "${q}".`
+							: "We couldn't find close matches."
+				}
 			/>
 			<Spacer size="2xs" />
 			<Grid>

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -204,13 +204,9 @@ function PossibleMatchesSection({
 							</li>
 						))}
 					</ul>
-					<p className="mt-4 text-sm text-slate-500">
-						{hasMatches ? 'None of these match? ' : 'No close matches found. '}
-						<a href={searchUrl} className="underlined">
-							Try semantic search
-						</a>
-						.
-					</p>
+					<div className="mt-8">
+						<ArrowLink to={searchUrl}>Try semantic search</ArrowLink>
+					</div>
 				</div>
 			</Grid>
 		</>

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -226,10 +226,20 @@ function FourOhFour({
 	const searchUrl = q ? `/search?q=${encodeURIComponent(q)}` : '/search'
 	const hasPossibleMatches =
 		Array.isArray(possibleMatchesProp) && possibleMatchesProp.length > 0
-	const heroActionTo = hasPossibleMatches ? '#possible-matches' : searchUrl
-	const heroActionLabel = hasPossibleMatches
-		? 'Possible matches'
-		: 'Search the site'
+	const heroAction = hasPossibleMatches ? (
+		<ArrowLink to="#possible-matches" className="whitespace-nowrap">
+			Possible matches
+		</ArrowLink>
+	) : (
+		<div className="space-y-2">
+			<ArrowLink to={searchUrl} className="whitespace-nowrap">
+				Search the site
+			</ArrowLink>
+			<p className="text-sm text-slate-500 dark:text-slate-400">
+				Uses semantic search to find related content.
+			</p>
+		</div>
+	)
 
 	// Most pages intentionally use the global `mx-10vw` gutter (it’s part of the
 	// overall site layout). The 404 view reads better on mobile when it’s a bit
@@ -248,11 +258,7 @@ function FourOhFour({
 					title: "404 - Oh no, you found a page that's missing stuff.",
 					subtitle: `"${pathname}" is not a page on kentcdodds.com. So sorry.`,
 					image: <MissingSomething className="rounded-lg" aspectRatio="3:4" />,
-					action: (
-						<ArrowLink to={heroActionTo} className="whitespace-nowrap">
-							{heroActionLabel}
-						</ArrowLink>
-					),
+					action: heroAction,
 				}}
 			/>
 		</div>

--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -119,9 +119,10 @@ function ErrorPage({
 					/>
 				) : null}
 
+				{possibleMatches?.length === 0 ? <Spacer size="lg" /> : null}
+
 				{articles?.length ? (
 					<>
-						{possibleMatches?.length === 0 ? <Spacer size="lg" /> : null}
 						<div id="articles" />
 						<BlogSection
 							articles={articles}

--- a/app/components/sections/header-section.tsx
+++ b/app/components/sections/header-section.tsx
@@ -8,7 +8,7 @@ interface HeaderSectionProps {
 	cta?: string
 	as?: React.ElementType
 	title: string
-	subTitle: string
+	subTitle?: string
 	className?: string
 }
 
@@ -30,9 +30,11 @@ function HeaderSection({
 			>
 				<div className="space-y-2 lg:space-y-0">
 					<H2>{title}</H2>
-					<H2 variant="secondary" as="p">
-						{subTitle}
-					</H2>
+					{subTitle ? (
+						<H2 variant="secondary" as="p">
+							{subTitle}
+						</H2>
+					) : null}
 				</div>
 
 				{cta && ctaUrl ? (


### PR DESCRIPTION
Add a large spacer and update heading copy on 404 no-match pages to improve clarity and spacing.

---
<p><a href="https://cursor.com/agents/bc-5f8d4511-4850-41ee-8b1f-c951b9f0c75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f8d4511-4850-41ee-8b1f-c951b9f0c75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/content-only changes to 404 rendering and section headings; low risk aside from minor layout/conditional-rendering regressions.
> 
> **Overview**
> Tweaks the 404 page to treat *“no possible matches”* differently from *“possible matches exist”*: `PossibleMatchesSection` now renders only when the array has items, and an extra large `Spacer` is inserted when the array is explicitly empty to avoid awkward gaps.
> 
> Updates the 404 hero CTA to either deep-link to `#possible-matches` or point to semantic search with added helper copy, and removes the redundant “Try semantic search” footer from the possible-matches list.
> 
> Makes `HeaderSection`’s `subTitle` optional and only renders the secondary heading when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef701f2f6a9c7ff974a551ee81a08c5669975125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header sections now accept an optional subtitle and display it only when provided.

* **Bug Fixes**
  * More reliable conditional rendering for call-to-action links and actions when match lists or articles are absent.

* **Style**
  * Removed the trailing semantic-search prompt from possible-matches.
  * Improved spacing and messaging for empty match lists; CTA presentation adjusted for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->