### PR TITLE
Add Chats episode YouTube embeds

### DIFF
--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -8,10 +8,15 @@ import {
 	data as json,
 	redirect,
 	type HeadersFunction,
+	type LinksFunction,
 } from 'react-router'
 import { serverOnly$ } from 'vite-env-only/macros'
 import { ArrowLink, BackLink } from '#app/components/arrow-button.tsx'
 import { FourOhFour } from '#app/components/errors.tsx'
+import {
+	LiteYouTubeEmbed,
+	links as youTubeEmbedLinks,
+} from '#app/components/fullscreen-yt-embed.tsx'
 import { Grid } from '#app/components/grid.tsx'
 import { IconLink } from '#app/components/icon-link.tsx'
 import {
@@ -202,6 +207,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 export const headers: HeadersFunction = reuseUsefulLoaderHeaders
 
+export const links: LinksFunction = () => {
+	return youTubeEmbedLinks()
+}
+
 function Homework({
 	homeworkHTMLs = [],
 }: {
@@ -353,6 +362,31 @@ function Transcript({
 					</span>
 				</button>
 			) : null}
+		</div>
+	)
+}
+
+function EpisodeVideo({
+	youtubeVideoId,
+	title,
+}: {
+	youtubeVideoId: string
+	title: string
+}) {
+	return (
+		<div className="col-span-full lg:col-span-8 lg:col-start-3">
+			<div className="overflow-hidden rounded-lg bg-black">
+				<LiteYouTubeEmbed
+					id={youtubeVideoId}
+					title={`${title} video`}
+					announce="Play video"
+					alwaysLoadIframe={true}
+					params={new URLSearchParams({
+						rel: '0',
+						modestbranding: '1',
+					}).toString()}
+				/>
+			</div>
 		</div>
 	)
 }
@@ -515,6 +549,16 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 						<PrevNextButton episodeListItem={nextEpisode} direction="next" />
 					</div>
 				</div>
+
+				{episode.youtubeVideoId ? (
+					<>
+						<EpisodeVideo
+							youtubeVideoId={episode.youtubeVideoId}
+							title={episode.title}
+						/>
+						<Spacer size="3xs" className="col-span-full" />
+					</>
+				) : null}
 
 				<H3
 					className="col-span-full lg:col-span-8 lg:col-start-3"

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -560,12 +560,16 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 					</>
 				) : null}
 
-				<H3
-					className="col-span-full lg:col-span-8 lg:col-start-3"
-					dangerouslySetInnerHTML={{ __html: episode.descriptionHTML }}
-				/>
+				{episode.descriptionHTML ? (
+					<>
+						<H3
+							className="col-span-full lg:col-span-8 lg:col-start-3"
+							dangerouslySetInnerHTML={{ __html: episode.descriptionHTML }}
+						/>
 
-				<Spacer size="3xs" className="col-span-full" />
+						<Spacer size="3xs" className="col-span-full" />
+					</>
+				) : null}
 
 				<div className="col-span-full lg:col-span-8 lg:col-start-3">
 					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/services/site/app/utils/__tests__/simplecast.server.test.ts
+++ b/services/site/app/utils/__tests__/simplecast.server.test.ts
@@ -9,7 +9,10 @@ vi.mock('../cache.server.ts', () => ({
 	}) => await getFreshValue({}),
 }))
 
-import { parseSummaryMarkdown } from '../simplecast.server.ts'
+import {
+	parseDescriptionMarkdown,
+	parseSummaryMarkdown,
+} from '../simplecast.server.ts'
 import { getYouTubeVideoId } from '../youtube-utils.ts'
 
 test('parseSummaryMarkdown extracts youtube video metadata section', async () => {
@@ -34,6 +37,32 @@ Welcome to the episode summary.
 	expect(result.resources).toEqual([
 		{ name: 'Docs', url: 'https://kentcdodds.com' },
 	])
+})
+
+test('parseDescriptionMarkdown strips metadata-only youtube paragraphs with punctuation', async () => {
+	const result = await parseDescriptionMarkdown(
+		`
+Lead-in description.
+
+(https://www.youtube.com/watch?v=dQw4w9WgXcQ)
+		`.trim(),
+	)
+
+	expect(result.youtubeVideoId).toBe('dQw4w9WgXcQ')
+	expect(result.descriptionHTML).toContain('<p>Lead-in description.</p>')
+	expect(result.descriptionHTML).not.toContain('dQw4w9WgXcQ')
+})
+
+test('parseDescriptionMarkdown keeps incidental youtube links in content as fallback', async () => {
+	const result = await parseDescriptionMarkdown(
+		`
+Watch this recap on YouTube: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+		`.trim(),
+	)
+
+	expect(result.youtubeVideoId).toBe('dQw4w9WgXcQ')
+	expect(result.descriptionHTML).toContain('Watch this recap on YouTube:')
+	expect(result.descriptionHTML).toContain('dQw4w9WgXcQ')
 })
 
 test('getYouTubeVideoId supports common youtube url formats', () => {

--- a/services/site/app/utils/__tests__/simplecast.server.test.ts
+++ b/services/site/app/utils/__tests__/simplecast.server.test.ts
@@ -1,0 +1,51 @@
+import { expect, test, vi } from 'vitest'
+
+vi.mock('../cache.server.ts', () => ({
+	cache: {},
+	cachified: async ({
+		getFreshValue,
+	}: {
+		getFreshValue: (context: {}) => unknown
+	}) => await getFreshValue({}),
+}))
+
+import { parseSummaryMarkdown } from '../simplecast.server.ts'
+import { getYouTubeVideoId } from '../youtube-utils.ts'
+
+test('parseSummaryMarkdown extracts youtube video metadata section', async () => {
+	const result = await parseSummaryMarkdown(
+		`
+Welcome to the episode summary.
+
+### Video
+
+[Watch the episode on YouTube](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
+
+### Resources
+
+* [Docs](https://kentcdodds.com)
+		`.trim(),
+		'test-episode',
+	)
+
+	expect(result.youtubeVideoId).toBe('dQw4w9WgXcQ')
+	expect(result.summaryHTML).toContain('<p>Welcome to the episode summary.</p>')
+	expect(result.summaryHTML).not.toContain('Watch the episode on YouTube')
+	expect(result.resources).toEqual([
+		{ name: 'Docs', url: 'https://kentcdodds.com' },
+	])
+})
+
+test('getYouTubeVideoId supports common youtube url formats', () => {
+	expect(getYouTubeVideoId('dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+	expect(getYouTubeVideoId('https://youtu.be/dQw4w9WgXcQ?t=43')).toBe(
+		'dQw4w9WgXcQ',
+	)
+	expect(
+		getYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=abc'),
+	).toBe('dQw4w9WgXcQ')
+	expect(
+		getYouTubeVideoId('https://www.youtube.com/shorts/dQw4w9WgXcQ?feature=share'),
+	).toBe('dQw4w9WgXcQ')
+	expect(getYouTubeVideoId('https://kentcdodds.com')).toBeNull()
+})

--- a/services/site/app/utils/simplecast.server.ts
+++ b/services/site/app/utils/simplecast.server.ts
@@ -415,7 +415,16 @@ function isYouTubeOnlyNode(node: M.PhrasingContent) {
 
 	if (node.type === 'text') {
 		const value = node.value.trim()
-		return Boolean(value) && Boolean(getYouTubeVideoId(value))
+		if (!value) return false
+
+		const youtubeVideoId = findFirstYouTubeVideoIdInText(value)
+		if (!youtubeVideoId) return false
+
+		const textWithoutYouTubeUrls = value.replace(/https?:\/\/\S+/g, (match) => {
+			const candidate = match.replace(/[<>"')\],.;!?]+$/g, '')
+			return getYouTubeVideoId(candidate) ? '' : match
+		})
+		return /^[\s\p{P}]*$/u.test(textWithoutYouTubeUrls)
 	}
 
 	return false
@@ -425,7 +434,7 @@ function isYouTubeOnlyParagraph(node: U.Node): node is M.Paragraph {
 	if (node.type !== 'paragraph') return false
 	const paragraphNode = node as M.Paragraph
 	return paragraphNode.children.every((child: M.PhrasingContent) => {
-		if (child.type === 'text' && !child.value.trim()) return true
+		if (child.type === 'text' && /^[\s\p{P}]*$/u.test(child.value)) return true
 		return isYouTubeOnlyNode(child)
 	})
 }
@@ -454,7 +463,7 @@ async function parseDescriptionMarkdown(
 	}
 
 	const isHTMLInput = descriptionInput.trim().startsWith('<')
-	let youtubeVideoId = findFirstYouTubeVideoIdInText(descriptionInput) ?? undefined
+	let youtubeVideoId: string | undefined
 	let removedYouTubeOnlyParagraphs = false
 
 	const result = await unified()
@@ -477,13 +486,15 @@ async function parseDescriptionMarkdown(
 	if (isHTMLInput && !removedYouTubeOnlyParagraphs) {
 		return {
 			descriptionHTML: descriptionInput,
-			youtubeVideoId,
+			youtubeVideoId:
+				youtubeVideoId ?? findFirstYouTubeVideoIdInText(descriptionInput) ?? undefined,
 		}
 	}
 
 	return {
 		descriptionHTML: result.value.toString(),
-		youtubeVideoId,
+		youtubeVideoId:
+			youtubeVideoId ?? findFirstYouTubeVideoIdInText(descriptionInput) ?? undefined,
 	}
 }
 
@@ -734,4 +745,9 @@ async function getSeasonListItems({
 	return listItemSeasons
 }
 
-export { getSeasonListItems, getCachedSeasons as getSeasons, parseSummaryMarkdown }
+export {
+	getSeasonListItems,
+	getCachedSeasons as getSeasons,
+	parseDescriptionMarkdown,
+	parseSummaryMarkdown,
+}

--- a/services/site/app/utils/simplecast.server.ts
+++ b/services/site/app/utils/simplecast.server.ts
@@ -408,7 +408,7 @@ function findYouTubeVideoIdInNodes(nodes: Array<U.Node>) {
 	return youtubeVideoId
 }
 
-function isYouTubeOnlyNode(node: U.Node) {
+function isYouTubeOnlyNode(node: M.PhrasingContent) {
 	if (node.type === 'link') {
 		return Boolean(getYouTubeVideoId(node.url))
 	}
@@ -421,9 +421,10 @@ function isYouTubeOnlyNode(node: U.Node) {
 	return false
 }
 
-function isYouTubeOnlyParagraph(node: U.Node) {
+function isYouTubeOnlyParagraph(node: U.Node): node is M.Paragraph {
 	if (node.type !== 'paragraph') return false
-	return node.children.every((child) => {
+	const paragraphNode = node as M.Paragraph
+	return paragraphNode.children.every((child: M.PhrasingContent) => {
 		if (child.type === 'text' && !child.value.trim()) return true
 		return isYouTubeOnlyNode(child)
 	})

--- a/services/site/app/utils/simplecast.server.ts
+++ b/services/site/app/utils/simplecast.server.ts
@@ -434,9 +434,11 @@ async function parseEpisodeMarkdown(input: string | null | undefined) {
 	if (!input) return ''
 
 	const isHTMLInput = input.trim().startsWith('<')
+	if (isHTMLInput) {
+		return input
+	}
 	const result = await unified()
-		.use(isHTMLInput ? parseHtml : parseMarkdown)
-		.use(isHTMLInput ? rehype2remark : () => {})
+		.use(parseMarkdown)
 		.use(remark2rehype)
 		.use(rehypeStringify)
 		.process(input)

--- a/services/site/app/utils/simplecast.server.ts
+++ b/services/site/app/utils/simplecast.server.ts
@@ -18,7 +18,7 @@ import { isAbortError, throwIfAborted } from './abort-utils.server.ts'
 import { cache, cachified } from './cache.server.ts'
 import { getEnv } from './env.server.ts'
 import { fetchJsonWithRetryAfter } from './fetch-json-with-retry-after.server.ts'
-import { markdownToHtml, stripHtml } from './markdown.server.ts'
+import { stripHtml } from './markdown.server.ts'
 import { typedBoolean } from './misc.ts'
 import {
 	simplecastEpisodeSchema,
@@ -26,6 +26,10 @@ import {
 	simplecastSeasonsResponseSchema,
 } from './simplecast-api-schema.server.ts'
 import { type Timings } from './timing.server.ts'
+import {
+	findFirstYouTubeVideoIdInText,
+	getYouTubeVideoId,
+} from './youtube-utils.ts'
 
 function getSimplecastConfig() {
 	const env = getEnv()
@@ -83,6 +87,7 @@ const cwkCachedEpisodeSchema = z
 		transcriptHTML: z.string(),
 		simpleCastId: z.string().min(1),
 		mediaUrl: z.string().min(1),
+		youtubeVideoId: z.string().min(1).optional(),
 	})
 	.passthrough()
 
@@ -306,20 +311,11 @@ async function getEpisode(
 
 	const keywords = keywordsData?.collection?.map(({ value }) => value) ?? []
 	const [
+		{ descriptionHTML, youtubeVideoId: descriptionYouTubeVideoId },
+		{ summaryHTML, homeworkHTMLs, resources, guests, youtubeVideoId },
 		transcriptHTML,
-		descriptionHTML,
-		{ summaryHTML, homeworkHTMLs, resources, guests },
 	] = await Promise.all([
-		transcriptMarkdown
-			? transcriptMarkdown.trim().startsWith('<')
-				? transcriptMarkdown
-				: markdownToHtml(transcriptMarkdown)
-			: '',
-		descriptionMarkdown
-			? descriptionMarkdown.trim().startsWith('<')
-				? descriptionMarkdown
-				: markdownToHtml(descriptionMarkdown)
-			: '',
+		parseDescriptionMarkdown(descriptionMarkdown),
 		summaryMarkdown
 			? parseSummaryMarkdown(summaryMarkdown, `${id}-${slug}`)
 			: {
@@ -327,7 +323,9 @@ async function getEpisode(
 					homeworkHTMLs: [],
 					resources: [],
 					guests: [],
+					youtubeVideoId: null,
 				},
+		parseEpisodeMarkdown(transcriptMarkdown),
 	])
 
 	// Simplecast exposes both published and updated timestamps; fall back to
@@ -355,6 +353,7 @@ async function getEpisode(
 		},
 		simpleCastId: episodeId,
 		mediaUrl,
+		youtubeVideoId: youtubeVideoId ?? descriptionYouTubeVideoId ?? undefined,
 	}
 	return cwkEpisode
 }
@@ -387,16 +386,109 @@ function autoAffiliates() {
 	}
 }
 
+function findYouTubeVideoIdInNodes(nodes: Array<U.Node>) {
+	let youtubeVideoId: string | null = null
+
+	for (const node of nodes) {
+		visit(node, 'link', (link: M.Link) => {
+			if (youtubeVideoId) return
+			youtubeVideoId = getYouTubeVideoId(link.url)
+		})
+
+		if (youtubeVideoId) break
+
+		visit(node, 'text', (text: M.Text) => {
+			if (youtubeVideoId) return
+			youtubeVideoId = findFirstYouTubeVideoIdInText(text.value)
+		})
+
+		if (youtubeVideoId) break
+	}
+
+	return youtubeVideoId
+}
+
+function isYouTubeOnlyNode(node: U.Node) {
+	if (node.type === 'link') {
+		return Boolean(getYouTubeVideoId(node.url))
+	}
+
+	if (node.type === 'text') {
+		const value = node.value.trim()
+		return Boolean(value) && findFirstYouTubeVideoIdInText(value) === value
+	}
+
+	return false
+}
+
+function isYouTubeOnlyParagraph(node: U.Node) {
+	if (node.type !== 'paragraph') return false
+	return node.children.every((child) => {
+		if (child.type === 'text' && !child.value.trim()) return true
+		return isYouTubeOnlyNode(child)
+	})
+}
+
+async function parseEpisodeMarkdown(input: string | null | undefined) {
+	if (!input) return ''
+
+	const isHTMLInput = input.trim().startsWith('<')
+	const result = await unified()
+		.use(isHTMLInput ? parseHtml : parseMarkdown)
+		.use(isHTMLInput ? rehype2remark : () => {})
+		.use(remark2rehype)
+		.use(rehypeStringify)
+		.process(input)
+
+	return result.value.toString()
+}
+
+async function parseDescriptionMarkdown(
+	descriptionInput: string | null | undefined,
+): Promise<Pick<CWKEpisode, 'descriptionHTML' | 'youtubeVideoId'>> {
+	if (!descriptionInput) {
+		return { descriptionHTML: '', youtubeVideoId: undefined }
+	}
+
+	const isHTMLInput = descriptionInput.trim().startsWith('<')
+	let youtubeVideoId = findFirstYouTubeVideoIdInText(descriptionInput) ?? undefined
+
+	const result = await unified()
+		.use(isHTMLInput ? parseHtml : parseMarkdown)
+		.use(isHTMLInput ? rehype2remark : () => {})
+		.use(function extractDescriptionMetadata() {
+			return function transformer(tree: M.Root) {
+				tree.children = tree.children.filter((child) => {
+					if (!isYouTubeOnlyParagraph(child)) return true
+					youtubeVideoId ??= findYouTubeVideoIdInNodes([child]) ?? undefined
+					return false
+				})
+			}
+		})
+		.use(remark2rehype)
+		.use(rehypeStringify)
+		.process(descriptionInput)
+
+	return {
+		descriptionHTML: result.value.toString(),
+		youtubeVideoId,
+	}
+}
+
 async function parseSummaryMarkdown(
 	summaryInput: string,
 	errorKey: string,
 ): Promise<
-	Pick<CWKEpisode, 'summaryHTML' | 'resources' | 'guests' | 'homeworkHTMLs'>
+	Pick<
+		CWKEpisode,
+		'summaryHTML' | 'resources' | 'guests' | 'homeworkHTMLs' | 'youtubeVideoId'
+	>
 > {
 	const isHTMLInput = summaryInput.trim().startsWith('<')
 	const resources: CWKEpisode['resources'] = []
 	const guests: CWKEpisode['guests'] = []
 	const homeworkHTMLs: CWKEpisode['homeworkHTMLs'] = []
+	let youtubeVideoId: string | null = null
 
 	const result = await unified()
 		.use(isHTMLInput ? parseHtml : parseMarkdown)
@@ -472,6 +564,11 @@ async function parseSummaryMarkdown(
 								})
 							})
 						}
+					}
+					if (/^(video|youtube|youtube video)$/i.test(sectionTitle)) {
+						remove()
+						youtubeVideoId ??= findYouTubeVideoIdInNodes(children)
+						continue
 					}
 					if (/homework/i.test(sectionTitle)) {
 						remove()
@@ -584,6 +681,7 @@ async function parseSummaryMarkdown(
 		homeworkHTMLs,
 		resources,
 		guests,
+		youtubeVideoId: youtubeVideoId ?? undefined,
 	}
 }
 
@@ -624,4 +722,4 @@ async function getSeasonListItems({
 	return listItemSeasons
 }
 
-export { getSeasonListItems, getCachedSeasons as getSeasons }
+export { getSeasonListItems, getCachedSeasons as getSeasons, parseSummaryMarkdown }

--- a/services/site/app/utils/simplecast.server.ts
+++ b/services/site/app/utils/simplecast.server.ts
@@ -415,7 +415,7 @@ function isYouTubeOnlyNode(node: M.PhrasingContent) {
 
 	if (node.type === 'text') {
 		const value = node.value.trim()
-		return Boolean(value) && findFirstYouTubeVideoIdInText(value) === value
+		return Boolean(value) && Boolean(getYouTubeVideoId(value))
 	}
 
 	return false

--- a/services/site/app/utils/simplecast.server.ts
+++ b/services/site/app/utils/simplecast.server.ts
@@ -455,6 +455,7 @@ async function parseDescriptionMarkdown(
 
 	const isHTMLInput = descriptionInput.trim().startsWith('<')
 	let youtubeVideoId = findFirstYouTubeVideoIdInText(descriptionInput) ?? undefined
+	let removedYouTubeOnlyParagraphs = false
 
 	const result = await unified()
 		.use(isHTMLInput ? parseHtml : parseMarkdown)
@@ -463,6 +464,7 @@ async function parseDescriptionMarkdown(
 			return function transformer(tree: M.Root) {
 				tree.children = tree.children.filter((child) => {
 					if (!isYouTubeOnlyParagraph(child)) return true
+					removedYouTubeOnlyParagraphs = true
 					youtubeVideoId ??= findYouTubeVideoIdInNodes([child]) ?? undefined
 					return false
 				})
@@ -471,6 +473,13 @@ async function parseDescriptionMarkdown(
 		.use(remark2rehype)
 		.use(rehypeStringify)
 		.process(descriptionInput)
+
+	if (isHTMLInput && !removedYouTubeOnlyParagraphs) {
+		return {
+			descriptionHTML: descriptionInput,
+			youtubeVideoId,
+		}
+	}
 
 	return {
 		descriptionHTML: result.value.toString(),

--- a/services/site/app/utils/youtube-utils.ts
+++ b/services/site/app/utils/youtube-utils.ts
@@ -58,4 +58,4 @@ function findFirstYouTubeVideoIdInText(text: string | null | undefined) {
 	return null
 }
 
-export { findFirstYouTubeVideoIdInText, getYouTubeVideoId, isYouTubeVideoId }
+export { findFirstYouTubeVideoIdInText, getYouTubeVideoId }

--- a/services/site/app/utils/youtube-utils.ts
+++ b/services/site/app/utils/youtube-utils.ts
@@ -1,0 +1,61 @@
+const youtubeVideoIdPattern = /^[A-Za-z0-9_-]{11}$/
+
+function isYouTubeVideoId(value: string | null | undefined): value is string {
+	return typeof value === 'string' && youtubeVideoIdPattern.test(value)
+}
+
+function getYouTubeVideoId(value: string | null | undefined) {
+	if (typeof value !== 'string') return null
+
+	const trimmed = value.trim()
+	if (!trimmed) return null
+	if (isYouTubeVideoId(trimmed)) return trimmed
+
+	try {
+		const url = new URL(trimmed)
+		const hostname = url.hostname.replace(/^www\./, '')
+
+		if (hostname === 'youtu.be') {
+			const [pathnameVideoId] = url.pathname.split('/').filter(Boolean)
+			return isYouTubeVideoId(pathnameVideoId) ? pathnameVideoId : null
+		}
+
+		if (
+			hostname !== 'youtube.com' &&
+			hostname !== 'm.youtube.com' &&
+			hostname !== 'music.youtube.com' &&
+			hostname !== 'youtube-nocookie.com'
+		) {
+			return null
+		}
+
+		const searchVideoId = url.searchParams.get('v')
+		if (isYouTubeVideoId(searchVideoId)) return searchVideoId
+
+		const pathParts = url.pathname.split('/').filter(Boolean)
+		const embeddedVideoId =
+			pathParts[0] === 'embed' ||
+			pathParts[0] === 'shorts' ||
+			pathParts[0] === 'live'
+				? pathParts[1]
+				: null
+
+		return isYouTubeVideoId(embeddedVideoId) ? embeddedVideoId : null
+	} catch {
+		return null
+	}
+}
+
+function findFirstYouTubeVideoIdInText(text: string | null | undefined) {
+	if (typeof text !== 'string') return null
+
+	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
+		const candidate = match[0].replace(/[<>"')\],.;!?]+$/g, '')
+		const youtubeVideoId = getYouTubeVideoId(candidate)
+		if (youtubeVideoId) return youtubeVideoId
+	}
+
+	return null
+}
+
+export { findFirstYouTubeVideoIdInText, getYouTubeVideoId, isYouTubeVideoId }

--- a/services/site/mocks/simplecast.ts
+++ b/services/site/mocks/simplecast.ts
@@ -89,6 +89,10 @@ ${faker.lorem.paragraphs(3)}
 
 * * *
 
+### Video
+
+[Watch the episode on YouTube](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
+
 ### Homework
 
 * ${homework.join('\n* ')}

--- a/services/site/types/index.d.ts
+++ b/services/site/types/index.d.ts
@@ -80,6 +80,7 @@ type CWKEpisode = {
 	descriptionHTML: string
 	description: string
 	summaryHTML: string
+	youtubeVideoId?: string
 	publishedAt: string
 	updatedAt: string
 	seasonNumber: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- parse YouTube video metadata from Chats with Kent episode content, including dedicated `### Video`/`### YouTube` sections and standalone YouTube-link descriptions
- reuse the existing site YouTube embed on episode pages when a parsed video ID is present
- tighten metadata-only paragraph detection so punctuation-wrapped YouTube links are stripped consistently while incidental description links remain visible and only act as a fallback video ID
- add focused backend coverage for summary extraction and description fallback behavior, and update local mock episode data so the UI path is easy to verify in dev

## Testing
- `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/simplecast.server.test.ts`
- `npm run typecheck --workspace kentcdodds.com`
- `npm run lint --workspace kentcdodds.com`
- Manual verification on `http://127.0.0.1:3000/chats/05/01/ex-curriculum-capillus`

## Walkthrough
[chats-episode-youtube-embed-demo.mp4](https://cursor.com/agents/bc-bd21d4c4-524a-4cbc-9bfd-7643b684a852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats-episode-youtube-embed-demo.mp4)
[Chats episode audio and video](https://cursor.com/agents/bc-bd21d4c4-524a-4cbc-9bfd-7643b684a852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats-episode-audio-and-video.webp)
[Chats episode embed and summary](https://cursor.com/agents/bc-bd21d4c4-524a-4cbc-9bfd-7643b684a852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats-episode-embed-and-summary.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd21d4c4-524a-4cbc-9bfd-7643b684a852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd21d4c4-524a-4cbc-9bfd-7643b684a852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episode pages now embed YouTube videos with fullscreen playback when a video is detected.
  * YouTube links are auto-detected and removed from rendered episode descriptions so only the embedded player or cleaned HTML appears.
  * Episode descriptions and video blocks render conditionally—missing video or description sections are omitted cleanly.
  * Episode summaries detect and extract YouTube videos so listings and details reflect available video content.
* **Tests**
  * Added unit tests validating YouTube link detection, extraction, and parsing across common URL formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->