### PR TITLE
Metadata generation retry flow

### DIFF
--- a/app/routes/calls_.admin/$callId.tsx
+++ b/app/routes/calls_.admin/$callId.tsx
@@ -57,6 +57,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 					step: true,
 					errorMessage: true,
 					episodeAudioKey: true,
+					responseAudioKey: true,
 					transcript: true,
 					title: true,
 					description: true,
@@ -76,6 +77,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 	}
 	const episodeDraft = call.episodeDraft
 	const hasEpisodeAudio = Boolean(episodeDraft?.episodeAudioKey)
+	const hasResponseAudio = Boolean(episodeDraft?.responseAudioKey)
 	const episodeAudioUrl = hasEpisodeAudio
 		? `/resources/calls/draft-episode-audio?callId=${call.id}`
 		: null
@@ -88,7 +90,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 						...episodeDraft,
 						// Don’t send the storage key to the client.
 						episodeAudioKey: null,
+						responseAudioKey: null,
 						hasEpisodeAudio,
+						hasResponseAudio,
 						episodeAudioUrl,
 					}
 				: null,
@@ -773,6 +777,7 @@ function DraftEditor({
 }
 
 const draftStatusResourcePath = '/resources/calls/draft-status'
+const draftResponseAudioResourcePath = '/resources/calls/draft-response-audio'
 
 function RecordingDetailScreen({
 	data,
@@ -780,6 +785,12 @@ function RecordingDetailScreen({
 	data: Route.ComponentProps['loaderData']
 }) {
 	const [responseAudio, setResponseAudio] = React.useState<Blob | null>(null)
+	const [restoredResponseAudio, setRestoredResponseAudio] =
+		React.useState<Blob | null>(null)
+	const [isRestoringResponseAudio, setIsRestoringResponseAudio] =
+		React.useState(false)
+	const [restoreResponseAudioError, setRestoreResponseAudioError] =
+		React.useState<string | null>(null)
 	const [polledStatus, setPolledStatus] = React.useState<{
 		status: string
 		step: string
@@ -790,7 +801,36 @@ function RecordingDetailScreen({
 	const revalidator = useRevalidator()
 	React.useEffect(() => {
 		setPolledStatus(null)
+		setRestoredResponseAudio(null)
+		setRestoreResponseAudioError(null)
+		setIsRestoringResponseAudio(false)
 	}, [draft?.id])
+
+	async function restoreSavedResponseAudio() {
+		if (isRestoringResponseAudio) return
+		setRestoreResponseAudioError(null)
+		setIsRestoringResponseAudio(true)
+		try {
+			const res = await fetch(
+				`${draftResponseAudioResourcePath}?callId=${data.call.id}`,
+			)
+			if (!res.ok) {
+				const text = await res.text().catch(() => '')
+				throw new Error(text.trim() || 'Unable to restore the saved recording.')
+			}
+			const mime = res.headers.get('Content-Type') ?? 'audio/webm'
+			const bytes = await res.arrayBuffer()
+			setRestoredResponseAudio(new Blob([bytes], { type: mime }))
+		} catch (error: unknown) {
+			setRestoreResponseAudioError(
+				error instanceof Error
+					? error.message
+					: 'Unable to restore the saved recording.',
+			)
+		} finally {
+			setIsRestoringResponseAudio(false)
+		}
+	}
 
 	// Caller transcript generation runs before episode-draft creation, so poll the
 	// full loader while that lightweight status is processing.
@@ -847,8 +887,32 @@ function RecordingDetailScreen({
 				</Paragraph>
 
 				{draft ? (
-					(draft.status === 'PROCESSING' && polledStatus?.status !== 'ERROR') ||
-					(polledStatus?.status === 'READY' && draft.status !== 'READY') ? (
+					restoredResponseAudio ? (
+						<div className="flex flex-col gap-4">
+							<Paragraph className="text-gray-500 dark:text-slate-400">
+								{`Saved recording restored. Review it and try generating the draft again, or record a new response instead.`}
+							</Paragraph>
+							<ResponseAudioDraftForm
+								audio={restoredResponseAudio}
+								callId={data.call.id}
+								callNotes={data.call.notes}
+								callTitle={data.call.title}
+							/>
+							<Form
+								method="post"
+								action={recordingFormActionPath}
+								preventScrollReset
+							>
+								<input type="hidden" name="intent" value="undo-episode-draft" />
+								<input type="hidden" name="callId" value={data.call.id} />
+								<Button type="submit" variant="secondary">
+									Record new response
+								</Button>
+							</Form>
+						</div>
+					) : (draft.status === 'PROCESSING' &&
+							polledStatus?.status !== 'ERROR') ||
+					  (polledStatus?.status === 'READY' && draft.status !== 'READY') ? (
 						<DraftPending
 							callId={data.call.id}
 							step={
@@ -867,18 +931,41 @@ function RecordingDetailScreen({
 									draft.errorMessage ??
 									'Unknown error'}
 							</Paragraph>
-							<Form
-								method="post"
-								action={recordingFormActionPath}
-								className="mt-6"
-								preventScrollReset
-							>
-								<input type="hidden" name="intent" value="undo-episode-draft" />
-								<input type="hidden" name="callId" value={data.call.id} />
-								<Button type="submit" variant="secondary">
-									Undo and re-record
-								</Button>
-							</Form>
+							{restoreResponseAudioError ? (
+								<Paragraph className="mt-4 whitespace-pre-wrap text-red-700 dark:text-red-300">
+									{restoreResponseAudioError}
+								</Paragraph>
+							) : null}
+							<div className="mt-6 flex flex-wrap gap-3">
+								{draft.hasResponseAudio ? (
+									<Button
+										type="button"
+										onClick={() => {
+											void restoreSavedResponseAudio()
+										}}
+										disabled={isRestoringResponseAudio}
+									>
+										{isRestoringResponseAudio
+											? 'Restoring saved recording...'
+											: 'Try again with saved recording'}
+									</Button>
+								) : null}
+								<Form
+									method="post"
+									action={recordingFormActionPath}
+									preventScrollReset
+								>
+									<input
+										type="hidden"
+										name="intent"
+										value="undo-episode-draft"
+									/>
+									<input type="hidden" name="callId" value={data.call.id} />
+									<Button type="submit" variant="secondary">
+										Undo and re-record
+									</Button>
+								</Form>
+							</div>
 						</div>
 					) : (
 						<DraftEditor

--- a/app/routes/resources/calls/__tests__/draft-response-audio.test.ts
+++ b/app/routes/resources/calls/__tests__/draft-response-audio.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { Buffer } from 'node:buffer'
+import { Readable } from 'node:stream'
+import { expect, test, vi } from 'vitest'
+
+vi.mock('#app/utils/call-kent-audio-storage.server.ts', () => ({
+	getAudioBuffer: vi.fn(),
+	getAudioStream: vi.fn(),
+	parseHttpByteRangeHeader: vi.fn(),
+}))
+
+vi.mock('#app/utils/prisma.server.ts', () => ({
+	prisma: {
+		callKentEpisodeDraft: {
+			findUnique: vi.fn(),
+		},
+	},
+}))
+
+vi.mock('#app/utils/session.server.ts', () => ({
+	requireAdminUser: vi.fn(),
+}))
+
+import {
+	getAudioBuffer,
+	getAudioStream,
+} from '#app/utils/call-kent-audio-storage.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
+import { loader } from '../draft-response-audio.ts'
+
+test('draft-response-audio streams saved response audio for admins', async () => {
+	vi.clearAllMocks()
+	vi.mocked(prisma.callKentEpisodeDraft.findUnique).mockResolvedValue({
+		responseAudioKey: 'call-kent/drafts/draft-1/response.webm',
+		responseAudioContentType: 'audio/webm',
+		responseAudioSize: 5,
+	} as any)
+	vi.mocked(getAudioStream).mockResolvedValue({
+		body: Readable.from(Buffer.from('hello')),
+	} as any)
+
+	const response = await loader({
+		request: new Request(
+			'http://localhost/resources/calls/draft-response-audio?callId=call-1',
+		),
+	} as any)
+
+	expect(response.status).toBe(200)
+	expect(response.headers.get('content-type')).toBe('audio/webm')
+	expect(Buffer.from(await response.arrayBuffer()).toString('utf8')).toBe(
+		'hello',
+	)
+	expect(getAudioStream).toHaveBeenCalledWith({
+		key: 'call-kent/drafts/draft-1/response.webm',
+		range: undefined,
+	})
+})
+
+test('draft-response-audio falls back to buffered reads when size is missing', async () => {
+	vi.clearAllMocks()
+	vi.mocked(prisma.callKentEpisodeDraft.findUnique).mockResolvedValue({
+		responseAudioKey: 'call-kent/drafts/draft-1/response.webm',
+		responseAudioContentType: 'audio/webm',
+		responseAudioSize: null,
+	} as any)
+	vi.mocked(getAudioBuffer).mockResolvedValue(Buffer.from('retry me'))
+
+	const response = await loader({
+		request: new Request(
+			'http://localhost/resources/calls/draft-response-audio?callId=call-1',
+		),
+	} as any)
+
+	expect(response.status).toBe(200)
+	expect(Buffer.from(await response.arrayBuffer()).toString('utf8')).toBe(
+		'retry me',
+	)
+	expect(getAudioBuffer).toHaveBeenCalledWith({
+		key: 'call-kent/drafts/draft-1/response.webm',
+	})
+})

--- a/app/routes/resources/calls/draft-episode-audio.ts
+++ b/app/routes/resources/calls/draft-episode-audio.ts
@@ -1,10 +1,4 @@
-import { Readable } from 'node:stream'
-import { createReadableStreamFromReadable } from '@react-router/node'
-import {
-	getAudioBuffer,
-	getAudioStream,
-	parseHttpByteRangeHeader,
-} from '#app/utils/call-kent-audio-storage.server.ts'
+import { createDraftAudioResponse } from '#app/utils/draft-audio-response.server.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { requireAdminUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/draft-episode-audio'
@@ -25,54 +19,13 @@ export async function loader({ request }: Route.LoaderArgs) {
 	})
 	if (!draft) throw new Response('Not found', { status: 404 })
 
-	const rangeHeader = request.headers.get('range')
-
 	if (!draft.episodeAudioKey) throw new Response('Not found', { status: 404 })
 
-	const contentType = draft.episodeAudioContentType ?? 'audio/mpeg'
-	const size = draft.episodeAudioSize
-
-	if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) {
-		const buffer = await getAudioBuffer({ key: draft.episodeAudioKey })
-		const totalSize = buffer.byteLength
-		const range = rangeHeader
-			? parseHttpByteRangeHeader(rangeHeader, totalSize)
-			: null
-		const body = range ? buffer.subarray(range.start, range.end + 1) : buffer
-		const stream = Readable.from(body)
-		return new Response(createReadableStreamFromReadable(stream), {
-			status: range ? 206 : 200,
-			headers: {
-				'Content-Type': contentType,
-				'Accept-Ranges': 'bytes',
-				...(range
-					? {
-							'Content-Range': `bytes ${range.start}-${range.end}/${totalSize}`,
-							'Content-Length': String(range.end - range.start + 1),
-						}
-					: { 'Content-Length': String(totalSize) }),
-				'Cache-Control': 'private, max-age=3600',
-			},
-		})
-	}
-
-	const range = rangeHeader ? parseHttpByteRangeHeader(rangeHeader, size) : null
-	const { body } = await getAudioStream({
+	return await createDraftAudioResponse({
+		request,
 		key: draft.episodeAudioKey,
-		range: range ?? undefined,
-	})
-	return new Response(createReadableStreamFromReadable(body), {
-		status: range ? 206 : 200,
-		headers: {
-			'Content-Type': contentType,
-			'Accept-Ranges': 'bytes',
-			...(range
-				? {
-						'Content-Range': `bytes ${range.start}-${range.end}/${size}`,
-						'Content-Length': String(range.end - range.start + 1),
-					}
-				: { 'Content-Length': String(size) }),
-			'Cache-Control': 'private, max-age=3600',
-		},
+		contentType: draft.episodeAudioContentType,
+		size: draft.episodeAudioSize,
+		defaultContentType: 'audio/mpeg',
 	})
 }

--- a/app/routes/resources/calls/draft-response-audio.ts
+++ b/app/routes/resources/calls/draft-response-audio.ts
@@ -1,0 +1,77 @@
+import { Readable } from 'node:stream'
+import { createReadableStreamFromReadable } from '@react-router/node'
+import {
+	getAudioBuffer,
+	getAudioStream,
+	parseHttpByteRangeHeader,
+} from '#app/utils/call-kent-audio-storage.server.ts'
+import { prisma } from '#app/utils/prisma.server.ts'
+import { requireAdminUser } from '#app/utils/session.server.ts'
+import { type Route } from './+types/draft-response-audio'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	await requireAdminUser(request)
+	const url = new URL(request.url)
+	const callId = url.searchParams.get('callId')
+	if (!callId) throw new Response('callId is required', { status: 400 })
+
+	const draft = await prisma.callKentEpisodeDraft.findUnique({
+		where: { callId },
+		select: {
+			responseAudioKey: true,
+			responseAudioContentType: true,
+			responseAudioSize: true,
+		},
+	})
+	if (!draft) throw new Response('Not found', { status: 404 })
+	if (!draft.responseAudioKey) throw new Response('Not found', { status: 404 })
+
+	const rangeHeader = request.headers.get('range')
+	const contentType =
+		draft.responseAudioContentType ?? 'application/octet-stream'
+	const size = draft.responseAudioSize
+
+	if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) {
+		const buffer = await getAudioBuffer({ key: draft.responseAudioKey })
+		const totalSize = buffer.byteLength
+		const range = rangeHeader
+			? parseHttpByteRangeHeader(rangeHeader, totalSize)
+			: null
+		const body = range ? buffer.subarray(range.start, range.end + 1) : buffer
+		const stream = Readable.from(body)
+		return new Response(createReadableStreamFromReadable(stream), {
+			status: range ? 206 : 200,
+			headers: {
+				'Content-Type': contentType,
+				'Accept-Ranges': 'bytes',
+				...(range
+					? {
+							'Content-Range': `bytes ${range.start}-${range.end}/${totalSize}`,
+							'Content-Length': String(range.end - range.start + 1),
+						}
+					: { 'Content-Length': String(totalSize) }),
+				'Cache-Control': 'private, max-age=3600',
+			},
+		})
+	}
+
+	const range = rangeHeader ? parseHttpByteRangeHeader(rangeHeader, size) : null
+	const { body } = await getAudioStream({
+		key: draft.responseAudioKey,
+		range: range ?? undefined,
+	})
+	return new Response(createReadableStreamFromReadable(body), {
+		status: range ? 206 : 200,
+		headers: {
+			'Content-Type': contentType,
+			'Accept-Ranges': 'bytes',
+			...(range
+				? {
+						'Content-Range': `bytes ${range.start}-${range.end}/${size}`,
+						'Content-Length': String(range.end - range.start + 1),
+					}
+				: { 'Content-Length': String(size) }),
+			'Cache-Control': 'private, max-age=3600',
+		},
+	})
+}

--- a/app/routes/resources/calls/draft-response-audio.ts
+++ b/app/routes/resources/calls/draft-response-audio.ts
@@ -1,10 +1,4 @@
-import { Readable } from 'node:stream'
-import { createReadableStreamFromReadable } from '@react-router/node'
-import {
-	getAudioBuffer,
-	getAudioStream,
-	parseHttpByteRangeHeader,
-} from '#app/utils/call-kent-audio-storage.server.ts'
+import { createDraftAudioResponse } from '#app/utils/draft-audio-response.server.ts'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { requireAdminUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/draft-response-audio'
@@ -26,52 +20,11 @@ export async function loader({ request }: Route.LoaderArgs) {
 	if (!draft) throw new Response('Not found', { status: 404 })
 	if (!draft.responseAudioKey) throw new Response('Not found', { status: 404 })
 
-	const rangeHeader = request.headers.get('range')
-	const contentType =
-		draft.responseAudioContentType ?? 'application/octet-stream'
-	const size = draft.responseAudioSize
-
-	if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) {
-		const buffer = await getAudioBuffer({ key: draft.responseAudioKey })
-		const totalSize = buffer.byteLength
-		const range = rangeHeader
-			? parseHttpByteRangeHeader(rangeHeader, totalSize)
-			: null
-		const body = range ? buffer.subarray(range.start, range.end + 1) : buffer
-		const stream = Readable.from(body)
-		return new Response(createReadableStreamFromReadable(stream), {
-			status: range ? 206 : 200,
-			headers: {
-				'Content-Type': contentType,
-				'Accept-Ranges': 'bytes',
-				...(range
-					? {
-							'Content-Range': `bytes ${range.start}-${range.end}/${totalSize}`,
-							'Content-Length': String(range.end - range.start + 1),
-						}
-					: { 'Content-Length': String(totalSize) }),
-				'Cache-Control': 'private, max-age=3600',
-			},
-		})
-	}
-
-	const range = rangeHeader ? parseHttpByteRangeHeader(rangeHeader, size) : null
-	const { body } = await getAudioStream({
+	return await createDraftAudioResponse({
+		request,
 		key: draft.responseAudioKey,
-		range: range ?? undefined,
-	})
-	return new Response(createReadableStreamFromReadable(body), {
-		status: range ? 206 : 200,
-		headers: {
-			'Content-Type': contentType,
-			'Accept-Ranges': 'bytes',
-			...(range
-				? {
-						'Content-Range': `bytes ${range.start}-${range.end}/${size}`,
-						'Content-Length': String(range.end - range.start + 1),
-					}
-				: { 'Content-Length': String(size) }),
-			'Cache-Control': 'private, max-age=3600',
-		},
+		contentType: draft.responseAudioContentType,
+		size: draft.responseAudioSize,
+		defaultContentType: 'audio/webm',
 	})
 }

--- a/app/utils/draft-audio-response.server.ts
+++ b/app/utils/draft-audio-response.server.ts
@@ -1,0 +1,70 @@
+import { Readable } from 'node:stream'
+import { createReadableStreamFromReadable } from '@react-router/node'
+import {
+	getAudioBuffer,
+	getAudioStream,
+	parseHttpByteRangeHeader,
+} from '#app/utils/call-kent-audio-storage.server.ts'
+
+type DraftAudioResponseOptions = {
+	request: Request
+	key: string
+	contentType: string | null
+	size: number | null
+	defaultContentType: string
+}
+
+export async function createDraftAudioResponse({
+	request,
+	key,
+	contentType,
+	size,
+	defaultContentType,
+}: DraftAudioResponseOptions) {
+	const rangeHeader = request.headers.get('range')
+	const resolvedContentType = contentType ?? defaultContentType
+
+	if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) {
+		const buffer = await getAudioBuffer({ key })
+		const totalSize = buffer.byteLength
+		const range = rangeHeader
+			? parseHttpByteRangeHeader(rangeHeader, totalSize)
+			: null
+		const body = range ? buffer.subarray(range.start, range.end + 1) : buffer
+		const stream = Readable.from(body)
+		return new Response(createReadableStreamFromReadable(stream), {
+			status: range ? 206 : 200,
+			headers: {
+				'Content-Type': resolvedContentType,
+				'Accept-Ranges': 'bytes',
+				...(range
+					? {
+							'Content-Range': `bytes ${range.start}-${range.end}/${totalSize}`,
+							'Content-Length': String(range.end - range.start + 1),
+						}
+					: { 'Content-Length': String(totalSize) }),
+				'Cache-Control': 'private, max-age=3600',
+			},
+		})
+	}
+
+	const range = rangeHeader ? parseHttpByteRangeHeader(rangeHeader, size) : null
+	const { body } = await getAudioStream({
+		key,
+		range: range ?? undefined,
+	})
+	return new Response(createReadableStreamFromReadable(body), {
+		status: range ? 206 : 200,
+		headers: {
+			'Content-Type': resolvedContentType,
+			'Accept-Ranges': 'bytes',
+			...(range
+				? {
+						'Content-Range': `bytes ${range.start}-${range.end}/${size}`,
+						'Content-Length': String(range.end - range.start + 1),
+					}
+				: { 'Content-Length': String(size) }),
+			'Cache-Control': 'private, max-age=3600',
+		},
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a 'Try again with saved recording' option to the Call Admin page error state to allow retrying metadata generation without re-recording.

The previous flow only offered "Undo and re-record" when metadata generation failed, forcing users to re-record audio unnecessarily. This change preserves the existing recording and restores it to the draft form, enabling a quick retry.

---
<p><a href="https://cursor.com/agents/bc-abc1533b-e4a7-45e2-b991-4e10d3e955e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abc1533b-e4a7-45e2-b991-4e10d3e955e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and restore draft response audio during calls; UI shows restored recordings with Undo/Record-new options and a restore workflow.

* **UX & Reliability**
  * Prioritize restored-audio display during recording, clearer restoration error messages, and option to attempt restoration before re-recording.

* **New Endpoints/Serving**
  * Added secure draft-audio serving with proper streaming, range support, and content-type handling.

* **Tests**
  * Added tests for draft-audio serving and sample-audio decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->