### PR TITLE
Unexpected search results

### DIFF
--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -27,6 +27,7 @@ import { HeroSection } from '#app/components/sections/hero-section.tsx'
 import { Paragraph } from '#app/components/typography.tsx'
 import { getGenericSocialImage, images } from '#app/images.tsx'
 import { type RootLoaderType } from '#app/root.tsx'
+import { type KCDHandle } from '#app/types.ts'
 import { getClientSession } from '#app/utils/client.server.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { getLoginInfoSession } from '#app/utils/login.server.ts'
@@ -44,6 +45,10 @@ import { prisma } from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/login'
+
+export const handle: KCDHandle = {
+	getSitemapEntries: () => null,
+}
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const user = await getUser(request)

--- a/app/routes/me_.passkeys.tsx
+++ b/app/routes/me_.passkeys.tsx
@@ -3,9 +3,14 @@ import { type PublicKeyCredentialCreationOptionsJSON } from '@simplewebauthn/ser
 import { data as json, Form, useRevalidator } from 'react-router'
 import { z } from 'zod'
 import { Button } from '#app/components/button.tsx'
+import { type KCDHandle } from '#app/types.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { requireUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/me_.passkeys'
+
+export const handle: KCDHandle = {
+	getSitemapEntries: () => null,
+}
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const user = await requireUser(request)

--- a/app/routes/me_.password.tsx
+++ b/app/routes/me_.password.tsx
@@ -4,6 +4,7 @@ import { Field, InputError } from '#app/components/form-elements.tsx'
 import { Grid } from '#app/components/grid.tsx'
 import { HeaderSection } from '#app/components/sections/header-section.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
+import { type KCDHandle } from '#app/types.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import {
 	getPasswordHash,
@@ -13,6 +14,10 @@ import {
 import { prisma } from '#app/utils/prisma.server.ts'
 import { getSession, requireUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/me_.password'
+
+export const handle: KCDHandle = {
+	getSitemapEntries: () => null,
+}
 
 type ActionData =
 	| {

--- a/other/semantic-search/__tests__/jsx-page-content.test.ts
+++ b/other/semantic-search/__tests__/jsx-page-content.test.ts
@@ -67,6 +67,9 @@ describe('jsx page content utils', () => {
 		expect(
 			shouldIndexJsxSitemapPath({ pathname: '/me/passkeys', mdxRoutes }),
 		).toBe(false)
+		expect(shouldIndexJsxSitemapPath({ pathname: '/me', mdxRoutes })).toBe(
+			false,
+		)
 	})
 
 	test('getJsxPageSlugFromPath and getJsxPagePathFromSlug are reversible', () => {

--- a/other/semantic-search/__tests__/jsx-page-content.test.ts
+++ b/other/semantic-search/__tests__/jsx-page-content.test.ts
@@ -58,6 +58,15 @@ describe('jsx page content utils', () => {
 		expect(
 			shouldIndexJsxSitemapPath({ pathname: '/feed.json', mdxRoutes }),
 		).toBe(false)
+		expect(shouldIndexJsxSitemapPath({ pathname: '/login', mdxRoutes })).toBe(
+			false,
+		)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/me/password', mdxRoutes }),
+		).toBe(false)
+		expect(
+			shouldIndexJsxSitemapPath({ pathname: '/me/passkeys', mdxRoutes }),
+		).toBe(false)
 	})
 
 	test('getJsxPageSlugFromPath and getJsxPagePathFromSlug are reversible', () => {

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -33,11 +33,16 @@ const SKIPPED_CLASS_NAMES = new Set([
 const SKIPPED_ROLES = new Set(['dialog', 'alert', 'status', 'navigation'])
 const SKIPPED_STATIC_ROUTES = new Set([
 	'/credits',
+	'/forgot-password',
+	'/login',
+	'/magic',
+	'/reset-password',
 	'/resume',
 	'/sitemap.xml',
+	'/signup',
 	'/testimonials',
 ])
-const SKIPPED_PREFIX_ROUTES = ['/blog/', '/calls/', '/chats/', '/talks/']
+const SKIPPED_PREFIX_ROUTES = ['/blog/', '/calls/', '/chats/', '/me/', '/talks/']
 const NON_HTML_EXTENSION_PATTERN = /\.[a-z0-9]+$/i
 const BLOCK_LEVEL_TAG_NAMES = new Set([
 	'address',

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -38,8 +38,8 @@ const SKIPPED_STATIC_ROUTES = new Set([
 	'/magic',
 	'/reset-password',
 	'/resume',
-	'/sitemap.xml',
 	'/signup',
+	'/sitemap.xml',
 	'/testimonials',
 ])
 const SKIPPED_PREFIX_ROUTES = ['/blog/', '/calls/', '/chats/', '/me/', '/talks/']

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -36,6 +36,7 @@ const SKIPPED_STATIC_ROUTES = new Set([
 	'/forgot-password',
 	'/login',
 	'/magic',
+	'/me',
 	'/reset-password',
 	'/resume',
 	'/signup',


### PR DESCRIPTION
Prevent authenticated pages (`/login`, `/me/*`) from appearing in search results by adding sitemap opt-outs and a defensive indexer filter.

---
<p><a href="https://cursor.com/agents/bc-b7e58587-f5fa-42f5-bfb6-8e9acb1f908e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7e58587-f5fa-42f5-bfb6-8e9acb1f908e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to sitemap/indexer filtering and related tests, but could affect what pages appear in search/indexing if the route allow/deny lists are incorrect.
> 
> **Overview**
> Prevents authenticated/account-related pages from being discoverable via the JSX semantic-search index and sitemap-driven indexing.
> 
> Adds `handle.getSitemapEntries: () => null` to opt out `login` and `/me` account routes from sitemap entries, and hardens the semantic-search crawler (`jsx-page-content.ts`) by skipping common auth/account paths (including `/me/*`) with updated tests to lock in the exclusions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43616bb9e27160d619d3e5dcaaa259befcbb746e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated sitemap configuration to exclude additional authentication and account management routes (login, signup, forgot/magic/reset-password, and /me/*) from indexing; added route-level sitemap metadata stubs to reinforce exclusions.

* **Tests**
  * Added/expanded test cases to verify these restricted pages are not included in sitemap/indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->