### PR TITLE
fix: `semantic-release` shoutout link

### DIFF
--- a/services/site/content/blog/how-i-am-so-productive.mdx
+++ b/services/site/content/blog/how-i-am-so-productive.mdx
@@ -180,7 +180,7 @@ automation script that publishes to npm and generates a GitHub changelog. For
 years I've been using an awesome tool called
 [semantic-release](https://github.com/semantic-release/semantic-release)
 (shoutout to
-[the team of fantastic humans](https://github.com/semantic-release/semantic-release/blob/caribou/README.md#team))
+[the team of fantastic humans](https://github.com/semantic-release/semantic-release/?tab=readme-ov-file#team))
 to automatically release my packages.
 
 The concept of automation is something


### PR DESCRIPTION
Broken link fix in the [How I am so productive](https://kentcdodds.com/blog/how-i-am-so-productive) article, regarding the shoutout to the `semantic-release` package team.