### PR TITLE
Contact page podcast prompt

### DIFF
--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -151,6 +151,16 @@ export default function ContactRoute() {
 								<a href="mailto:support@egghead.io">support@egghead.io</a>
 								{`) instead. I'll just forward your message to them anyway.`}
 							</Paragraph>
+							<div className="bg-secondary mt-6 rounded-lg p-4">
+								<Paragraph>
+									Have a general question? The best place is the{' '}
+									<Link to="/calls" className="underline">
+										Call Kent podcast
+									</Link>
+									. You can record your question or type it if you don&apos;t
+									want to record yourself.
+								</Paragraph>
+							</div>
 						</div>
 
 						<div className="col-span-full lg:col-span-8 lg:col-start-3">

--- a/e2e/contact.spec.ts
+++ b/e2e/contact.spec.ts
@@ -18,6 +18,14 @@ test('Users can send an email', async ({ page, login }) => {
 
 	// verify name and email are prefilled
 	const mainContent = page.getByRole('main')
+	await expect(
+		mainContent.getByText(
+			/have a general question\? the best place is the call kent podcast\./i,
+		),
+	).toBeVisible()
+	await expect(
+		mainContent.getByRole('link', { name: /call kent podcast/i }),
+	).toHaveAttribute('href', '/calls')
 	await expect(mainContent.getByRole('textbox', { name: /name/i })).toHaveValue(
 		user.firstName,
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a callout on the contact page to direct general questions to the Call Kent podcast, including that typed questions are welcome.

---
<p><a href="https://cursor.com/agents/bc-d38078ba-66c9-43bc-a899-cdb944d81bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d38078ba-66c9-43bc-a899-cdb944d81bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated the contact page to include a recommendation for users with general questions to check out the Call Kent podcast, with a convenient link to access it.

* **Tests**
  * Added test coverage to verify the new podcast recommendation is displayed and the link functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->