### PR TITLE
fix(lexical-search): declare required secrets and improve sync workflow error handling

### DIFF
--- a/.github/workflows/sync-lexical-search-worker.yml
+++ b/.github/workflows/sync-lexical-search-worker.yml
@@ -7,6 +7,11 @@ on:
         required: false
         type: boolean
         default: true
+    secrets:
+      LEXICAL_SEARCH_WORKER_URL:
+        required: true
+      LEXICAL_SEARCH_WORKER_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       force:
@@ -27,9 +32,17 @@ jobs:
           FORCE_SYNC: ${{ inputs.force }}
         run: |
           set -euo pipefail
-          curl --fail --show-error --silent \
+          response=$(curl -s -w "\n%{http_code}" --max-time 300 \
             -X POST \
             -H "Authorization: Bearer ${LEXICAL_SEARCH_WORKER_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{\"force\": ${FORCE_SYNC}}" \
-            "${LEXICAL_SEARCH_WORKER_URL}/admin/sync"
+            "${LEXICAL_SEARCH_WORKER_URL}/admin/sync")
+          http_code=$(echo "$response" | tail -1)
+          body=$(echo "$response" | sed '$d')
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Lexical sync failed (HTTP $http_code):"
+            echo "$body"
+            exit 1
+          fi
+          echo "Sync succeeded: $body"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes lexical search job failures by addressing two potential causes:

### 1. Explicit secrets declaration for reusable workflow

The sync workflow is invoked from `index-semantic-content`, `index-semantic-youtube`, and `index-semantic-podcasts` via `workflow_call`. When reusable workflows declare required secrets in `on.workflow_call.secrets`, GitHub Actions ensures they are properly passed from the caller. Without this declaration, some environments (e.g. scheduled runs) may not pass `LEXICAL_SEARCH_WORKER_URL` and `LEXICAL_SEARCH_WORKER_TOKEN` correctly.

### 2. Improved error handling and debugging

- **Response capture**: Replaced `curl --fail --silent` with explicit response capture so that when the Worker returns 4xx/5xx, the full response body is printed in the workflow logs
- **Timeout**: Added `--max-time 300` (5 minutes) to prevent indefinite hangs if the Worker is slow or unresponsive

### Verification

- Lexical search worker tests pass (`npm run test --workspace lexical-search-worker`)
- Parent workflows (`index-semantic-*`) already use `secrets: inherit`, so they will pass the required secrets to the sync workflow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-832eae40-fcba-457d-b48d-da0ee88d3eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-832eae40-fcba-457d-b48d-da0ee88d3eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling and status reporting in the synchronization workflow.
  * Updated workflow configuration to require additional authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->