### PR TITLE
Missing middleware handler

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -399,8 +399,6 @@ app.use((req, res, next) => {
 		'time spent in react-router request handling',
 	)
 	// `server-timing` auto-ends unfinished metrics when headers are written.
-	// Ending this metric on `finish/close` can double-end it and log:
-	// "No such name middleware-request-handler".
 	next()
 })
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -398,14 +398,9 @@ app.use((req, res, next) => {
 		metricName,
 		'time spent in react-router request handling',
 	)
-	let metricEnded = false
-	const finishMetric = () => {
-		if (metricEnded) return
-		metricEnded = true
-		endServerMetric(res, metricName)
-	}
-	res.once('finish', finishMetric)
-	res.once('close', finishMetric)
+	// `server-timing` auto-ends unfinished metrics when headers are written.
+	// Ending this metric on `finish/close` can double-end it and log:
+	// "No such name middleware-request-handler".
 	next()
 })
 


### PR DESCRIPTION
Remove duplicate `endTime` call for `middleware-request-handler` metric to fix 'No such name' production log warnings.

---
<p><a href="https://cursor.com/agents/bc-1af2f203-1d20-408b-9672-c849cfbc1617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1af2f203-1d20-408b-9672-c849cfbc1617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small observability-only change that removes event-based metric cleanup; risk is limited to potentially missing/altered timing data for that middleware.
> 
> **Overview**
> Stops manually ending the `middleware-request-handler` `server-timing` metric on `res` `finish`/`close`, relying on `server-timing` to auto-close unfinished metrics when headers are written.
> 
> This removes duplicate `endTime` calls that were triggering “No such name” warnings in production logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e5817e5ac4d45e9ef9de4d57daced5a2c11da97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified server-timing metric handling for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->