### PR TITLE
Cache admin deletion

### DIFF
--- a/app/routes/cache.admin.tsx
+++ b/app/routes/cache.admin.tsx
@@ -237,6 +237,8 @@ function DeleteAllMatchingCacheValuesButton({
 	instance: string
 	matchingCacheValuesCount: number
 }) {
+	if (matchingCacheValuesCount === 0) return null
+
 	const fetcher = useFetcher()
 	const dc = useDoubleCheck()
 	const isDeleting = fetcher.state !== 'idle'
@@ -248,7 +250,7 @@ function DeleteAllMatchingCacheValuesButton({
 			<Button
 				size="small"
 				variant="danger"
-				disabled={isDeleting || matchingCacheValuesCount === 0}
+				disabled={isDeleting}
 				{...dc.getButtonProps({ type: 'submit' })}
 			>
 				{isDeleting

--- a/app/routes/cache.admin.tsx
+++ b/app/routes/cache.admin.tsx
@@ -237,10 +237,9 @@ function DeleteAllMatchingCacheValuesButton({
 	instance: string
 	matchingCacheValuesCount: number
 }) {
-	if (matchingCacheValuesCount === 0) return null
-
 	const fetcher = useFetcher()
 	const dc = useDoubleCheck()
+	if (matchingCacheValuesCount === 0) return null
 	const isDeleting = fetcher.state !== 'idle'
 
 	return (

--- a/app/routes/cache.admin.tsx
+++ b/app/routes/cache.admin.tsx
@@ -78,14 +78,14 @@ export async function action({ request }: Route.ActionArgs) {
 	await requireAdminUser(request)
 	const searchParams = new URL(request.url).searchParams
 	const formData = await request.formData()
-	const { currentInstance } = await getInstanceInfo()
+	const { currentInstance, currentIsPrimary, primaryInstance } =
+		await getInstanceInfo()
 	const instance = formData.get('instance') ?? currentInstance
 	invariantResponse(typeof instance === 'string', 'instance must be a string')
 	await ensureInstance(instance)
 
 	const intent = formData.get('intent')
 	if (intent === deleteAllMatchingIntent) {
-		const { currentIsPrimary, primaryInstance } = await getInstanceInfo()
 		invariantResponse(
 			currentIsPrimary,
 			`Bulk delete must run on the primary instance (${primaryInstance})`,


### PR DESCRIPTION
Add a "Delete all matching cache values" button to `/cache/admin` to enable bulk deletion of filtered cache entries.

---
<p><a href="https://cursor.com/agents/bc-7f960355-7130-4efc-b173-24bfefcc2a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f960355-7130-4efc-b173-24bfefcc2a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a destructive bulk-delete path over caches; mistakes in filtering/limits or primary-instance enforcement could lead to unintended cache invalidation across the system.
> 
> **Overview**
> Adds a **bulk deletion** action to `/cache/admin` that removes *all currently filtered* cache keys from both the SQLite-backed cache and in-memory LRU cache.
> 
> Introduces input hardening around the `limit` param (sanitized and capped at `10_000`) and enforces that bulk deletes can only run on the **primary LiteFS instance**. The UI now shows a conditional “delete all N matching cache values” button with a double-confirmation flow and in-progress status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 869f83a89852bb25a0f4ebe03a41decaf114fd8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk delete to remove all cache entries matching specified criteria in one action.
  * New "Delete All Matching" button in Cache Admin showing total matching values, with double-confirm safety prompts.
  * Preserves existing single-key delete flow.

* **Improvements**
  * UI and loader updated to compute and display matching counts before deletion.
  * Safeguards ensure bulk deletion runs only on the primary instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->