### PR TITLE
Symbol dispose mechanism

### DIFF
--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -22,7 +22,7 @@ vi.mock('#app/utils/semantic-search-presentation.server.ts', () => ({
 import { semanticSearchKCD } from '../semantic-search.server.ts'
 
 test('semanticSearchKCD routes user query embeddings through CLOUDFLARE_AI_GATEWAY_ID', async () => {
-	using _env = setEnv({
+	using ignoredEnv = setEnv({
 		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-search-gateway',
 		CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-only-gateway',
 	})

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { withEnv } from '#tests/with-env.ts'
+import { setEnv } from '#tests/env-disposable.ts'
 
 vi.mock('#app/utils/cache.server.ts', () => ({
 	cache: {
@@ -22,61 +22,53 @@ vi.mock('#app/utils/semantic-search-presentation.server.ts', () => ({
 import { semanticSearchKCD } from '../semantic-search.server.ts'
 
 test('semanticSearchKCD routes user query embeddings through CLOUDFLARE_AI_GATEWAY_ID', async () => {
-	await withEnv(
-		{
-			CLOUDFLARE_AI_GATEWAY_ID: 'runtime-search-gateway',
-			CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-only-gateway',
-		},
-		async () => {
-			const fetchSpy = vi
-				.spyOn(globalThis, 'fetch')
-				.mockImplementation(async (input) => {
-					const url = input instanceof Request ? input.url : String(input)
+	using _env = setEnv({
+		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-search-gateway',
+		CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-only-gateway',
+	})
 
-					if (url.includes('/workers-ai/')) {
-						return new Response(
-							JSON.stringify({
-								result: {
-									shape: [1, 3],
-									data: [[0.1, 0.2, 0.3]],
-								},
-							}),
-							{
-								status: 200,
-								headers: { 'Content-Type': 'application/json' },
-							},
-						)
-					}
+	const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+		const url = input instanceof Request ? input.url : String(input)
 
-					if (url.includes('/vectorize/')) {
-						return new Response(
-							JSON.stringify({ result: { count: 0, matches: [] } }),
-							{
-								status: 200,
-								headers: { 'Content-Type': 'application/json' },
-							},
-						)
-					}
+		if (url.includes('/workers-ai/')) {
+			return new Response(
+				JSON.stringify({
+					result: {
+						shape: [1, 3],
+						data: [[0.1, 0.2, 0.3]],
+					},
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			)
+		}
 
-					throw new Error(`Unexpected fetch URL in semantic search test: ${url}`)
-				})
+		if (url.includes('/vectorize/')) {
+			return new Response(JSON.stringify({ result: { count: 0, matches: [] } }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		}
 
-			try {
-				await semanticSearchKCD({
-					query: `Gateway regression test ${Date.now()}`,
-					topK: 1,
-				})
+		throw new Error(`Unexpected fetch URL in semantic search test: ${url}`)
+	})
 
-				const embeddingRequestUrl = fetchSpy.mock.calls
-					.map(([input]) => (input instanceof Request ? input.url : String(input)))
-					.find((url) => url.includes('/workers-ai/'))
+	try {
+		await semanticSearchKCD({
+			query: `Gateway regression test ${Date.now()}`,
+			topK: 1,
+		})
 
-				expect(embeddingRequestUrl).toBeDefined()
-				expect(embeddingRequestUrl).toContain('/runtime-search-gateway/')
-				expect(embeddingRequestUrl).not.toContain('/indexing-only-gateway/')
-			} finally {
-				fetchSpy.mockRestore()
-			}
-		},
-	)
+		const embeddingRequestUrl = fetchSpy.mock.calls
+			.map(([input]) => (input instanceof Request ? input.url : String(input)))
+			.find((url) => url.includes('/workers-ai/'))
+
+		expect(embeddingRequestUrl).toBeDefined()
+		expect(embeddingRequestUrl).toContain('/runtime-search-gateway/')
+		expect(embeddingRequestUrl).not.toContain('/indexing-only-gateway/')
+	} finally {
+		fetchSpy.mockRestore()
+	}
 })

--- a/app/utils/__tests__/semantic-search.server.test.ts
+++ b/app/utils/__tests__/semantic-search.server.test.ts
@@ -23,8 +23,12 @@ import { semanticSearchKCD } from '../semantic-search.server.ts'
 
 test('semanticSearchKCD routes user query embeddings through CLOUDFLARE_AI_GATEWAY_ID', async () => {
 	using ignoredEnv = setEnv({
+		CLOUDFLARE_ACCOUNT_ID: 'cf-account',
+		CLOUDFLARE_API_TOKEN: 'cf-token',
 		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-search-gateway',
 		CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-only-gateway',
+		CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
+		CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
 	})
 
 	const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {

--- a/docs/agents/testing-principles.md
+++ b/docs/agents/testing-principles.md
@@ -11,6 +11,8 @@ magic.
 - Don't write tests for what the type system already guarantees.
 - Use disposable objects only when there is real cleanup. If no cleanup, skip
   `using` and `Symbol.dispose`.
+- For setup-only `using` bindings, name variables with an `ignored` prefix so
+  `@typescript-eslint/no-unused-vars` accepts intentional non-reads.
 - Build helpers that return ready-to-run objects (factory pattern), not globals.
 - Keep test intent obvious in the name: "auth handler returns 400 for invalid
   JSON".

--- a/docs/agents/testing-principles.md
+++ b/docs/agents/testing-principles.md
@@ -23,6 +23,21 @@ magic.
 
 ## Examples
 
+### Setup-only `using` bindings
+
+When the disposable is needed only for side-effects (like env restoration), use
+an `ignored` prefix for the binding name:
+
+```ts
+import { test, expect } from 'bun:test'
+import { setEnv } from '#tests/env-disposable.ts'
+
+test('reads env var', () => {
+	using ignoredEnv = setEnv({ MY_VAR: 'hello' })
+	expect(process.env.MY_VAR).toBe('hello')
+})
+```
+
 ### `Symbol.dispose` with `using`
 
 ```ts

--- a/other/semantic-search/__tests__/cloudflare-config.test.ts
+++ b/other/semantic-search/__tests__/cloudflare-config.test.ts
@@ -3,7 +3,7 @@ import { setEnv } from '#tests/env-disposable.ts'
 import { getCloudflareConfig } from '../cloudflare.ts'
 
 test('getCloudflareConfig prefers embedding gateway for indexing when configured', () => {
-	using _env = setEnv({
+	using ignoredEnv = setEnv({
 		CLOUDFLARE_ACCOUNT_ID: 'cf-account',
 		CLOUDFLARE_API_TOKEN: 'cf-token',
 		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
@@ -17,7 +17,7 @@ test('getCloudflareConfig prefers embedding gateway for indexing when configured
 })
 
 test('getCloudflareConfig falls back to regular gateway when embedding override is unset', () => {
-	using _env = setEnv({
+	using ignoredEnv = setEnv({
 		CLOUDFLARE_ACCOUNT_ID: 'cf-account',
 		CLOUDFLARE_API_TOKEN: 'cf-token',
 		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',

--- a/other/semantic-search/__tests__/cloudflare-config.test.ts
+++ b/other/semantic-search/__tests__/cloudflare-config.test.ts
@@ -1,37 +1,31 @@
 import { expect, test } from 'vitest'
-import { withEnv } from '#tests/with-env.ts'
+import { setEnv } from '#tests/env-disposable.ts'
 import { getCloudflareConfig } from '../cloudflare.ts'
 
-test('getCloudflareConfig prefers embedding gateway for indexing when configured', async () => {
-	await withEnv(
-		{
-			CLOUDFLARE_ACCOUNT_ID: 'cf-account',
-			CLOUDFLARE_API_TOKEN: 'cf-token',
-			CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
-			CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-gateway',
-			CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
-			CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
-		},
-		() => {
-			const config = getCloudflareConfig()
-			expect(config.gatewayId).toBe('indexing-gateway')
-		},
-	)
+test('getCloudflareConfig prefers embedding gateway for indexing when configured', () => {
+	using _env = setEnv({
+		CLOUDFLARE_ACCOUNT_ID: 'cf-account',
+		CLOUDFLARE_API_TOKEN: 'cf-token',
+		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
+		CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: 'indexing-gateway',
+		CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
+		CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
+	})
+
+	const config = getCloudflareConfig()
+	expect(config.gatewayId).toBe('indexing-gateway')
 })
 
-test('getCloudflareConfig falls back to regular gateway when embedding override is unset', async () => {
-	await withEnv(
-		{
-			CLOUDFLARE_ACCOUNT_ID: 'cf-account',
-			CLOUDFLARE_API_TOKEN: 'cf-token',
-			CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
-			CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: undefined,
-			CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
-			CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
-		},
-		() => {
-			const config = getCloudflareConfig()
-			expect(config.gatewayId).toBe('runtime-gateway')
-		},
-	)
+test('getCloudflareConfig falls back to regular gateway when embedding override is unset', () => {
+	using _env = setEnv({
+		CLOUDFLARE_ACCOUNT_ID: 'cf-account',
+		CLOUDFLARE_API_TOKEN: 'cf-token',
+		CLOUDFLARE_AI_GATEWAY_ID: 'runtime-gateway',
+		CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID: undefined,
+		CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'gateway-auth-token',
+		CLOUDFLARE_VECTORIZE_INDEX: 'vector-index',
+	})
+
+	const config = getCloudflareConfig()
+	expect(config.gatewayId).toBe('runtime-gateway')
 })

--- a/tests/env-disposable.ts
+++ b/tests/env-disposable.ts
@@ -1,7 +1,4 @@
-export async function withEnv(
-	overrides: Record<string, string | undefined>,
-	callback: () => Promise<void> | void,
-) {
+export function setEnv(overrides: Record<string, string | undefined>) {
 	const env = process.env as Record<string, string | undefined>
 	const previous = new Map<string, string | undefined>()
 
@@ -14,15 +11,15 @@ export async function withEnv(
 		}
 	}
 
-	try {
-		await callback()
-	} finally {
-		for (const [key, value] of previous.entries()) {
-			if (value === undefined) {
-				delete env[key]
-			} else {
-				env[key] = value
+	return {
+		[Symbol.dispose]() {
+			for (const [key, value] of previous.entries()) {
+				if (value === undefined) {
+					delete env[key]
+				} else {
+					env[key] = value
+				}
 			}
-		}
+		},
 	}
 }


### PR DESCRIPTION
Refactor environment variable scoping in tests to use `using` and `Symbol.dispose` for cleaner resource management.

The `withEnv` helper was replaced with a disposable `setEnv` utility, allowing test files to leverage the `using` keyword for automatic environment variable restoration. This aligns with project guidance for resource cleanup. A note was added to agent testing documentation regarding the `ignored*` naming convention required by lint for unused `using` bindings.

---
<p><a href="https://cursor.com/agents/bc-5ad981d1-9621-4be3-b6b3-d913a8daf26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ad981d1-9621-4be3-b6b3-d913a8daf26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor plus documentation updates; risk is limited to potential flakiness if env restoration semantics differ, but no production code paths change.
> 
> **Overview**
> Refactors test env var scoping from an async callback helper (`withEnv`) to a disposable `setEnv` that restores `process.env` via `using` + `Symbol.dispose`.
> 
> Updates semantic-search and Cloudflare config tests to use `using ignoredEnv = setEnv(...)` and simplifies test flow (direct assertions and explicit `fetch` spy lifecycle). Adds testing docs guidance + example for naming setup-only `using` bindings with an `ignored*` prefix to satisfy linting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90f8440cb4376ce485c5a3ea8082d4d8f60532f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test environment helpers from callback-based setup to a disposable-returning pattern, flattening test flow and making setup/cleanup explicit. Reworked semantic-search tests to use a single fetch spy and direct call inspections.

* **Documentation**
  * Added guidance and an example for setup-only environment bindings to testing principles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->