### PR TITLE
Cursor/node js abort signal crash 9702

### DIFF
--- a/app/utils/__tests__/transistor.server.test.ts
+++ b/app/utils/__tests__/transistor.server.test.ts
@@ -1,0 +1,32 @@
+import { expect, test, vi } from 'vitest'
+import { getEpisodes } from '../transistor.server.ts'
+
+test('getEpisodes does not forward signal to fetch', async () => {
+	const controller = new AbortController()
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) => {
+			if (String(input).startsWith('https://api.transistor.fm/')) {
+				return Response.json({ data: [], meta: { totalPages: 1 } }, { status: 200 })
+			}
+			return new Response(null, { status: 200 })
+		})
+
+	try {
+		const episodes = await getEpisodes({
+			forceFresh: true,
+			signal: controller.signal,
+		})
+
+		expect(episodes).toEqual([])
+
+		const transistorCall = fetchSpy.mock.calls.find(([input]) =>
+			String(input).startsWith('https://api.transistor.fm/'),
+		)
+		expect(transistorCall).toBeTruthy()
+		const requestInit = transistorCall?.[1] as RequestInit | undefined
+		expect(requestInit?.signal).toBeUndefined()
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})

--- a/app/utils/__tests__/transistor.server.test.ts
+++ b/app/utils/__tests__/transistor.server.test.ts
@@ -1,7 +1,16 @@
 import { expect, test, vi } from 'vitest'
-import { getEpisodes } from '../transistor.server.ts'
+
+vi.mock('../cache.server.ts', () => {
+	return {
+		cache: {},
+		cachified: async ({ getFreshValue }: { getFreshValue: (context: {}) => unknown }) =>
+			await getFreshValue({}),
+		shouldForceFresh: async () => true,
+	}
+})
 
 test('getEpisodes does not forward signal to fetch', async () => {
+	const { getEpisodes } = await import('../transistor.server.ts')
 	const controller = new AbortController()
 	const fetchSpy = vi
 		.spyOn(globalThis, 'fetch')

--- a/app/utils/fetch-json-with-retry-after.server.ts
+++ b/app/utils/fetch-json-with-retry-after.server.ts
@@ -4,7 +4,7 @@ import {
 	waitForDelay,
 	type Sleep,
 } from './abort-utils.server.ts'
-import { fetchWithTimeout } from './fetch-with-timeout.server'
+import { fetchWithTimeout } from './fetch-with-timeout.server.ts'
 
 type RetryDelayReason = 'retry-after' | 'rate-limit-reset' | 'default'
 

--- a/app/utils/fetch-with-timeout.server.ts
+++ b/app/utils/fetch-with-timeout.server.ts
@@ -9,9 +9,12 @@ export function fetchWithTimeout(
 	options: RequestInit = {},
 	timeoutMs: number = 1000,
 ): Promise<Response> {
+	const requestOptions: RequestInit = { ...options }
+	delete requestOptions.signal
+
 	const timeoutPromise = new Promise<never>((_, reject) => {
 		const id = setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
 		id.unref?.()
 	})
-	return Promise.race([fetch(url, options), timeoutPromise])
+	return Promise.race([fetch(url, requestOptions), timeoutPromise])
 }

--- a/app/utils/transistor.server.ts
+++ b/app/utils/transistor.server.ts
@@ -84,12 +84,13 @@ async function fetchTransitor<JsonResponse>({
 	for (const [key, value] of Object.entries(query)) {
 		url.searchParams.set(key, value)
 	}
+	// Intentionally do not pass AbortSignal to fetch: Node.js v24 can crash when
+	// aborting in-flight fetches. We still honor cancellation via throwIfAborted.
 	const config: RequestInit = {
 		method,
 		headers: {
 			'x-api-key': env.TRANSISTOR_API_SECRET,
 		},
-		signal,
 	}
 	if (data) {
 		config.body = JSON.stringify(data)

--- a/docs/agents/testing-principles.md
+++ b/docs/agents/testing-principles.md
@@ -18,6 +18,10 @@ magic.
   public internet and third-party services; prefer local fakes/fixtures.
 - Prefer fast unit tests for server logic; keep e2e tests focused on journeys.
 - Run server tests with `bun test server` to avoid Playwright spec discovery.
+- In backend Vitest tests, modules that transitively import `cache.server.ts`
+  may require mocking `../cache.server.ts` first; otherwise `vite-env-only`
+  macros (for `serverOnly$` route exports) can fail to transform in Node test
+  runs.
 
 ## Examples
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cancellation semantics for outbound requests (abort no longer cancels in-flight fetch), which could affect latency/resource usage and retry timing; mitigated by explicit `throwIfAborted` checks and added tests.
> 
> **Overview**
> Avoids passing `AbortSignal` into `fetch`/`fetchWithTimeout` calls (including Transistor API requests) to work around a Node.js v24 crash when aborting in-flight fetches, while still honoring cancellation via pre/post `throwIfAborted` checks.
> 
> Adds Vitest coverage to assert signals are not forwarded in `fetchJsonWithRetryAfter` (with and without timeouts) and in `transistor.getEpisodes`, and updates testing docs with a note about mocking `cache.server.ts` in backend Vitest runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3545931d309e4e83f9d8302cda160e736fd2d12d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering abort/cancellation behavior in network requests.

* **Chores**
  * Adjusted internal network request handling to avoid forwarding cancellation signals, improving reliability and retry behavior.

* **Documentation**
  * Clarified backend test guidance around mocking transitive modules to avoid transform-time issues in Node test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->