### PR TITLE
fix: add -S to curl so connection errors produce diagnostic output

### DIFF
--- a/.github/workflows/sync-lexical-search-worker.yml
+++ b/.github/workflows/sync-lexical-search-worker.yml
@@ -32,7 +32,7 @@ jobs:
           FORCE_SYNC: ${{ inputs.force }}
         run: |
           set -euo pipefail
-          response=$(curl -s -w "\n%{http_code}" --max-time 300 \
+          response=$(curl -sS -w "\n%{http_code}" --max-time 300 \
             -X POST \
             -H "Authorization: Bearer ${LEXICAL_SEARCH_WORKER_TOKEN}" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The curl invocation in the sync-lexical-search-worker workflow used only `-s` (silent), which suppresses all output including curl-level error messages. When connection-level failures occur (DNS failure, connection refused, timeout from `--max-time 300`), the script exits immediately due to `set -e` before the custom HTTP-status error handling runs, producing zero diagnostic output.

## Change

Use `-sS` instead of `-s`:
- `-s` (silent): suppresses the progress meter
- `-S` (--show-error): shows curl error messages when curl fails

This restores the intended debugging experience so connection failures surface useful diagnostics instead of failing silently.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b80739fd-207d-4bfc-b6f9-3f137643fe7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b80739fd-207d-4bfc-b6f9-3f137643fe7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

