### PR TITLE
Credits page anchor links

### DIFF
--- a/app/utils/__tests__/credits.server.test.ts
+++ b/app/utils/__tests__/credits.server.test.ts
@@ -51,9 +51,21 @@ test('getPeople checkValue rejects missing ids and revalidates via getFreshValue
 	try {
 		vi.mocked(downloadFile).mockResolvedValueOnce('- name: Fresh Person')
 		vi.mocked(cachified).mockImplementationOnce(async (...args) => {
-			const options = args[0]
-			expect(options.checkValue(staleCachedPeople)).toBe(false)
-			return options.getFreshValue()
+			const options = args[0] as {
+				checkValue?: (
+					value: unknown,
+					migrate: (value: unknown, updateCache?: boolean) => unknown,
+				) => unknown
+				getFreshValue: (context: {
+					metadata: { createdTime: number }
+					background: boolean
+				}) => Promise<unknown>
+			}
+			expect(options.checkValue?.(staleCachedPeople, () => undefined)).toBe(false)
+			return options.getFreshValue({
+				metadata: { createdTime: Date.now() },
+				background: false,
+			})
 		})
 
 		const people = await getPeople({})

--- a/app/utils/__tests__/credits.server.test.ts
+++ b/app/utils/__tests__/credits.server.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, vi } from 'vitest'
 import { cachified } from '@epic-web/cachified'
+import { expect, test, vi } from 'vitest'
 
 const staleCachedPeople = [
 	{
@@ -27,8 +27,8 @@ vi.mock('../github.server.ts', () => ({
 	downloadFile: vi.fn(async () => ''),
 }))
 
-import { downloadFile } from '../github.server.ts'
 import { getPeople } from '../credits.server.ts'
+import { downloadFile } from '../github.server.ts'
 
 test('getPeople normalizes stale cached people with missing id values', async () => {
 	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/app/utils/__tests__/credits.server.test.ts
+++ b/app/utils/__tests__/credits.server.test.ts
@@ -1,0 +1,38 @@
+import { expect, test, vi } from 'vitest'
+
+const staleCachedPeople = [
+	{
+		name: 'Jane Doe',
+		id: undefined,
+	},
+]
+
+vi.mock('@epic-web/cachified', () => ({
+	cachified: vi.fn(async () => staleCachedPeople),
+	verboseReporter: vi.fn(() => undefined),
+}))
+
+vi.mock('../cache.server.ts', () => ({
+	cache: {
+		name: 'test-cache',
+		get: vi.fn(),
+		set: vi.fn(),
+		delete: vi.fn(),
+	},
+	shouldForceFresh: vi.fn(async () => false),
+}))
+
+vi.mock('../github.server.ts', () => ({
+	downloadFile: vi.fn(async () => ''),
+}))
+
+import { getPeople } from '../credits.server.ts'
+
+test('getPeople normalizes stale cached people with missing id values', async () => {
+	const people = await getPeople({})
+	expect(people).toHaveLength(1)
+	expect(people[0]).toMatchObject({
+		id: 'jane-doe',
+		name: 'Jane Doe',
+	})
+})

--- a/app/utils/credits.server.ts
+++ b/app/utils/credits.server.ts
@@ -16,6 +16,9 @@ export type Person = {
 }
 
 type UnknownObj = Record<string, unknown>
+const isUnknownObj = (v: unknown): v is UnknownObj =>
+	typeof v === 'object' && v !== null
+
 function getValueWithFallback<PropertyType>(
 	obj: UnknownObj,
 	key: string,
@@ -43,6 +46,12 @@ function getValueWithFallback<PropertyType>(
 }
 
 const isString = (v: unknown): v is string => typeof v === 'string'
+const hasStringId = (v: unknown): v is UnknownObj & { id: string } =>
+	isUnknownObj(v) && isString(v.id)
+
+function normalizePeople(people: ReadonlyArray<unknown>) {
+	return people.filter(isUnknownObj).map(mapPerson).filter(typedBoolean)
+}
 
 function mapPerson(rawPerson: UnknownObj) {
 	try {
@@ -145,13 +154,14 @@ async function getPeople({
 					throw new Error('Credits is not an array.')
 				}
 
-				return rawCredits.map(mapPerson).filter(typedBoolean)
+				return normalizePeople(rawCredits)
 			},
-			checkValue: (value: unknown) => Array.isArray(value),
+			checkValue: (value: unknown) =>
+				Array.isArray(value) && value.every(hasStringId),
 		},
 		verboseReporter(),
 	)
-	return allPeople
+	return normalizePeople(allPeople)
 }
 
 export { getPeople }

--- a/app/utils/credits.server.ts
+++ b/app/utils/credits.server.ts
@@ -161,6 +161,9 @@ async function getPeople({
 		},
 		verboseReporter(),
 	)
+	// We normalize after `cachified` too because `checkValue` can reject stale data,
+	// `getFreshValue` can fail (for example if GitHub is unavailable), and
+	// `cachified` may still return fallbackToCache data under forceFresh semantics.
 	return normalizePeople(allPeople)
 }
 


### PR DESCRIPTION
Fix broken anchor links on the credits page by ensuring all credit records have a valid ID.

The `href` for anchor links was constructed using `person.id`, but cached credit records could sometimes be missing this `id`, leading to `#undefined` in the URL. This PR normalizes these records to prevent such cases.

---
<p><a href="https://cursor.com/agents/bc-d9785141-132a-42df-b2dd-ebac307c9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9785141-132a-42df-b2dd-ebac307c9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to credits data normalization and cache validation; primary risk is unintended cache misses or extra revalidation if `checkValue` is overly strict.
> 
> **Overview**
> Fixes broken credits-page anchor links by **guaranteeing every returned person has a non-empty string `id`**, even when `cachified` serves stale/fallback cached data.
> 
> `getPeople` now validates cache entries with a stricter `checkValue` (rejects arrays containing missing/invalid `id`s) and normalizes both freshly fetched YAML and cached results via a shared `normalizePeople` pipeline that slugifies `name` when `id` is absent. Adds Vitest coverage for normalizing stale cached records and for revalidation behavior when `checkValue` fails (including asserting the GitHub fetch path).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5834df3f93a126e45356e1f2bd38d5b5895dbe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of credits data to handle stale or incomplete cached entries so contributor names consistently have stable IDs.

* **Tests**
  * Added unit tests covering normalization and revalidation when IDs are missing, including scenarios that fetch fresh credits; console warnings are suppressed during assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->