### PR TITLE
Add Season 7 launch email draft

### DIFF
--- a/other/season-7-launch-email.md
+++ b/other/season-7-launch-email.md
@@ -1,0 +1,41 @@
+# Subject
+
+Season 7 of Chats with Kent is here: Become a Product Engineer
+
+# Email draft
+
+Hey friends,
+
+Season 7 of *Chats with Kent* launches today, and it marks an important shift in what I want to help you get better at next.
+
+For years, I have spent a lot of my time teaching implementation skills: how to write better code, build better UIs, and ship software with confidence. Those things still matter. But as AI keeps raising the floor on implementation, I believe one of the most valuable skills you can develop now is **product engineering**: understanding users deeply, clarifying the real problem, and building the right thing before you worry about building the thing right.
+
+That is the focus of this new season.
+
+The first three full episodes are already out today:
+
+- **Dax Raad** on product sense, restraint, and building OpenCode in a crowded AI tooling market
+- **Wayne Allan** on falling in love with the problem instead of the solution
+- **Dillon Mulroy** on feedback loops, observability, and learning directly from support and real users
+
+If you listen to these first episodes, here are a few ideas I think will pay off immediately:
+
+- **Product sense matters more than ever.** Faster implementation only helps if you are aiming at the right problem.
+- **Short feedback loops are a superpower.** The best builders do not wait forever for perfect research; they talk to users, support, and sales early and often.
+- **Taste and restraint are part of the job.** Just because you *can* ship more, faster, does not mean you should.
+- **Strong foundations still win.** Good onboarding, good observability, and good product judgment compound over time.
+
+If you want to become the kind of engineer who is not just valuable because you can write code, but because you can help a team build something people actually need, I think you will get a lot out of this season.
+
+And we are just getting started: there will be a new episode every week for the next couple of months, and next week I’ll be talking with **Aaron Francis**.
+
+If that sounds useful to you, subscribe now so you do not miss what is coming next:
+
+- [Listen to Season 7](https://kentcdodds.com/chats/07)
+- [Apple Podcasts](https://podcasts.apple.com/us/podcast/chats-with-kent-c-dodds/id1475543959)
+- [Spotify](https://open.spotify.com/show/7GkO2poedjbltWT5lduL5w)
+- [RSS](https://feeds.simplecast.com/X_wS_WYh)
+
+I hope these conversations help you build a stronger sense for what to build, why it matters, and how to create software that actually helps people.
+
+Kent


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a markdown draft for the Season 7 `Chats with Kent` mailing list announcement
- focus the copy on product engineering, the first three launch-day guests, and the value readers will get from subscribing

## Testing
- researched the published Season 7 landing page and launch-day episode pages on kentcdodds.com
- verified the draft file contents locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9b42ac8-733e-4a1d-8040-9d709b8c5992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9b42ac8-733e-4a1d-8040-9d709b8c5992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

