### PR TITLE
Always install Playwright browsers in CI

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -60,7 +60,8 @@ jobs:
             playwright-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
       - name: 🌐 Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        # Always validate/install Chromium even on cache hit so stale or partial
+        # caches do not break browser-mode tests in `ci:verify`.
         run: npm run test:e2e:install --workspace kentcdodds.com
 
       - name: 🔬 Verify site
@@ -154,7 +155,8 @@ jobs:
         uses: FedericoCarboni/setup-ffmpeg@v3
 
       - name: 🌐 Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        # Always validate/install Chromium even on cache hit so stale or partial
+        # caches do not break the Playwright job.
         run: npm run test:e2e:install --workspace kentcdodds.com
 
       - name: 📦 Download site build artifacts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- always run the Playwright browser install step in the site verify job
- always run the Playwright browser install step in the Playwright job
- keep the cache, but stop treating a cache hit as proof that Chromium is usable

## Testing
- cp services/site/.env.example services/site/.env
- npm run test:e2e:install --workspace kentcdodds.com
- npm run ci:verify --workspace=kentcdodds.com
- cd services/site && npx prisma migrate reset --force
- npm run prime-cache:mocks --workspace kentcdodds.com
- cd services/site && CI=1 PORT=8811 npx playwright test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f7e826-edd7-4a2d-bfbc-c10cc1503c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f7e826-edd7-4a2d-bfbc-c10cc1503c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

