### PR TITLE
Add one-time season 7 promotification

### DIFF
--- a/services/site/app/components/button.tsx
+++ b/services/site/app/components/button.tsx
@@ -98,13 +98,16 @@ function LinkButton({
 function ButtonLink({
 	children,
 	variant = 'primary',
+	size = 'large',
 	className,
 	ref,
 	...rest
 }: React.ComponentPropsWithRef<typeof AnchorOrLink> & ButtonProps) {
 	return (
 		<AnchorOrLink ref={ref} className={getClassName({ className })} {...rest}>
-			<ButtonInner variant={variant}>{children}</ButtonInner>
+			<ButtonInner variant={variant} size={size}>
+				{children}
+			</ButtonInner>
 		</AnchorOrLink>
 	)
 }

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -30,11 +30,16 @@ import {
 import { type Route } from './+types/root'
 import { AppHotkeys } from './components/app-hotkeys.tsx'
 import { ArrowLink } from './components/arrow-button.tsx'
+import { ButtonLink } from './components/button.tsx'
 import { ErrorPage, FourHundred, FourOhFour } from './components/errors.tsx'
 import { Footer } from './components/footer.tsx'
 import { Grimmacing } from './components/kifs.tsx'
 import { Navbar } from './components/navbar.tsx'
 import { NotificationMessage } from './components/notification-message.tsx'
+import {
+	Promotification,
+	getPromoCookieValue,
+} from './routes/resources/promotification.tsx'
 import { Spacer } from './components/spacer.tsx'
 import { TeamCircle } from './components/team-circle.tsx'
 import { getGenericSocialImage, illustrationImages, images } from './images.tsx'
@@ -125,6 +130,8 @@ const PODCAST_LINKS_FALLBACK = {
 	calls: { latestSeasonNumber: null, latestSeasonPath: '/calls' },
 } as const
 
+const SEASON_7_PROMOTIFICATION_NAME = 'chats-with-kent-season-7'
+
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
 	const loaderStart = performance.now()
@@ -172,6 +179,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 		user,
 		userInfo: user ? await getUserInfo(user, { request, timings }) : null,
 		latestPodcastSeasonLinks,
+		season7PromotificationCookieValue: getPromoCookieValue({
+			promoName: SEASON_7_PROMOTIFICATION_NAME,
+			request,
+		}),
 		ENV: getPublicEnv(),
 		randomFooterImageKey,
 		requestInfo: {
@@ -384,6 +395,23 @@ function App({
 			</head>
 			<body className="bg-white transition duration-500 dark:bg-gray-900">
 				<PageLoadingMessage />
+				<Promotification
+					position="top-center"
+					promoName={SEASON_7_PROMOTIFICATION_NAME}
+					cookieValue={data.season7PromotificationCookieValue}
+					hidePermanentlyOnInteraction
+				>
+					<div className="space-y-4">
+						<p className="font-semibold">
+							{`Season 7 of Chats with Kent is out: Become a Product Engineer.`}
+						</p>
+						<div className="flex flex-wrap items-center justify-end gap-3">
+							<ButtonLink to="/chats/07" variant="secondary" size="medium">
+								{`Listen to season 7`}
+							</ButtonLink>
+						</div>
+					</div>
+				</Promotification>
 				<NotificationMessage queryStringKey="message" delay={0.3} />
 				<Navbar />
 				<AppHotkeys />

--- a/services/site/app/routes/resources/__tests__/promotification.test.ts
+++ b/services/site/app/routes/resources/__tests__/promotification.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { expect, test } from 'vitest'
+
+import { action } from '../promotification.tsx'
+
+function makeRequest(formData: FormData) {
+	return new Request('http://localhost/resources/promotification', {
+		method: 'POST',
+		body: formData,
+	})
+}
+
+test('action stores a hidden cookie for a valid promo name', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'chats-with-kent-season-7')
+	formData.set('maxAge', String(60 * 60 * 24))
+
+	const result = (await action({
+		request: makeRequest(formData),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBeUndefined()
+	const cookieHeader = new Headers(result.init?.headers).get('Set-Cookie')
+	expect(cookieHeader).toContain('chats-with-kent-season-7=hidden')
+	expect(cookieHeader).toContain('Max-Age=86400')
+})
+
+test('action rejects invalid promo names', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'invalid promo name')
+
+	const result = (await action({
+		request: makeRequest(formData),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(400)
+	expect(result.data).toEqual({
+		success: false,
+		error: 'Invalid promoName',
+	})
+})
+
+test('action caps one-time promo cookie max age', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'chats-with-kent-season-7')
+	formData.set('maxAge', String(60 * 60 * 24 * 365 * 20))
+
+	const result = (await action({
+		request: makeRequest(formData),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	const cookieHeader = new Headers(result.init?.headers).get('Set-Cookie')
+	expect(cookieHeader).toContain(`Max-Age=${60 * 60 * 24 * 365 * 10}`)
+})

--- a/services/site/app/routes/resources/promotification.tsx
+++ b/services/site/app/routes/resources/promotification.tsx
@@ -1,5 +1,5 @@
 // A full stack component + action for promotional notification messages.
-// The user can dismiss (snooze) the promo for a period of time via an httpOnly cookie.
+// The user can dismiss a promo via an httpOnly cookie, either temporarily or once.
 import { invariantResponse } from '@epic-web/invariant'
 import * as cookie from 'cookie'
 import * as React from 'react'
@@ -40,7 +40,7 @@ export async function action({ request }: Route.ActionArgs) {
 	}
 
 	const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 * 7 * 2
-	const MAX_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days ceiling
+	const MAX_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10
 	const rawMaxAge = Number(formData.get('maxAge'))
 	const maxAge =
 		Number.isFinite(rawMaxAge) && rawMaxAge > 0
@@ -62,6 +62,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 type NotificationMessageProps = Parameters<typeof NotificationMessage>[0]
+const ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10
 
 export function Promotification({
 	children,
@@ -69,27 +70,52 @@ export function Promotification({
 	dismissTimeSeconds = 60 * 60 * 24 * 4,
 	cookieValue,
 	promoEndTime,
+	hidePermanentlyOnInteraction = false,
 	...props
 }: {
 	promoName: string
 	/** maxAge for the cookie */
 	dismissTimeSeconds?: number
 	cookieValue: string | undefined
-	promoEndTime: Date
+	promoEndTime?: Date
+	hidePermanentlyOnInteraction?: boolean
 } & NotificationMessageProps & {
 		queryStringKey?: never
 		autoClose?: never
 		visibleMs?: never
 	} & Required<Pick<NotificationMessageProps, 'children'>>) {
-	const promoEndTimeMs = promoEndTime.getTime()
-	const [isPastEndTime, setIsPastEndTime] = useState(
-		() => promoEndTimeMs <= Date.now(),
+	const promoEndTimeMs = promoEndTime?.getTime() ?? null
+	const [isPastEndTime, setIsPastEndTime] = useState(() =>
+		promoEndTimeMs ? promoEndTimeMs <= Date.now() : false,
 	)
 
 	const [visible, setVisible] = useState(cookieValue !== 'hidden')
 	const fetcher = useFetcher<SerializeFrom<typeof action>>()
 	const showSpinner = useSpinDelay(fetcher.state !== 'idle')
 	const disableLink = fetcher.state !== 'idle' || fetcher.data?.success
+
+	function submitDismiss(maxAge: number) {
+		const formData = new FormData()
+		formData.set('promoName', promoName)
+		formData.set('maxAge', String(maxAge))
+		fetcher.submit(formData, {
+			action: '/resources/promotification',
+			method: 'POST',
+		})
+	}
+
+	function handleInteraction(event: React.MouseEvent<HTMLDivElement>) {
+		if (!hidePermanentlyOnInteraction) return
+		if (fetcher.state !== 'idle' || fetcher.data?.success) return
+		const target = event.target
+		if (!(target instanceof HTMLElement)) return
+		const interactiveElement = target.closest(
+			'a, button, input, select, textarea, [role="button"], [role="link"]',
+		)
+		if (!interactiveElement) return
+		setVisible(false)
+		submitDismiss(ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS)
+	}
 
 	useEffect(() => {
 		if (fetcher.data?.success) {
@@ -104,71 +130,77 @@ export function Promotification({
 
 	useEffect(() => {
 		// `promoEndTime` can change if a parent swaps promos; keep this derived.
-		setIsPastEndTime(promoEndTimeMs <= Date.now())
+		setIsPastEndTime(promoEndTimeMs ? promoEndTimeMs <= Date.now() : false)
 	}, [promoEndTimeMs])
 
 	// Key fix for issue #462: compute from absolute end time each tick so we jump
 	// after tab inactivity rather than counting down rapidly to catch up.
-	const timeLeft = useCountdown(promoEndTimeMs, 1000)
+	const timeLeft = useCountdown(promoEndTimeMs ?? 0, 1000)
 	const completed = timeLeft <= 0
 	const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24))
 	const hours = Math.floor((timeLeft / (1000 * 60 * 60)) % 24)
 	const minutes = Math.floor((timeLeft / 1000 / 60) % 60)
 	const seconds = Math.floor((timeLeft / 1000) % 60)
 
-	if (isPastEndTime) return null
+	if (promoEndTime && isPastEndTime) return null
 
 	return (
 		<NotificationMessage
 			{...props}
 			autoClose={false}
 			visible={visible}
-			onDismiss={() => setVisible(false)}
+			onDismiss={() => {
+				setVisible(false)
+				if (hidePermanentlyOnInteraction) {
+					submitDismiss(ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS)
+				}
+			}}
 		>
-			{children}
-			<div className="mt-4">
-				{completed ? (
-					<div>{`Time's up. The sale is over`}</div>
-				) : (
-					<>
-						<div className="flex flex-wrap gap-3 tabular-nums">
-							<span>
-								{days} day{days === 1 ? '' : 's'}
-							</span>
-							<span>
-								{hours} hour{hours === 1 ? '' : 's'}
-							</span>
-							<span>
-								{minutes} min{minutes === 1 ? '' : 's'}
-							</span>
-							<span>
-								{seconds} sec{seconds === 1 ? '' : 's'}
-							</span>
-						</div>
-						<fetcher.Form action="/resources/promotification" method="POST">
-							<input type="hidden" name="promoName" value={promoName} />
-							<input type="hidden" name="maxAge" value={dismissTimeSeconds} />
-							<div className="mt-4 flex flex-wrap items-center justify-end gap-2">
-								{dismissError ? (
-									<p className="text-sm text-red-500" role="alert">
-										{dismissError}
-									</p>
-								) : null}
-								<LinkButton
-									type="submit"
-									className={`text-inverse flex items-center gap-1 transition-opacity ${
-										showSpinner ? 'opacity-50' : ''
-									}`}
-									disabled={disableLink}
-								>
-									<span>Remind me later</span>
-									<AlarmIcon />
-								</LinkButton>
-								<Spinner size={16} showSpinner={showSpinner} />
-							</div>
-						</fetcher.Form>
-					</>
-				)}
+			<div onClickCapture={handleInteraction}>
+				{children}
+				{promoEndTime ? (
+					<div className="mt-4">
+						{completed ? (
+							<div>{`Time's up. The sale is over`}</div>
+						) : (
+							<>
+								<div className="flex flex-wrap gap-3 tabular-nums">
+									<span>
+										{days} day{days === 1 ? '' : 's'}
+									</span>
+									<span>
+										{hours} hour{hours === 1 ? '' : 's'}
+									</span>
+									<span>
+										{minutes} min{minutes === 1 ? '' : 's'}
+									</span>
+									<span>
+										{seconds} sec{seconds === 1 ? '' : 's'}
+									</span>
+								</div>
+								<div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+									{dismissError ? (
+										<p className="text-sm text-red-500" role="alert">
+											{dismissError}
+										</p>
+									) : null}
+									<LinkButton
+										type="button"
+										className={`text-inverse flex items-center gap-1 transition-opacity ${
+											showSpinner ? 'opacity-50' : ''
+										}`}
+										disabled={disableLink}
+										onClick={() => submitDismiss(dismissTimeSeconds)}
+									>
+										<span>Remind me later</span>
+										<AlarmIcon />
+									</LinkButton>
+									<Spinner size={16} showSpinner={showSpinner} />
+								</div>
+							</>
+						)}
+					</div>
+				) : null}
 			</div>
 		</NotificationMessage>
 	)

--- a/services/site/app/routes/resources/promotification.tsx
+++ b/services/site/app/routes/resources/promotification.tsx
@@ -113,6 +113,7 @@ export function Promotification({
 			'a, button, input, select, textarea, [role="button"], [role="link"]',
 		)
 		if (!interactiveElement) return
+		if (interactiveElement.closest('[data-promotification-snooze]')) return
 		setVisible(false)
 		submitDismiss(ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS)
 	}
@@ -189,6 +190,7 @@ export function Promotification({
 										className={`text-inverse flex items-center gap-1 transition-opacity ${
 											showSpinner ? 'opacity-50' : ''
 										}`}
+										data-promotification-snooze
 										disabled={disableLink}
 										onClick={() => submitDismiss(dismissTimeSeconds)}
 									>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a site-wide season 7 promotification that links to `/chats/07`
- extend the shared promotification component with an opt-in one-time dismissal mode
- add focused backend coverage for the promotification action

## Walkthrough
[season-7-promotification-demo-small.mp4](https://cursor.com/agents/bc-20f03279-398c-4d90-8b16-70e62b0e888c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseason-7-promotification-demo-small.mp4)
[Season 7 promo visible](https://cursor.com/agents/bc-20f03279-398c-4d90-8b16-70e62b0e888c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseason-7-promotification-visible.webp)
[Season 7 page after CTA](https://cursor.com/agents/bc-20f03279-398c-4d90-8b16-70e62b0e888c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseason-7-promotification-destination.webp)

## Testing
- `npm run lint --workspace kentcdodds.com`
- `npm run test:backend --workspace kentcdodds.com -- app/routes/resources/__tests__/promotification.test.ts`
- manual browser verification that dismissing or clicking the CTA hides the promo permanently


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20f03279-398c-4d90-8b16-70e62b0e888c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20f03279-398c-4d90-8b16-70e62b0e888c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Season 7 promotional banner at the top with a "Listen to season 7" CTA.
  * Banner can be dismissed temporarily or permanently; interacting with clickable elements in the banner now permanently hides it.
  * Dismissal persists via secure server-set cookie with a max duration increased up to 10 years.
  * Button component now supports an explicit size option.

* **Tests**
  * Added automated tests covering promo dismissal behaviors and cookie handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->