### PR TITLE
Call Kent transcript formatting

### DIFF
--- a/app/utils/__tests__/call-kent-transcript-format.server.test.ts
+++ b/app/utils/__tests__/call-kent-transcript-format.server.test.ts
@@ -83,7 +83,7 @@ test('formatCallKentTranscriptWithWorkersAi does not truncate long transcripts',
 	expect(formatted).toMatch(/[.!?]\n\n/)
 })
 
-test('formatCallKentTranscriptWithWorkersAi repairs a long Kent wall of text when the model is a no-op', async () => {
+test('formatCallKentTranscriptWithWorkersAi prompts for paragraph breaks in long single-speaker sections', async () => {
 	using _env = setEnv({
 		CLOUDFLARE_API_TOKEN: 'MOCK_CLOUDFLARE_API_TOKEN',
 		CLOUDFLARE_ACCOUNT_ID: 'mock-account',
@@ -92,17 +92,7 @@ test('formatCallKentTranscriptWithWorkersAi repairs a long Kent wall of text whe
 		CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL: '@cf/meta/llama-3.1-8b-instruct',
 	})
 
-	const transcript = `
-Announcer: Intro line.
-
----
-
-Kent: First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence.
-
----
-
-Announcer: Outro line.
-`.trim()
+	const transcript = `Kent: First sentence. Second sentence. Third sentence. Fourth sentence.`
 
 	const fetchSpy = vi
 		.spyOn(globalThis, 'fetch')
@@ -117,9 +107,20 @@ Announcer: Outro line.
 
 	try {
 		const formatted = await formatCallKentTranscriptWithWorkersAi({ transcript })
-		expect(formatted).toContain('---')
-		expect(formatted).toContain(
-			'Kent: First sentence. Second sentence. Third sentence.\n\nFourth sentence. Fifth sentence. Sixth sentence.',
+		expect(formatted).toBe(transcript)
+
+		const request = fetchSpy.mock.calls[0]?.[1]
+		expect(request).toBeDefined()
+		expect(request?.body).toBeTypeOf('string')
+
+		const body = JSON.parse(String(request?.body)) as {
+			messages: Array<{ role: string; content: string }>
+		}
+		expect(body.messages[0]?.content).toContain(
+			'For long single-speaker sections, insert paragraph breaks every few sentences or at clear topic shifts.',
+		)
+		expect(body.messages[0]?.content).not.toContain(
+			"(especially Kent's response)",
 		)
 	} finally {
 		fetchSpy.mockRestore()

--- a/app/utils/__tests__/call-kent-transcript-format.server.test.ts
+++ b/app/utils/__tests__/call-kent-transcript-format.server.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { formatCallKentTranscriptWithWorkersAi } from '#app/utils/cloudflare-ai-call-kent-transcript-format.server.ts'
 import { setEnv } from '#tests/env-disposable.ts'
 
@@ -81,4 +81,47 @@ test('formatCallKentTranscriptWithWorkersAi does not truncate long transcripts',
 	expect(formatted).toContain('Kent:')
 	expect(formatted).toContain('Sentence 600.')
 	expect(formatted).toMatch(/[.!?]\n\n/)
+})
+
+test('formatCallKentTranscriptWithWorkersAi repairs a long Kent wall of text when the model is a no-op', async () => {
+	using _env = setEnv({
+		CLOUDFLARE_API_TOKEN: 'MOCK_CLOUDFLARE_API_TOKEN',
+		CLOUDFLARE_ACCOUNT_ID: 'mock-account',
+		CLOUDFLARE_AI_GATEWAY_ID: 'mock-gateway',
+		CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN: 'MOCK_CLOUDFLARE_AI_GATEWAY_AUTH_TOKEN',
+		CLOUDFLARE_AI_CALL_KENT_TRANSCRIPT_FORMAT_MODEL: '@cf/meta/llama-3.1-8b-instruct',
+	})
+
+	const transcript = `
+Announcer: Intro line.
+
+---
+
+Kent: First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence.
+
+---
+
+Announcer: Outro line.
+`.trim()
+
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				result: {
+					response: transcript,
+				},
+			}),
+		} as Response)
+
+	try {
+		const formatted = await formatCallKentTranscriptWithWorkersAi({ transcript })
+		expect(formatted).toContain('---')
+		expect(formatted).toContain(
+			'Kent: First sentence. Second sentence. Third sentence.\n\nFourth sentence. Fifth sentence. Sixth sentence.',
+		)
+	} finally {
+		fetchSpy.mockRestore()
+	}
 })

--- a/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
+++ b/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
@@ -52,124 +52,6 @@ function countSeparatorLines(text: string) {
 	return (text.match(/^---$/gm) ?? []).length
 }
 
-function normalizeLineEndings(text: string) {
-	return text.replace(/\r\n?/g, '\n')
-}
-
-function normalizeWhitespace(text: string) {
-	return text.trim().replace(/\s+/g, ' ')
-}
-
-function splitIntoSentenceLikeChunks(text: string) {
-	const matches = text.match(/.+?(?:[.!?]+(?=\s+|$)|$)/g) ?? []
-	return matches.map((chunk) => normalizeWhitespace(chunk)).filter(Boolean)
-}
-
-function splitIntoWordParagraphs(text: string, wordsPerParagraph = 55) {
-	const words = normalizeWhitespace(text).split(' ').filter(Boolean)
-	if (words.length <= wordsPerParagraph) return [words.join(' ')]
-
-	const paragraphs: Array<string> = []
-	for (let index = 0; index < words.length; index += wordsPerParagraph) {
-		paragraphs.push(words.slice(index, index + wordsPerParagraph).join(' '))
-	}
-	return paragraphs
-}
-
-function groupSentenceChunksIntoParagraphs(
-	chunks: Array<string>,
-	{
-		maxSentencesPerParagraph = 3,
-		maxParagraphLength = 260,
-	}: {
-		maxSentencesPerParagraph?: number
-		maxParagraphLength?: number
-	} = {},
-) {
-	const paragraphs: Array<string> = []
-	let currentChunks: Array<string> = []
-
-	function flushCurrentParagraph() {
-		if (!currentChunks.length) return
-		paragraphs.push(currentChunks.join(' ').trim())
-		currentChunks = []
-	}
-
-	for (const chunk of chunks) {
-		const candidate = [...currentChunks, chunk].join(' ').trim()
-		const shouldFlush =
-			currentChunks.length > 0 &&
-			(currentChunks.length >= maxSentencesPerParagraph ||
-				candidate.length > maxParagraphLength)
-		if (shouldFlush) flushCurrentParagraph()
-		currentChunks.push(chunk)
-	}
-
-	flushCurrentParagraph()
-	return paragraphs.filter(Boolean)
-}
-
-function formatTranscriptBlock(block: string) {
-	const trimmed = block.trim()
-	if (!trimmed) return ''
-
-	const speakerMatch = /^(?<label>[^:\n]{1,60}:)\s*(?<body>[\s\S]*)$/u.exec(trimmed)
-	const label = speakerMatch?.groups?.label?.trim() ?? null
-	const rawBody = speakerMatch?.groups?.body ?? trimmed
-	const existingParagraphs = normalizeLineEndings(rawBody)
-		.split(/\n{2,}/)
-		.map((paragraph) => normalizeWhitespace(paragraph))
-		.filter(Boolean)
-
-	let paragraphs: Array<string>
-	if (existingParagraphs.length >= 2) {
-		paragraphs = existingParagraphs
-	} else {
-		const normalizedBody = normalizeWhitespace(rawBody)
-		const sentenceChunks = splitIntoSentenceLikeChunks(normalizedBody)
-		paragraphs =
-			sentenceChunks.length >= 2
-				? groupSentenceChunksIntoParagraphs(sentenceChunks)
-				: splitIntoWordParagraphs(normalizedBody)
-	}
-
-	if (!paragraphs.length) return label ? label : ''
-	if (!label) return paragraphs.join('\n\n')
-	return `${label} ${paragraphs[0]}${paragraphs
-		.slice(1)
-		.map((paragraph) => `\n\n${paragraph}`)
-		.join('')}`.trim()
-}
-
-function applyDeterministicTranscriptFormatting(text: string) {
-	const normalized = normalizeLineEndings(text).trim()
-	if (!normalized) return normalized
-
-	const lines = normalized.split('\n')
-	const blocks: Array<string> = []
-	let currentLines: Array<string> = []
-
-	function flushCurrentBlock() {
-		if (!currentLines.length) return
-		const block = currentLines.join('\n').trim()
-		if (block) blocks.push(formatTranscriptBlock(block))
-		currentLines = []
-	}
-
-	for (const line of lines) {
-		if (line.trim() === '---') {
-			flushCurrentBlock()
-			blocks.push('---')
-			continue
-		}
-		currentLines.push(line)
-	}
-
-	flushCurrentBlock()
-
-	return blocks.filter(Boolean).join('\n\n').trim()
-}
-
 export async function formatCallKentTranscriptWithWorkersAi({
 	transcript,
 	callTitle,
@@ -212,7 +94,7 @@ You format transcripts for the "Call Kent Podcast", hosted by Kent C. Dodds.
 Your job is to improve readability by inserting paragraph breaks (blank lines) and normalizing whitespace.
 Do NOT add, remove, or reorder any words. Do NOT change speaker labels.
 Keep speaker turns in the same order and never merge one speaker's turn into another.
-For long single-speaker sections (especially Kent's response), insert paragraph breaks every few sentences or at clear topic shifts.
+For long single-speaker sections, insert paragraph breaks every few sentences or at clear topic shifts.
 
 If the transcript includes separator lines containing only "---", keep those lines exactly as-is and on their own line.
 
@@ -288,8 +170,6 @@ ${endMarker}
 	if (!formatted) {
 		throw new Error('Transcript formatter returned an empty transcript.')
 	}
-
-	formatted = applyDeterministicTranscriptFormatting(formatted)
 
 	const originalSepCount = countSeparatorLines(input)
 	if (originalSepCount > 0) {

--- a/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
+++ b/app/utils/cloudflare-ai-call-kent-transcript-format.server.ts
@@ -52,6 +52,124 @@ function countSeparatorLines(text: string) {
 	return (text.match(/^---$/gm) ?? []).length
 }
 
+function normalizeLineEndings(text: string) {
+	return text.replace(/\r\n?/g, '\n')
+}
+
+function normalizeWhitespace(text: string) {
+	return text.trim().replace(/\s+/g, ' ')
+}
+
+function splitIntoSentenceLikeChunks(text: string) {
+	const matches = text.match(/.+?(?:[.!?]+(?=\s+|$)|$)/g) ?? []
+	return matches.map((chunk) => normalizeWhitespace(chunk)).filter(Boolean)
+}
+
+function splitIntoWordParagraphs(text: string, wordsPerParagraph = 55) {
+	const words = normalizeWhitespace(text).split(' ').filter(Boolean)
+	if (words.length <= wordsPerParagraph) return [words.join(' ')]
+
+	const paragraphs: Array<string> = []
+	for (let index = 0; index < words.length; index += wordsPerParagraph) {
+		paragraphs.push(words.slice(index, index + wordsPerParagraph).join(' '))
+	}
+	return paragraphs
+}
+
+function groupSentenceChunksIntoParagraphs(
+	chunks: Array<string>,
+	{
+		maxSentencesPerParagraph = 3,
+		maxParagraphLength = 260,
+	}: {
+		maxSentencesPerParagraph?: number
+		maxParagraphLength?: number
+	} = {},
+) {
+	const paragraphs: Array<string> = []
+	let currentChunks: Array<string> = []
+
+	function flushCurrentParagraph() {
+		if (!currentChunks.length) return
+		paragraphs.push(currentChunks.join(' ').trim())
+		currentChunks = []
+	}
+
+	for (const chunk of chunks) {
+		const candidate = [...currentChunks, chunk].join(' ').trim()
+		const shouldFlush =
+			currentChunks.length > 0 &&
+			(currentChunks.length >= maxSentencesPerParagraph ||
+				candidate.length > maxParagraphLength)
+		if (shouldFlush) flushCurrentParagraph()
+		currentChunks.push(chunk)
+	}
+
+	flushCurrentParagraph()
+	return paragraphs.filter(Boolean)
+}
+
+function formatTranscriptBlock(block: string) {
+	const trimmed = block.trim()
+	if (!trimmed) return ''
+
+	const speakerMatch = /^(?<label>[^:\n]{1,60}:)\s*(?<body>[\s\S]*)$/u.exec(trimmed)
+	const label = speakerMatch?.groups?.label?.trim() ?? null
+	const rawBody = speakerMatch?.groups?.body ?? trimmed
+	const existingParagraphs = normalizeLineEndings(rawBody)
+		.split(/\n{2,}/)
+		.map((paragraph) => normalizeWhitespace(paragraph))
+		.filter(Boolean)
+
+	let paragraphs: Array<string>
+	if (existingParagraphs.length >= 2) {
+		paragraphs = existingParagraphs
+	} else {
+		const normalizedBody = normalizeWhitespace(rawBody)
+		const sentenceChunks = splitIntoSentenceLikeChunks(normalizedBody)
+		paragraphs =
+			sentenceChunks.length >= 2
+				? groupSentenceChunksIntoParagraphs(sentenceChunks)
+				: splitIntoWordParagraphs(normalizedBody)
+	}
+
+	if (!paragraphs.length) return label ? label : ''
+	if (!label) return paragraphs.join('\n\n')
+	return `${label} ${paragraphs[0]}${paragraphs
+		.slice(1)
+		.map((paragraph) => `\n\n${paragraph}`)
+		.join('')}`.trim()
+}
+
+function applyDeterministicTranscriptFormatting(text: string) {
+	const normalized = normalizeLineEndings(text).trim()
+	if (!normalized) return normalized
+
+	const lines = normalized.split('\n')
+	const blocks: Array<string> = []
+	let currentLines: Array<string> = []
+
+	function flushCurrentBlock() {
+		if (!currentLines.length) return
+		const block = currentLines.join('\n').trim()
+		if (block) blocks.push(formatTranscriptBlock(block))
+		currentLines = []
+	}
+
+	for (const line of lines) {
+		if (line.trim() === '---') {
+			flushCurrentBlock()
+			blocks.push('---')
+			continue
+		}
+		currentLines.push(line)
+	}
+
+	flushCurrentBlock()
+
+	return blocks.filter(Boolean).join('\n\n').trim()
+}
+
 export async function formatCallKentTranscriptWithWorkersAi({
 	transcript,
 	callTitle,
@@ -93,6 +211,8 @@ You format transcripts for the "Call Kent Podcast", hosted by Kent C. Dodds.
 
 Your job is to improve readability by inserting paragraph breaks (blank lines) and normalizing whitespace.
 Do NOT add, remove, or reorder any words. Do NOT change speaker labels.
+Keep speaker turns in the same order and never merge one speaker's turn into another.
+For long single-speaker sections (especially Kent's response), insert paragraph breaks every few sentences or at clear topic shifts.
 
 If the transcript includes separator lines containing only "---", keep those lines exactly as-is and on their own line.
 
@@ -168,6 +288,8 @@ ${endMarker}
 	if (!formatted) {
 		throw new Error('Transcript formatter returned an empty transcript.')
 	}
+
+	formatted = applyDeterministicTranscriptFormatting(formatted)
 
 	const originalSepCount = countSeparatorLines(input)
 	if (originalSepCount > 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Strengthen the Call Kent transcript formatting prompt and add deterministic post-formatting to prevent long speaker blocks from appearing as a wall of text.

The existing Workers AI formatting pass could sometimes return the input transcript largely unchanged, especially for long `Kent:` segments. This resulted in unformatted, dense text being saved and displayed in the admin UI, making it hard to read. This PR enhances the prompt and adds a post-processing step to ensure proper paragraph breaks, even if the AI model doesn't fully reformat the text.

---
<p><a href="https://cursor.com/agents/bc-1129f6d7-8f1c-410e-8c66-dbbf3bb5c2a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1129f6d7-8f1c-410e-8c66-dbbf3bb5c2a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript formatting to maintain proper speaker turn order throughout the document.
  * Long single-speaker sections now include automatic paragraph breaks for enhanced readability.

* **Tests**
  * Added test coverage for transcript formatting with extended single-speaker section handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->