### PR TITLE
Cash Kent episode 501 error

### DIFF
--- a/services/call-kent-audio-worker/src/call-kent-audio-sandbox.test.ts
+++ b/services/call-kent-audio-worker/src/call-kent-audio-sandbox.test.ts
@@ -150,3 +150,46 @@ test('runCallKentAudioSandboxJob retries transient sandbox startup errors', asyn
 		responseSegmentAudioSize: 61,
 	})
 })
+
+test('runCallKentAudioSandboxJob retries transient 501 session creation errors', async () => {
+	const exec = vi
+		.fn()
+		.mockRejectedValueOnce(
+			new Error('Failed to create session: 501 Not Implemented'),
+		)
+		.mockResolvedValue({
+			success: true,
+			stdout:
+				'{"episodeAudioSize":101,"callerSegmentAudioSize":51,"responseSegmentAudioSize":61}',
+			stderr: '',
+			exitCode: 0,
+		})
+	const destroy = vi.fn().mockResolvedValue(undefined)
+	const sleepImpl = vi.fn().mockResolvedValue(undefined)
+	const getSandboxImpl = vi.fn().mockReturnValue({ exec, destroy })
+
+	const result = await runCallKentAudioSandboxJob({
+		binding: {} as never,
+		sandboxId: 'sandbox-1',
+		request: {
+			draftId: 'draft-123',
+			attempt: 2,
+			callAudioUrl: 'https://example.com/call',
+			responseAudioUrl: 'https://example.com/response',
+			episodeUploadUrl: 'https://example.com/episode',
+			callerSegmentUploadUrl: 'https://example.com/caller',
+			responseSegmentUploadUrl: 'https://example.com/response-segment',
+		},
+		getSandboxImpl: getSandboxImpl as never,
+		sleepImpl,
+	})
+
+	expect(exec).toHaveBeenCalledTimes(2)
+	expect(sleepImpl).toHaveBeenCalledTimes(1)
+	expect(destroy).toHaveBeenCalledTimes(1)
+	expect(result).toEqual({
+		episodeAudioSize: 101,
+		callerSegmentAudioSize: 51,
+		responseSegmentAudioSize: 61,
+	})
+})

--- a/services/call-kent-audio-worker/src/call-kent-audio-sandbox.ts
+++ b/services/call-kent-audio-worker/src/call-kent-audio-sandbox.ts
@@ -2,8 +2,19 @@ import { getSandbox, type Sandbox as SandboxBinding } from '@cloudflare/sandbox'
 import { z } from 'zod'
 
 const sandboxExecTimeoutMs = 30 * 60_000
-const sandboxStartupRetryCount = 5
+const sandboxStartupRetryCount = 10
 const sandboxStartupRetryDelayMs = 2_000
+
+const retryableSandboxStartupSubstrings = [
+	'container is starting',
+	'container not ready',
+	'operation was aborted',
+	'not listening in the tcp address',
+	'please retry in a moment',
+	'failed to create session',
+	'connection refused: container port not found',
+	'port ready timeout',
+]
 
 const sandboxExecResponseSchema = z.object({
 	episodeAudioSize: z.number().int().positive(),
@@ -40,16 +51,31 @@ function sleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
-function isRetryableSandboxStartupError(error: unknown) {
+export function isRetryableSandboxStartupError(error: unknown) {
 	if (!(error instanceof Error)) return false
 	const message = error.message.toLowerCase()
-	return (
-		message.includes('container is starting') ||
-		message.includes('container not ready') ||
-		message.includes('operation was aborted') ||
-		message.includes('not listening in the tcp address') ||
-		message.includes('please retry in a moment')
-	)
+	if (
+		retryableSandboxStartupSubstrings.some((substring) =>
+			message.includes(substring),
+		)
+	) {
+		return true
+	}
+	const mentionsTransientStatusCode =
+		message.includes('500') ||
+		message.includes('501') ||
+		message.includes('502') ||
+		message.includes('503') ||
+		message.includes('504')
+	const mentionsSandboxStartup =
+		(message.includes('sandbox') ||
+			message.includes('container') ||
+			message.includes('session')) &&
+		(message.includes('start') ||
+			message.includes('ready') ||
+			message.includes('create') ||
+			message.includes('port'))
+	return mentionsTransientStatusCode && mentionsSandboxStartup
 }
 
 function getErrorMessage(error: unknown) {

--- a/services/call-kent-audio-worker/src/index.test.ts
+++ b/services/call-kent-audio-worker/src/index.test.ts
@@ -152,6 +152,61 @@ test('handleQueueBatch retries failed sandbox jobs after sending a failed callba
 	)
 })
 
+test('handleQueueBatch retries transient sandbox startup errors without sending a failed callback', async () => {
+	const ack = vi.fn()
+	const retry = vi.fn()
+	const sendCallback = vi.fn().mockResolvedValue(undefined)
+	const createSignedUrls = vi.fn().mockResolvedValue({
+		callAudioUrl: 'https://example.com/call',
+		responseAudioUrl: 'https://example.com/response',
+		episodeAudioKey: 'call-kent/drafts/draft-1/episode.mp3',
+		episodeUploadUrl: 'https://example.com/episode',
+		callerSegmentAudioKey: 'call-kent/drafts/draft-1/caller-segment.mp3',
+		callerSegmentUploadUrl: 'https://example.com/caller',
+		responseSegmentAudioKey: 'call-kent/drafts/draft-1/response-segment.mp3',
+		responseSegmentUploadUrl: 'https://example.com/response-segment',
+	})
+	const runSandboxJob = vi
+		.fn()
+		.mockRejectedValue(
+			new Error('Failed to create session: 501 Not Implemented'),
+		)
+
+	await handleQueueBatch({
+		batch: {
+			messages: [
+				{
+					body: {
+						draftId: 'draft-1',
+						callAudioKey: 'call-kent/calls/call-1/call.webm',
+						responseAudioKey: 'call-kent/drafts/draft-1/response.webm',
+					},
+					attempts: 1,
+					ack,
+					retry,
+				},
+			],
+		},
+		env: createEnv(),
+		sendCallback,
+		createSignedUrls,
+		runSandboxJob,
+	})
+
+	expect(ack).not.toHaveBeenCalled()
+	expect(retry).toHaveBeenCalledTimes(1)
+	expect(sendCallback).toHaveBeenCalledTimes(1)
+	expect(sendCallback).toHaveBeenCalledWith(
+		expect.objectContaining({
+			event: {
+				type: 'audio_generation_started',
+				draftId: 'draft-1',
+				attempt: 1,
+			},
+		}),
+	)
+})
+
 test('handleQueueBatch retries invalid messages without attempting callbacks', async () => {
 	const ack = vi.fn()
 	const retry = vi.fn()

--- a/services/call-kent-audio-worker/src/index.ts
+++ b/services/call-kent-audio-worker/src/index.ts
@@ -3,7 +3,10 @@ import {
 	sendCallKentAudioProcessorCallback,
 } from './call-kent-audio-callback'
 import { createSignedEpisodeAudioUrls } from './call-kent-audio-r2'
-import { runCallKentAudioSandboxJob } from './call-kent-audio-sandbox'
+import {
+	isRetryableSandboxStartupError,
+	runCallKentAudioSandboxJob,
+} from './call-kent-audio-sandbox'
 import { type Env } from './env'
 
 export { Sandbox } from '@cloudflare/sandbox'
@@ -116,7 +119,7 @@ export async function processMessage({
 		return { draftId: parsed.draftId, attempt }
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)
-		if (draftId) {
+		if (draftId && !isRetryableSandboxStartupError(error)) {
 			await sendCallback({
 				callbackUrl: env.CALL_KENT_AUDIO_CALLBACK_URL,
 				callbackSecret: env.CALL_KENT_AUDIO_CALLBACK_SECRET,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Broaden Cloudflare worker sandbox retry logic and increase retry attempts to fix transient 501 errors during audio generation.

The 501 errors were identified as transient Cloudflare worker sandbox startup failures, specifically "Failed to create session: 501 Not Implemented". Previously, these were treated as terminal errors, causing the audio generation to fail immediately instead of retrying. This change allows the worker to recover from these temporary issues.

<div><a href="https://cursor.com/agents/bc-3547c2cb-f09e-4258-8926-f2e380dbf819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3547c2cb-f09e-4258-8926-f2e380dbf819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->