### PR TITLE
fix(search): escape unsafe FTS terms

### DIFF
--- a/services/search-worker/src/search-db.test.ts
+++ b/services/search-worker/src/search-db.test.ts
@@ -100,3 +100,65 @@ test('queryLexicalSearch retries when D1 reports no such column', async () => {
 		},
 	])
 })
+
+test('queryLexicalSearch quotes uppercase OR tokens', async () => {
+	const { db, boundQueries } = createDb({
+		onAll: async () => ({
+			results: [
+				{
+					id: 'blog:or-token:chunk:0',
+					type: 'blog',
+					slug: 'or-token',
+					title: 'Literal OR token',
+					url: '/blog/or-token',
+					snippet: 'Contains the word OR as content',
+				},
+			],
+		}),
+	})
+
+	const results = await queryLexicalSearch({
+		db,
+		query: 'OR',
+		topK: 5,
+	})
+
+	expect(boundQueries).toEqual([
+		{
+			candidateQuery: '"OR"',
+			topK: 5,
+		},
+	])
+	expect(results[0]?.id).toBe('blog:or-token:chunk:0')
+})
+
+test('queryLexicalSearch quotes uppercase NEAR tokens', async () => {
+	const { db, boundQueries } = createDb({
+		onAll: async () => ({
+			results: [
+				{
+					id: 'blog:near-token:chunk:0',
+					type: 'blog',
+					slug: 'near-token',
+					title: 'Literal NEAR token',
+					url: '/blog/near-token',
+					snippet: 'Contains the word NEAR as content',
+				},
+			],
+		}),
+	})
+
+	const results = await queryLexicalSearch({
+		db,
+		query: 'NEAR',
+		topK: 5,
+	})
+
+	expect(boundQueries).toEqual([
+		{
+			candidateQuery: '"NEAR"',
+			topK: 5,
+		},
+	])
+	expect(results[0]?.id).toBe('blog:near-token:chunk:0')
+})

--- a/services/search-worker/src/search-db.test.ts
+++ b/services/search-worker/src/search-db.test.ts
@@ -1,0 +1,102 @@
+import { expect, test, vi } from 'vitest'
+import { queryLexicalSearch } from './search-db'
+
+function createDb({
+	onAll,
+}: {
+	onAll: (
+		candidateQuery: string,
+		topK: number,
+	) => Promise<{ results?: Array<Record<string, unknown>> }>
+}) {
+	const boundQueries: Array<{ candidateQuery: string; topK: number }> = []
+
+	const db = {
+		prepare: vi.fn(() => ({
+			bind: vi.fn((candidateQuery: string, topK: number) => ({
+				all: vi.fn(async () => {
+					boundQueries.push({ candidateQuery, topK })
+					return await onAll(candidateQuery, topK)
+				}),
+			})),
+		})),
+	} as unknown as D1Database
+
+	return { db, boundQueries }
+}
+
+test('queryLexicalSearch quotes hyphenated date tokens for FTS', async () => {
+	const { db, boundQueries } = createDb({
+		onAll: async () => ({
+			results: [
+				{
+					id: 'youtube:office-hours:chunk:0',
+					type: 'youtube',
+					slug: 'office-hours',
+					title: 'KCD Office Hours',
+					url: '/youtube?video=office-hours',
+					snippet: 'Office hours recording',
+					startSeconds: 17,
+				},
+			],
+		}),
+	})
+
+	const results = await queryLexicalSearch({
+		db,
+		query: 'KCD Office Hours 2025-04-17',
+		topK: 5,
+	})
+
+	expect(boundQueries).toEqual([
+		{
+			candidateQuery: 'KCD OR Office OR Hours OR "2025-04-17"',
+			topK: 5,
+		},
+	])
+	expect(results).toEqual([
+		{
+			id: 'youtube:office-hours:chunk:0',
+			type: 'youtube',
+			slug: 'office-hours',
+			title: 'KCD Office Hours',
+			url: '/youtube?video=office-hours',
+			snippet: 'Office hours recording',
+			chunkIndex: undefined,
+			chunkCount: undefined,
+			startSeconds: 17,
+			endSeconds: undefined,
+			imageUrl: undefined,
+			imageAlt: undefined,
+		},
+	])
+})
+
+test('queryLexicalSearch retries when D1 reports no such column', async () => {
+	const { db, boundQueries } = createDb({
+		onAll: async () => {
+			if (boundQueries.length === 1) {
+				throw new Error('D1_ERROR: no such column: 04: SQLITE_ERROR')
+			}
+			return { results: [] }
+		},
+	})
+
+	const results = await queryLexicalSearch({
+		db,
+		query: 'KCD Office Hours 2025-04-17',
+		topK: 5,
+	})
+
+	expect(results).toEqual([])
+	expect(boundQueries).toEqual([
+		{
+			candidateQuery: 'KCD OR Office OR Hours OR "2025-04-17"',
+			topK: 5,
+		},
+		{
+			candidateQuery: 'KCD OR Office OR Hours OR "2025-04-17"',
+			topK: 5,
+		},
+	])
+})

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -130,17 +130,27 @@ function asNumber(value: unknown): number | undefined {
 	return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
+function toSafeFtsTerm(term: string) {
+	const trimmed = term.trim()
+	if (!trimmed) return null
+	if (/^[\p{L}\p{N}_]+$/u.test(trimmed)) return trimmed
+	return `"${trimmed.replace(/"/g, '""')}"`
+}
+
 function buildLexicalSearchMatchQuery(query: string) {
 	const terms: string[] = []
 	for (const match of query.matchAll(/"([^"]+)"|([\p{L}\p{N}_-]+)/gu)) {
 		const phrase = match[1]?.trim()
 		if (phrase) {
-			terms.push(`"${phrase.replace(/"/g, '""')}"`)
+			const safePhrase = toSafeFtsTerm(phrase)
+			if (safePhrase) terms.push(safePhrase)
 			continue
 		}
 
 		const token = match[2]?.trim()
-		if (token) terms.push(token)
+		if (!token) continue
+		const safeToken = toSafeFtsTerm(token)
+		if (safeToken) terms.push(safeToken)
 	}
 
 	if (!terms.length) return null
@@ -196,7 +206,9 @@ function buildDocRecords({
 
 function isFtsQuerySyntaxError(error: unknown) {
 	if (!(error instanceof Error)) return false
-	return /fts5|syntax error|malformed match|unterminated/i.test(error.message)
+	return /fts5|syntax error|malformed match|unterminated|no such column/i.test(
+		error.message,
+	)
 }
 
 async function runStatementsInTransaction({
@@ -452,6 +464,7 @@ export async function queryLexicalSearch({
 		const fallbackQuery = query
 			.split(/\s+/u)
 			.map((token) => token.replace(/[^\p{L}\p{N}_-]+/gu, '').trim())
+			.map((token) => toSafeFtsTerm(token))
 			.filter(Boolean)
 			.join(' OR ')
 		if (!fallbackQuery) return []

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -130,10 +130,16 @@ function asNumber(value: unknown): number | undefined {
 	return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
+function isReservedFtsOperator(term: string) {
+	return /^(AND|OR|NOT|NEAR)$/u.test(term)
+}
+
 function toSafeFtsTerm(term: string) {
 	const trimmed = term.trim()
 	if (!trimmed) return null
-	if (/^[\p{L}\p{N}_]+$/u.test(trimmed)) return trimmed
+	if (/^[\p{L}\p{N}_]+$/u.test(trimmed) && !isReservedFtsOperator(trimmed)) {
+		return trimmed
+	}
 	return `"${trimmed.replace(/"/g, '""')}"`
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- quote unsafe lexical FTS terms so date-like queries and reserved uppercase FTS operators are treated as literals instead of SQLite syntax
- treat D1 `no such column` parser errors as retryable FTS syntax failures
- add regression coverage for hyphenated date tokens plus `OR` and `NEAR` literal queries

## Verification
- verified the current code still emitted bare `OR`/`NEAR` tokens before this patch
- reproduced that bare `OR` fails in SQLite FTS with `fts5: syntax error near "OR"`
- confirmed the quoted form succeeds and the focused worker tests, typecheck, and lint all pass

## Testing
- `npm run test --workspace search-worker -- src/search-db.test.ts src/search-service.test.ts`
- `npm run typecheck --workspace search-worker`
- `npm run lint --workspace search-worker`
- `sqlite3 :memory:` repro showing bare `OR` fails while quoted `"OR"` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4982536-e3a8-4cdc-a8ae-eafc5aa47db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4982536-e3a8-4cdc-a8ae-eafc5aa47db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability by sanitizing search terms and broadening error handling so database errors are handled more gracefully and fallback searches are safer.

* **Refactor**
  * Centralized term normalization to ensure consistent behavior between primary and fallback search paths.

* **Tests**
  * Added unit tests covering query construction, result mapping, quoting behavior, and retry/fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->