### PR TITLE
Publish Call Kent Audio sandbox image to Docker Hub

### DIFF
--- a/.github/workflows/call-kent-audio-sandbox-image.yml
+++ b/.github/workflows/call-kent-audio-sandbox-image.yml
@@ -1,0 +1,45 @@
+name: Publish Call Kent Audio sandbox image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - services/call-kent-audio-worker/**
+      - .github/workflows/call-kent-audio-sandbox-image.yml
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract short SHA
+        id: vars
+        run: echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/call-kent-audio-worker
+          file: services/call-kent-audio-worker/sandbox.dockerfile
+          push: true
+          tags: |
+            docker.io/kentcdodds/kcd-call-kent-audio-sandbox:latest
+            docker.io/kentcdodds/kcd-call-kent-audio-sandbox:${{ steps.vars.outputs.sha_short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/services/call-kent-audio-worker/readme.md
+++ b/services/call-kent-audio-worker/readme.md
@@ -53,6 +53,18 @@ The sandbox image expects these files in `assets/`:
   need startup behavior, add a `CMD` instead and let the base image keep serving
   the sandbox control API.
 
+## Sandbox image publishing
+
+The sandbox image is built and pushed to Docker Hub by GitHub Actions whenever
+files under `services/call-kent-audio-worker/` change on `main`. The workflow
+publishes `docker.io/kentcdodds/kcd-call-kent-audio-sandbox:latest` and a
+short-SHA tag. `wrangler deploy` now pulls the pre-built image from Docker Hub
+instead of building it locally.
+
+To deploy a new sandbox image version, push the sandbox changes, wait for the
+GitHub Actions workflow to publish the image, then re-deploy the worker so the
+new image tag is pulled.
+
 Site development/tests still use the MSW Cloudflare mock instead of the real
 worker+sandbox path, and the sandbox CLI tests generate temporary fixture
 assets at runtime.

--- a/services/call-kent-audio-worker/sandbox.dockerfile
+++ b/services/call-kent-audio-worker/sandbox.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.7.16
+FROM docker.io/cloudflare/sandbox:0.7.18
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ffmpeg \

--- a/services/call-kent-audio-worker/wrangler.jsonc
+++ b/services/call-kent-audio-worker/wrangler.jsonc
@@ -21,7 +21,7 @@
 	"containers": [
 		{
 			"class_name": "Sandbox",
-			"image": "./sandbox.dockerfile",
+			"image": "docker.io/kentcdodds/kcd-call-kent-audio-sandbox:latest",
 			"instance_type": "standard-1",
 			"max_instances": 3,
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump the sandbox base image to 0.7.18
- publish the sandbox image to Docker Hub via GitHub Actions
- switch wrangler to pull the Docker Hub image and document the flow

## Testing
- not run (docs/config/workflow-only changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6ef2b6e-f881-44ed-ae79-ed4b19fcae58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6ef2b6e-f881-44ed-ae79-ed4b19fcae58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

