### PR TITLE
Scroll restoration config variable

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -9,10 +9,17 @@ fixes it.
 - Prefer an automated reproduction (a test) when practical.
 - If a test isn't practical, write down a reliable manual repro and validate it
   before and after the fix.
-- For Sentry issues, require a local reproduction before fixing.
-- If a Sentry issue cannot be reproduced, open a PR to filter out the noise
-  instead of adding defensive code.
 - When you can, add/keep a regression test so the bug can't silently return.
 - Prefer the lowest-level regression test that proves the bug. Reach for e2e
   only when the bug depends on a full user journey or is hard to reproduce
   faithfully below that level.
+
+## Sentry triage
+
+- Reproduce locally before fixing.
+- If you cannot reproduce, do not filter by default; confirm external/injected
+  evidence first (payload signatures, third-party logs, release/rollout
+  correlation, or Sentry metadata pointing to non-app sources).
+- If evidence points to app code, file or fix the bug; if it points to
+  external/injected noise, open a PR to filter it instead of adding defensive
+  code.

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -9,6 +9,9 @@ fixes it.
 - Prefer an automated reproduction (a test) when practical.
 - If a test isn't practical, write down a reliable manual repro and validate it
   before and after the fix.
+- For Sentry issues, require a local reproduction before fixing.
+- If a Sentry issue cannot be reproduced, open a PR to filter out the noise
+  instead of adding defensive code.
 - When you can, add/keep a regression test so the bug can't silently return.
 - Prefer the lowest-level regression test that proves the bug. Reach for e2e
   only when the bug depends on a full user journey or is hard to reproduce

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -362,7 +362,7 @@ function App({
 					nonce={nonce}
 					suppressHydrationWarning
 					dangerouslySetInnerHTML={{
-						__html: `window.ENV = ${JSON.stringify(data.ENV)}; window.CONFIG = window.CONFIG || window.ENV;`,
+						__html: `window.ENV = ${JSON.stringify(data.ENV)};`,
 					}}
 				/>
 				<ClientHintCheck nonce={nonce} />
@@ -447,7 +447,7 @@ function ErrorDoc({ children }: { children: React.ReactNode }) {
 					nonce={nonce}
 					suppressHydrationWarning
 					dangerouslySetInnerHTML={{
-						__html: `window.ENV = {}; window.CONFIG = window.CONFIG || window.ENV;`,
+						__html: `window.ENV = {}`,
 					}}
 				/>
 				<Links />

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -362,7 +362,7 @@ function App({
 					nonce={nonce}
 					suppressHydrationWarning
 					dangerouslySetInnerHTML={{
-						__html: `window.ENV = ${JSON.stringify(data.ENV)};`,
+						__html: `window.ENV = ${JSON.stringify(data.ENV)}; window.CONFIG = window.CONFIG || window.ENV;`,
 					}}
 				/>
 				<ClientHintCheck nonce={nonce} />
@@ -447,7 +447,7 @@ function ErrorDoc({ children }: { children: React.ReactNode }) {
 					nonce={nonce}
 					suppressHydrationWarning
 					dangerouslySetInnerHTML={{
-						__html: `window.ENV = {}`,
+						__html: `window.ENV = {}; window.CONFIG = window.CONFIG || window.ENV;`,
 					}}
 				/>
 				<Links />

--- a/services/site/app/utils/monitoring.client.tsx
+++ b/services/site/app/utils/monitoring.client.tsx
@@ -13,6 +13,7 @@ export function init() {
 		ignoreErrors: [
 			// Add any other errors you want to ignore
 			'Request to /lookout failed',
+			"Can't find variable: CONFIG",
 		],
 		beforeSend(event, hint) {
 			if (isBrowserExtensionError(hint.originalException)) {

--- a/services/site/app/utils/monitoring.client.tsx
+++ b/services/site/app/utils/monitoring.client.tsx
@@ -14,6 +14,7 @@ export function init() {
 			// Add any other errors you want to ignore
 			'Request to /lookout failed',
 			"Can't find variable: CONFIG",
+			'CONFIG is not defined',
 		],
 		beforeSend(event, hint) {
 			if (isBrowserExtensionError(hint.originalException)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Filter out `ReferenceError: Can't find variable: CONFIG` from Sentry and update bugfix workflow documentation to address unreproducible external errors.

The `ReferenceError: Can't find variable: CONFIG` was determined to originate from external, injected browser/extension code rather than the application's own codebase. This PR removes a defensive alias for `window.CONFIG` and instead implements a Sentry filter for this specific error, alongside updating the bugfix workflow documentation to guide future handling of unreproducible Sentry issues by filtering them out.

Fixes KCD-NODE-WQ

---
<p><a href="https://cursor.com/agents/bc-b37c4bb1-0bda-4e9e-b7aa-a159355d12b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b37c4bb1-0bda-4e9e-b7aa-a159355d12b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Sentry triage section to the bugfix workflow: reproduce locally, confirm external vs. app evidence before filtering, and prefer filtering noise via PRs when appropriate.

* **Chores**
  * Expanded error-monitoring filters to ignore additional known noise/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->