### PR TITLE
User search gateway routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,9 @@ CLOUDFLARE_API_TOKEN=MOCK_CLOUDFLARE_API_TOKEN
 CLOUDFLARE_VECTORIZE_INDEX=MOCK_CLOUDFLARE_VECTORIZE_INDEX
 # Route Workers AI requests through Cloudflare AI Gateway (gateway name/id)
 CLOUDFLARE_AI_GATEWAY_ID=MOCK_CLOUDFLARE_AI_GATEWAY_ID
-# Optional: route embeddings through a different AI Gateway (for example,
-# without guardrails). Falls back to CLOUDFLARE_AI_GATEWAY_ID when omitted.
+# Optional: indexing/batch embedding jobs can use a different AI Gateway (for
+# example, without guardrails). Runtime user search queries still use
+# CLOUDFLARE_AI_GATEWAY_ID. Falls back to CLOUDFLARE_AI_GATEWAY_ID when omitted.
 CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID=MOCK_CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID
 # AI Gateway Authenticated Gateway token (sent as `cf-aig-authorization`)
 CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN=MOCK_CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -47,16 +47,8 @@ test('semanticSearchKCD routes user query embeddings through CLOUDFLARE_AI_GATEW
 		expect(embeddingRequestUrl).not.toContain('/indexing-only-gateway/')
 	} finally {
 		fetchSpy.mockRestore()
-		if (previousGatewayId === undefined) {
-			delete process.env.CLOUDFLARE_AI_GATEWAY_ID
-		} else {
-			process.env.CLOUDFLARE_AI_GATEWAY_ID = previousGatewayId
-		}
-		if (previousEmbeddingGatewayId === undefined) {
-			delete process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID
-		} else {
-			process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID =
-				previousEmbeddingGatewayId
-		}
+		process.env.CLOUDFLARE_AI_GATEWAY_ID = previousGatewayId ?? ''
+		process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID =
+			previousEmbeddingGatewayId ?? ''
 	}
 })

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -1,0 +1,62 @@
+import { expect, test, vi } from 'vitest'
+
+vi.mock('#app/utils/cache.server.ts', () => ({
+	cache: {
+		name: 'test-cache',
+		get: () => null,
+		set: async () => {},
+		delete: async () => {},
+	},
+	cachified: async ({
+		getFreshValue,
+	}: {
+		getFreshValue: () => Promise<unknown>
+	}) => getFreshValue(),
+}))
+
+vi.mock('#app/utils/semantic-search-presentation.server.ts', () => ({
+	getSemanticSearchPresentation: async () => ({}),
+}))
+
+import { semanticSearchKCD } from '../semantic-search.server.ts'
+
+test('semanticSearchKCD routes user query embeddings through CLOUDFLARE_AI_GATEWAY_ID', async () => {
+	const previousGatewayId = process.env.CLOUDFLARE_AI_GATEWAY_ID
+	const previousEmbeddingGatewayId =
+		process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID
+	process.env.CLOUDFLARE_AI_GATEWAY_ID = 'runtime-search-gateway'
+	process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID = 'indexing-only-gateway'
+
+	const originalFetch = globalThis.fetch
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation((input, init) => originalFetch(input, init))
+
+	try {
+		await semanticSearchKCD({
+			query: `Gateway regression test ${Date.now()}`,
+			topK: 1,
+		})
+
+		const embeddingRequestUrl = fetchSpy.mock.calls
+			.map(([input]) => input.toString())
+			.find((url) => url.includes('/workers-ai/'))
+
+		expect(embeddingRequestUrl).toBeDefined()
+		expect(embeddingRequestUrl).toContain('/runtime-search-gateway/')
+		expect(embeddingRequestUrl).not.toContain('/indexing-only-gateway/')
+	} finally {
+		fetchSpy.mockRestore()
+		if (previousGatewayId === undefined) {
+			delete process.env.CLOUDFLARE_AI_GATEWAY_ID
+		} else {
+			process.env.CLOUDFLARE_AI_GATEWAY_ID = previousGatewayId
+		}
+		if (previousEmbeddingGatewayId === undefined) {
+			delete process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID
+		} else {
+			process.env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID =
+				previousEmbeddingGatewayId
+		}
+	}
+})

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -68,7 +68,8 @@ const schemaBase = z.object({
 	/** AI Gateway "id" is the gateway name you create in Cloudflare. */
 	CLOUDFLARE_AI_GATEWAY_ID: nonEmptyString,
 	/**
-	 * Optional embedding-specific AI Gateway id.
+	 * Optional indexing/batch embedding AI Gateway id.
+	 * Runtime user search queries continue to use `CLOUDFLARE_AI_GATEWAY_ID`.
 	 * Falls back to `CLOUDFLARE_AI_GATEWAY_ID` when omitted.
 	 */
 	CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: z.string().trim().optional(),
@@ -183,8 +184,9 @@ export type Env = Omit<
 	 */
 	CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL: string
 	/**
-	 * Embeddings can be routed through a separate gateway (for example, with
-	 * guardrails disabled) without affecting other AI routes.
+	 * Indexing/batch embedding jobs can be routed through a separate gateway
+	 * (for example, with guardrails disabled). Runtime user search queries
+	 * should use `CLOUDFLARE_AI_GATEWAY_ID`.
 	 */
 	CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: string
 	/** Derived from CLOUDFLARE_ACCOUNT_ID when not explicitly set. */

--- a/app/utils/semantic-search.server.ts
+++ b/app/utils/semantic-search.server.ts
@@ -178,7 +178,7 @@ function getRequiredSemanticSearchEnv() {
 	return {
 		accountId: env.CLOUDFLARE_ACCOUNT_ID,
 		apiToken: env.CLOUDFLARE_API_TOKEN,
-		embeddingGatewayId: env.CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID,
+		gatewayId: env.CLOUDFLARE_AI_GATEWAY_ID,
 		gatewayAuthToken: env.CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN,
 		indexName: env.CLOUDFLARE_VECTORIZE_INDEX,
 		embeddingModel: env.CLOUDFLARE_AI_EMBEDDING_MODEL,
@@ -221,21 +221,21 @@ async function cloudflareFetch(
 async function getEmbedding({
 	accountId,
 	apiToken,
-	embeddingGatewayId,
+	gatewayId,
 	gatewayAuthToken,
 	model,
 	text,
 }: {
 	accountId: string
 	apiToken: string
-	embeddingGatewayId: string
+	gatewayId: string
 	gatewayAuthToken: string
 	model: string
 	text: string
 }) {
 	const url = getWorkersAiRunUrl({
 		accountId,
-		gatewayId: embeddingGatewayId,
+		gatewayId,
 		model,
 	})
 	const res = await fetch(url, {
@@ -496,7 +496,7 @@ export async function semanticSearchKCD({
 	const {
 		accountId,
 		apiToken,
-		embeddingGatewayId,
+		gatewayId,
 		gatewayAuthToken,
 		indexName,
 		embeddingModel,
@@ -533,7 +533,7 @@ export async function semanticSearchKCD({
 			const vector = await getEmbedding({
 				accountId,
 				apiToken,
-				embeddingGatewayId,
+				gatewayId,
 				gatewayAuthToken,
 				model: embeddingModel,
 				text: cleanedQuery,

--- a/other/semantic-search/__tests__/cloudflare-config.test.ts
+++ b/other/semantic-search/__tests__/cloudflare-config.test.ts
@@ -1,33 +1,6 @@
 import { expect, test } from 'vitest'
+import { withEnv } from '#tests/with-env.ts'
 import { getCloudflareConfig } from '../cloudflare.ts'
-
-async function withEnv(
-	overrides: Record<string, string | undefined>,
-	callback: () => Promise<void> | void,
-) {
-	const previous = new Map<string, string | undefined>()
-
-	for (const [key, value] of Object.entries(overrides)) {
-		previous.set(key, process.env[key])
-		if (value === undefined) {
-			delete process.env[key]
-		} else {
-			process.env[key] = value
-		}
-	}
-
-	try {
-		await callback()
-	} finally {
-		for (const [key, value] of previous.entries()) {
-			if (value === undefined) {
-				delete process.env[key]
-			} else {
-				process.env[key] = value
-			}
-		}
-	}
-}
 
 test('getCloudflareConfig prefers embedding gateway for indexing when configured', async () => {
 	await withEnv(

--- a/other/semantic-search/__tests__/cloudflare-config.test.ts
+++ b/other/semantic-search/__tests__/cloudflare-config.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest'
+import { getCloudflareConfig } from '../cloudflare.ts'
+
+async function withEnv(
+	overrides: Record<string, string | undefined>,
+	callback: () => Promise<void> | void,
+) {
+	const previous = new Map<string, string | undefined>()
+
+	for (const [key, value] of Object.entries(overrides)) {
+		previous.set(key, process.env[key])
+		if (value === undefined) {
+			delete process.env[key]
+		} else {
+			process.env[key] = value
+		}
+	}
+
+	try {
+		await callback()
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete process.env[key]
+			} else {
+				process.env[key] = value
+			}
+		}
+	}
+}
+
+test('getCloudflareConfig prefers embedding gateway for indexing when configured', async () => {
+	await withEnv(
+		{
+			CLOUDFLARE_ACCOUNT_ID: 'cf-account',
+			CLOUDFLARE_API_TOKEN: 'cf-token',
+			CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
+			CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-gateway',
+			CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
+			CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
+		},
+		() => {
+			const config = getCloudflareConfig()
+			expect(config.gatewayId).toBe('indexing-gateway')
+		},
+	)
+})
+
+test('getCloudflareConfig falls back to regular gateway when embedding override is unset', async () => {
+	await withEnv(
+		{
+			CLOUDFLARE_ACCOUNT_ID: 'cf-account',
+			CLOUDFLARE_API_TOKEN: 'cf-token',
+			CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
+			CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: undefined,
+			CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
+			CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
+		},
+		() => {
+			const config = getCloudflareConfig()
+			expect(config.gatewayId).toBe('runtime-gateway')
+		},
+	)
+})

--- a/other/semantic-search/readme.md
+++ b/other/semantic-search/readme.md
@@ -24,7 +24,7 @@ and shared utilities.
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_VECTORIZE_INDEX`
 - `CLOUDFLARE_AI_EMBEDDING_MODEL` (optional; defaults in code)
-- `CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID` (optional; defaults to `CLOUDFLARE_AI_GATEWAY_ID`)
+- `CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID` (optional; indexers only; defaults to `CLOUDFLARE_AI_GATEWAY_ID`)
 
 - `R2_BUCKET`
 

--- a/tests/with-env.ts
+++ b/tests/with-env.ts
@@ -1,0 +1,28 @@
+export async function withEnv(
+	overrides: Record<string, string | undefined>,
+	callback: () => Promise<void> | void,
+) {
+	const env = process.env as Record<string, string | undefined>
+	const previous = new Map<string, string | undefined>()
+
+	for (const [key, value] of Object.entries(overrides)) {
+		previous.set(key, env[key])
+		if (value === undefined) {
+			delete env[key]
+		} else {
+			env[key] = value
+		}
+	}
+
+	try {
+		await callback()
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete env[key]
+			} else {
+				env[key] = value
+			}
+		}
+	}
+}


### PR DESCRIPTION
Reroute live user search queries to the regular AI gateway to comply with policy, while preserving embedding gateway usage for indexing workflows.

---
<p><a href="https://cursor.com/agents/bc-06759f44-0ed6-4d4d-bb50-d89902b87b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06759f44-0ed6-4d4d-bb50-d89902b87b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the outbound routing for live semantic search embedding calls, which could impact production search behavior and Cloudflare gateway policy/metrics. Scope is small and covered by targeted tests.
> 
> **Overview**
> Runtime semantic search (`semanticSearchKCD`) now routes user query embedding requests through the primary Cloudflare AI Gateway (`CLOUDFLARE_AI_GATEWAY_ID`) instead of the embedding-only gateway override.
> 
> Documentation and env typing/comments were updated to clarify that `CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID` is intended for *indexing/batch embedding jobs* only (falling back to the primary gateway when unset). New Vitest coverage (plus a shared `withEnv` helper) locks in the gateway selection behavior for both runtime search and the indexer config (`getCloudflareConfig`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 685668fe3105220c4ba3dc5a44abe6cc38f49c63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified environment variable guidance: separate gateway for indexing/batch embeddings, runtime searches use the main gateway with fallback.

* **Tests**
  * Added tests covering gateway selection and embedding/search routing.
  * Added a test helper to temporarily override environment variables during tests.

* **Refactor**
  * Internal naming standardized for gateway configuration (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->