### PR TITLE
Add Chats with Kent homework completion

### DIFF
--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -187,22 +187,19 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		episodeNumber: episode.episodeNumber,
 		...(user ? { userId: user.id } : clientId ? { clientId } : {}),
 	})
-	const homeworkItems = episode.homeworkHTMLs.map((homeworkHTML, itemIndex) => ({
-		id: getEpisodeHomeworkContentId({
+	const homeworkItems = episode.homeworkHTMLs.map((homeworkHTML, itemIndex) => {
+		const id = getEpisodeHomeworkContentId({
 			seasonNumber: episode.seasonNumber,
 			episodeNumber: episode.episodeNumber,
 			itemIndex,
-		}),
-		itemIndex,
-		homeworkHTML,
-		isCompleted: completedHomeworkIds.has(
-			getEpisodeHomeworkContentId({
-				seasonNumber: episode.seasonNumber,
-				episodeNumber: episode.episodeNumber,
-				itemIndex,
-			}),
-		),
-	}))
+		})
+		return {
+			id,
+			itemIndex,
+			homeworkHTML,
+			isCompleted: completedHomeworkIds.has(id),
+		}
+	})
 
 	return json(
 		{

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -16,7 +16,6 @@ import { Grid } from '#app/components/grid.tsx'
 import { IconLink } from '#app/components/icon-link.tsx'
 import {
 	ArrowIcon,
-	CheckCircledIcon,
 	ChevronLeftIcon,
 	ChevronRightIcon,
 	ClipboardIcon,
@@ -30,6 +29,7 @@ import { H2, H3, H6, Paragraph } from '#app/components/typography.tsx'
 import { getSocialImageWithPreTitle } from '#app/images.tsx'
 import { type RootLoaderType } from '#app/root.tsx'
 import { FavoriteToggle } from '#app/routes/resources/favorite.tsx'
+import { HomeworkCompletionToggle } from '#app/routes/resources/homework-completion.tsx'
 import {
 	type CWKEpisode,
 	type CWKListItem,
@@ -39,7 +39,10 @@ import {
 	getCWKEpisodePath,
 	getFeaturedEpisode,
 } from '#app/utils/chats-with-kent.ts'
-import { getEpisodeFavoriteContentId } from '#app/utils/favorites.ts'
+import {
+	getEpisodeFavoriteContentId,
+	getEpisodeHomeworkContentId,
+} from '#app/utils/favorites.ts'
 import {
 	formatDate,
 	formatDuration,
@@ -51,7 +54,11 @@ import {
 	typedBoolean,
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
-import { prisma } from '#app/utils/prisma.server.ts'
+import { getClientSession } from '#app/utils/client.server.ts'
+import {
+	getEpisodeHomeworkCompletions,
+	prisma,
+} from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { getUser } from '#app/utils/session.server.ts'
@@ -141,6 +148,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		getUser(request, { timings }),
 		getSeasons({ request, timings }),
 	])
+	const clientSession = await getClientSession(request, user)
+	const clientId = clientSession.getClientId()
 	const season = seasons.find((s) => s.seasonNumber === seasonNumber)
 	if (!season) {
 		throw new Response(`Season ${seasonNumber} not found`, { status: 404 })
@@ -173,6 +182,27 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 				select: { id: true },
 			})
 		: null
+	const completedHomeworkIds = await getEpisodeHomeworkCompletions({
+		seasonNumber: episode.seasonNumber,
+		episodeNumber: episode.episodeNumber,
+		...(user ? { userId: user.id } : clientId ? { clientId } : {}),
+	})
+	const homeworkItems = episode.homeworkHTMLs.map((homeworkHTML, itemIndex) => ({
+		id: getEpisodeHomeworkContentId({
+			seasonNumber: episode.seasonNumber,
+			episodeNumber: episode.episodeNumber,
+			itemIndex,
+		}),
+		itemIndex,
+		homeworkHTML,
+		isCompleted: completedHomeworkIds.has(
+			getEpisodeHomeworkContentId({
+				seasonNumber: episode.seasonNumber,
+				episodeNumber: episode.episodeNumber,
+				itemIndex,
+			}),
+		),
+	}))
 
 	return json(
 		{
@@ -186,6 +216,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 				season.episodes.filter((e) => episode !== e),
 			),
 			episode,
+			homeworkItems,
 			favoriteContentType,
 			favoriteContentId,
 			isFavorite: Boolean(favorite),
@@ -203,9 +234,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export const headers: HeadersFunction = reuseUsefulLoaderHeaders
 
 function Homework({
-	homeworkHTMLs = [],
+	homeworkItems,
+	seasonNumber,
+	episodeNumber,
 }: {
-	homeworkHTMLs: CWKEpisode['homeworkHTMLs']
+	homeworkItems: Array<{
+		id: string
+		itemIndex: number
+		homeworkHTML: string
+		isCompleted: boolean
+	}>
+	seasonNumber: number
+	episodeNumber: number
 }) {
 	return (
 		<div className="bg-secondary w-full rounded-lg p-10 pb-16">
@@ -215,21 +255,46 @@ function Homework({
 			</H6>
 
 			<ul className="text-primary html -mb-10 text-lg font-medium">
-				{homeworkHTMLs.map((homeworkHTML) => (
+				{homeworkItems.map((homeworkItem) => (
 					<li
-						key={homeworkHTML}
-						className="border-secondary flex border-t pt-8 pb-10"
+						key={homeworkItem.id}
+						className="border-secondary border-t pt-8 pb-10"
 					>
-						<CheckCircledIcon
-							className="mr-6 flex-none text-gray-400 dark:text-gray-600"
-							size={24}
+						<HomeworkToggle
+							seasonNumber={seasonNumber}
+							episodeNumber={episodeNumber}
+							homeworkItem={homeworkItem}
 						/>
-
-						<div dangerouslySetInnerHTML={{ __html: homeworkHTML }} />
 					</li>
 				))}
 			</ul>
 		</div>
+	)
+}
+
+function HomeworkToggle({
+	seasonNumber,
+	episodeNumber,
+	homeworkItem,
+}: {
+	seasonNumber: number
+	episodeNumber: number
+	homeworkItem: {
+		id: string
+		itemIndex: number
+		homeworkHTML: string
+		isCompleted: boolean
+	}
+}) {
+	return (
+		<HomeworkCompletionToggle
+			seasonNumber={seasonNumber}
+			episodeNumber={episodeNumber}
+			itemIndex={homeworkItem.itemIndex}
+			initialCompleted={homeworkItem.isCompleted}
+		>
+			<div dangerouslySetInnerHTML={{ __html: homeworkItem.homeworkHTML }} />
+		</HomeworkCompletionToggle>
 	)
 }
 
@@ -445,6 +510,7 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 	const { requestInfo } = useRootData()
 	const {
 		episode,
+		homeworkItems,
 		featured,
 		nextEpisode,
 		prevEpisode,
@@ -561,8 +627,12 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 				<Spacer size="3xs" className="col-span-full" />
 
 				<div className="col-span-full space-y-4 lg:col-span-8 lg:col-start-3">
-					{episode.homeworkHTMLs.length > 0 ? (
-						<Homework homeworkHTMLs={episode.homeworkHTMLs} />
+					{homeworkItems.length > 0 ? (
+						<Homework
+							homeworkItems={homeworkItems}
+							seasonNumber={episode.seasonNumber}
+							episodeNumber={episode.episodeNumber}
+						/>
 					) : null}
 					{episode.resources.length > 0 ? (
 						<Resources resources={episode.resources} />

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -220,7 +220,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		},
 		{
 			headers: {
-				'Cache-Control': user ? 'private, max-age=600' : 'public, max-age=600',
+				'Cache-Control': 'private, max-age=600',
 				Vary: 'Cookie',
 				'Server-Timing': getServerTimeHeader(timings),
 			},

--- a/services/site/app/routes/login.tsx
+++ b/services/site/app/routes/login.tsx
@@ -41,7 +41,10 @@ import {
 	DUMMY_PASSWORD_HASH,
 	verifyPassword,
 } from '#app/utils/password.server.ts'
-import { prisma } from '#app/utils/prisma.server.ts'
+import {
+	migrateHomeworkCompletionsToUser,
+	prisma,
+} from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/login'
@@ -172,9 +175,13 @@ export async function action({ request }: Route.ActionArgs) {
 					data: { userId: userWithPassword.id, clientId: null },
 					where: { clientId },
 				})
+				await migrateHomeworkCompletionsToUser({
+					userId: userWithPassword.id,
+					clientId,
+				})
 			}
 		} catch (error) {
-			console.error('Failed to migrate postReads on login', error)
+			console.error('Failed to migrate client data on login', error)
 		}
 		clientSession.setUser({})
 		await clientSession.getHeaders(headers)

--- a/services/site/app/routes/reset-password.tsx
+++ b/services/site/app/routes/reset-password.tsx
@@ -294,7 +294,7 @@ export async function action({ request }: Route.ActionArgs) {
 				})
 			}
 		} catch (error) {
-			console.error('Failed to migrate postReads on password reset', error)
+			console.error('Failed to migrate client data on password reset', error)
 		}
 		clientSession.setUser({})
 		await clientSession.getHeaders(headers)

--- a/services/site/app/routes/reset-password.tsx
+++ b/services/site/app/routes/reset-password.tsx
@@ -14,7 +14,10 @@ import {
 	getPasswordStrengthError,
 	getPasswordHash,
 } from '#app/utils/password.server.ts'
-import { prisma } from '#app/utils/prisma.server.ts'
+import {
+	migrateHomeworkCompletionsToUser,
+	prisma,
+} from '#app/utils/prisma.server.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
 import {
 	consumeVerification,
@@ -284,6 +287,10 @@ export async function action({ request }: Route.ActionArgs) {
 				await prisma.postRead.updateMany({
 					data: { userId: userRecord.id, clientId: null },
 					where: { clientId },
+				})
+				await migrateHomeworkCompletionsToUser({
+					userId: userRecord.id,
+					clientId,
 				})
 			}
 		} catch (error) {

--- a/services/site/app/routes/resources/__tests__/homework-completion.test.ts
+++ b/services/site/app/routes/resources/__tests__/homework-completion.test.ts
@@ -148,3 +148,37 @@ test('action stores completion for anonymous client', async () => {
 		completed: true,
 	})
 })
+
+test('action stores completion for authenticated user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
+	clientServerMocks.getClientSession.mockResolvedValue({
+		getClientId: vi.fn().mockReturnValue('client-1'),
+		getHeaders: vi.fn().mockResolvedValue(new Headers()),
+	})
+	prismaServerMocks.setEpisodeHomeworkCompletion.mockResolvedValue(true)
+
+	const formData = new FormData()
+	formData.set('contentId', '7:12:1')
+	formData.set('completed', 'true')
+
+	const request = new Request('http://localhost/resources/homework-completion', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ completed: true, authenticated: true })
+	expect(prismaServerMocks.setEpisodeHomeworkCompletion).toHaveBeenCalledWith({
+		seasonNumber: 7,
+		episodeNumber: 12,
+		itemIndex: 1,
+		userId: 'user-1',
+		completed: true,
+	})
+})

--- a/services/site/app/routes/resources/__tests__/homework-completion.test.ts
+++ b/services/site/app/routes/resources/__tests__/homework-completion.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+import { expect, test, vi } from 'vitest'
+
+const sessionServerMocks = vi.hoisted(() => ({
+	getUser: vi.fn(),
+}))
+
+const clientServerMocks = vi.hoisted(() => ({
+	getClientSession: vi.fn(),
+}))
+
+const litefsServerMocks = vi.hoisted(() => ({
+	ensurePrimary: vi.fn(),
+}))
+
+const prismaServerMocks = vi.hoisted(() => ({
+	getEpisodeHomeworkCompletions: vi.fn(),
+	setEpisodeHomeworkCompletion: vi.fn(),
+}))
+
+vi.mock('#app/utils/session.server.ts', () => sessionServerMocks)
+vi.mock('#app/utils/client.server.ts', () => clientServerMocks)
+vi.mock('#app/utils/litefs-js.server.ts', () => litefsServerMocks)
+vi.mock('#app/utils/prisma.server.ts', () => prismaServerMocks)
+
+import { action, loader } from '../homework-completion.tsx'
+
+test('loader returns completion status for authenticated user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
+	clientServerMocks.getClientSession.mockResolvedValue({
+		getClientId: vi.fn().mockReturnValue('client-1'),
+		getHeaders: vi.fn().mockResolvedValue(new Headers()),
+	})
+	prismaServerMocks.getEpisodeHomeworkCompletions.mockResolvedValue(
+		new Set(['7:12:1']),
+	)
+
+	const request = new Request(
+		'http://localhost/resources/homework-completion?contentId=7:12:1',
+	)
+	const result = (await loader({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ completed: true, authenticated: true })
+	expect(prismaServerMocks.getEpisodeHomeworkCompletions).toHaveBeenCalledWith({
+		seasonNumber: 7,
+		episodeNumber: 12,
+		userId: 'user-1',
+	})
+})
+
+test('loader falls back to client session for anonymous user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue(null)
+	clientServerMocks.getClientSession.mockResolvedValue({
+		getClientId: vi.fn().mockReturnValue('client-1'),
+		getHeaders: vi.fn().mockResolvedValue(new Headers()),
+	})
+	prismaServerMocks.getEpisodeHomeworkCompletions.mockResolvedValue(new Set())
+
+	const request = new Request(
+		'http://localhost/resources/homework-completion?contentId=7:12:1',
+	)
+	const result = (await loader({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ completed: false, authenticated: false })
+	expect(prismaServerMocks.getEpisodeHomeworkCompletions).toHaveBeenCalledWith({
+		seasonNumber: 7,
+		episodeNumber: 12,
+		clientId: 'client-1',
+	})
+})
+
+test('action validates content ids', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue(null)
+	clientServerMocks.getClientSession.mockResolvedValue({
+		getClientId: vi.fn().mockReturnValue('client-1'),
+		getHeaders: vi.fn().mockResolvedValue(new Headers()),
+	})
+
+	const formData = new FormData()
+	formData.set('contentId', 'bad-id')
+	formData.set('completed', 'true')
+
+	const request = new Request('http://localhost/resources/homework-completion', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(400)
+	expect(result.data).toEqual({
+		completed: false,
+		authenticated: false,
+		error: 'INVALID_CONTENT_ID',
+	})
+	expect(litefsServerMocks.ensurePrimary).not.toHaveBeenCalled()
+	expect(prismaServerMocks.setEpisodeHomeworkCompletion).not.toHaveBeenCalled()
+})
+
+test('action stores completion for anonymous client', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue(null)
+	clientServerMocks.getClientSession.mockResolvedValue({
+		getClientId: vi.fn().mockReturnValue('client-1'),
+		getHeaders: vi.fn().mockResolvedValue(new Headers()),
+	})
+	prismaServerMocks.setEpisodeHomeworkCompletion.mockResolvedValue(true)
+
+	const formData = new FormData()
+	formData.set('contentId', '7:12:1')
+	formData.set('completed', 'true')
+
+	const request = new Request('http://localhost/resources/homework-completion', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ completed: true, authenticated: false })
+	expect(litefsServerMocks.ensurePrimary).toHaveBeenCalledTimes(1)
+	expect(prismaServerMocks.setEpisodeHomeworkCompletion).toHaveBeenCalledWith({
+		seasonNumber: 7,
+		episodeNumber: 12,
+		itemIndex: 1,
+		clientId: 'client-1',
+		completed: true,
+	})
+})

--- a/services/site/app/routes/resources/homework-completion.tsx
+++ b/services/site/app/routes/resources/homework-completion.tsx
@@ -63,7 +63,9 @@ export function HomeworkCompletionToggle({
 				? false
 				: undefined
 	const fetchedCompleted =
-		isHomeworkCompletionResponse(fetcher.data) && !fetcher.data.error
+		fetcher.state !== 'idle' &&
+		isHomeworkCompletionResponse(fetcher.data) &&
+		!fetcher.data.error
 			? fetcher.data.completed
 			: undefined
 	const isCompleted =

--- a/services/site/app/routes/resources/homework-completion.tsx
+++ b/services/site/app/routes/resources/homework-completion.tsx
@@ -273,9 +273,11 @@ export const headers: HeadersFunction = ({
 			errorHeaders,
 		}),
 	)
-	for (const [headerName, headerValue] of loaderHeaders.entries()) {
-		if (headerName.toLowerCase() === 'set-cookie') {
-			headers.append('Set-Cookie', headerValue)
+	for (const sourceHeaders of [loaderHeaders, actionHeaders]) {
+		for (const [headerName, headerValue] of sourceHeaders.entries()) {
+			if (headerName.toLowerCase() === 'set-cookie') {
+				headers.append('Set-Cookie', headerValue)
+			}
 		}
 	}
 	return headers

--- a/services/site/app/routes/resources/homework-completion.tsx
+++ b/services/site/app/routes/resources/homework-completion.tsx
@@ -1,0 +1,281 @@
+import * as React from 'react'
+import {
+	data as json,
+	Link,
+	useFetcher,
+	type HeadersFunction,
+} from 'react-router'
+import { z } from 'zod'
+import { clsx } from 'clsx'
+import { CheckIcon, CheckCircledIcon, SpinnerIcon } from '#app/components/icons.tsx'
+import {
+	getEpisodeHomeworkContentId,
+	parseEpisodeHomeworkContentId,
+} from '#app/utils/favorites.ts'
+import { reuseUsefulLoaderHeaders } from '#app/utils/misc.ts'
+import { type Route } from './+types/homework-completion'
+
+const homeworkCompletionResourceRoute = '/resources/homework-completion'
+
+type HomeworkCompletionResponse = {
+	completed: boolean
+	authenticated: boolean
+	error?: string
+}
+
+function isHomeworkCompletionResponse(
+	data: unknown,
+): data is HomeworkCompletionResponse {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'completed' in data &&
+		typeof (data as HomeworkCompletionResponse).completed === 'boolean' &&
+		'authenticated' in data &&
+		typeof (data as HomeworkCompletionResponse).authenticated === 'boolean'
+	)
+}
+
+export function HomeworkCompletionToggle({
+	seasonNumber,
+	episodeNumber,
+	itemIndex,
+	initialCompleted = false,
+	children,
+}: {
+	seasonNumber: number
+	episodeNumber: number
+	itemIndex: number
+	initialCompleted?: boolean
+	children: React.ReactNode
+}) {
+	const fetcherKey = `homework:${seasonNumber}:${episodeNumber}:${itemIndex}`
+	const fetcher = useFetcher<HomeworkCompletionResponse>({ key: fetcherKey })
+	const contentId = getEpisodeHomeworkContentId({
+		seasonNumber,
+		episodeNumber,
+		itemIndex,
+	})
+
+	const optimisticCompleted =
+		fetcher.formData?.get('completed') === 'true'
+			? true
+			: fetcher.formData?.get('completed') === 'false'
+				? false
+				: undefined
+	const fetchedCompleted = isHomeworkCompletionResponse(fetcher.data)
+		? fetcher.data.completed
+		: undefined
+	const isCompleted =
+		optimisticCompleted ?? fetchedCompleted ?? initialCompleted ?? false
+	const isBusy = fetcher.state !== 'idle'
+
+	const buttonContents = (
+		<>
+			<span
+				aria-hidden="true"
+				className={clsx(
+					'mt-1 mr-6 inline-flex h-10 w-10 flex-none items-center justify-center rounded-full border transition',
+					isCompleted
+						? 'border-emerald-600 bg-emerald-600 text-white shadow-[0_0_0_4px_rgba(16,185,129,0.12)] dark:border-emerald-400 dark:bg-emerald-500 dark:text-gray-950 dark:shadow-[0_0_0_4px_rgba(52,211,153,0.16)]'
+						: 'border-gray-300 bg-white text-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-500',
+				)}
+			>
+				{isBusy ? (
+					<SpinnerIcon size={18} className="animate-spin" />
+				) : isCompleted ? (
+					<CheckIcon />
+				) : (
+					<CheckCircledIcon size={20} className="opacity-65" />
+				)}
+			</span>
+			<span
+				className={clsx(
+					'min-w-0 transition',
+					isCompleted
+						? 'text-primary'
+						: 'text-primary/90 dark:text-white/90',
+				)}
+			>
+				{children}
+			</span>
+		</>
+	)
+
+	if (
+		fetcher.data &&
+		isHomeworkCompletionResponse(fetcher.data) &&
+		fetcher.data.error === 'LOGIN_REQUIRED'
+	) {
+		return (
+			<Link
+				to="/login"
+				className="group focus-ring flex w-full items-start rounded-lg px-2 py-2 text-left transition focus:outline-none"
+			>
+				{buttonContents}
+			</Link>
+		)
+	}
+
+	return (
+		<fetcher.Form method="POST" action={homeworkCompletionResourceRoute}>
+			<input type="hidden" name="contentId" value={contentId} />
+			<input
+				type="hidden"
+				name="completed"
+				value={String(!isCompleted)}
+			/>
+			<button
+				type="submit"
+				disabled={isBusy}
+				aria-pressed={isCompleted}
+				className={clsx(
+					'group focus-ring flex w-full items-start rounded-lg px-2 py-2 text-left transition focus:outline-none',
+					isCompleted
+						? 'bg-emerald-50/90 hover:bg-emerald-50 dark:bg-emerald-500/10 dark:hover:bg-emerald-500/15'
+						: 'hover:bg-black/3 dark:hover:bg-white/4',
+				)}
+			>
+				{buttonContents}
+			</button>
+		</fetcher.Form>
+	)
+}
+
+async function getHomeworkCompletionServerServices() {
+	const [
+		{ ensurePrimary },
+		{ getUser },
+		{ getClientSession },
+		{ setEpisodeHomeworkCompletion, getEpisodeHomeworkCompletions },
+	] = await Promise.all([
+		import('#app/utils/litefs-js.server.ts'),
+		import('#app/utils/session.server.ts'),
+		import('#app/utils/client.server.ts'),
+		import('#app/utils/prisma.server.ts'),
+	])
+	return {
+		ensurePrimary,
+		getUser,
+		getClientSession,
+		setEpisodeHomeworkCompletion,
+		getEpisodeHomeworkCompletions,
+	}
+}
+
+const HomeworkCompletionFormSchema = z.object({
+	contentId: z.string().min(1).max(200),
+	completed: z.enum(['true', 'false']).transform((value) => value === 'true'),
+})
+
+export async function action({ request }: Route.ActionArgs) {
+	const {
+		ensurePrimary,
+		getUser,
+		getClientSession,
+		setEpisodeHomeworkCompletion,
+	} = await getHomeworkCompletionServerServices()
+	const formData = await request.formData()
+	const submission = HomeworkCompletionFormSchema.safeParse(
+		Object.fromEntries(formData),
+	)
+	if (!submission.success) {
+		return json(
+			{ completed: false, authenticated: false, error: 'INVALID_FORM_DATA' },
+			{ status: 400 },
+		)
+	}
+
+	const parsedContentId = parseEpisodeHomeworkContentId(submission.data.contentId)
+	if (!parsedContentId) {
+		return json(
+			{ completed: false, authenticated: false, error: 'INVALID_CONTENT_ID' },
+			{ status: 400 },
+		)
+	}
+
+	await ensurePrimary()
+
+	const user = await getUser(request)
+	const clientSession = await getClientSession(request, user)
+	const clientId = clientSession.getClientId()
+	if (!user && !clientId) {
+		return json(
+			{ completed: false, authenticated: false, error: 'MISSING_CLIENT_ID' },
+			{ status: 400 },
+		)
+	}
+	const completed = user
+		? await setEpisodeHomeworkCompletion({
+				...parsedContentId,
+				completed: submission.data.completed,
+				userId: user.id,
+			})
+		: await setEpisodeHomeworkCompletion({
+				...parsedContentId,
+				completed: submission.data.completed,
+				clientId: clientId!,
+			})
+
+	const headers = await clientSession.getHeaders()
+	return json(
+		{
+			completed,
+			authenticated: Boolean(user),
+		} satisfies HomeworkCompletionResponse,
+		{ headers },
+	)
+}
+
+const HomeworkCompletionQuerySchema = z.object({
+	contentId: z.string().min(1).max(200),
+})
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const { getUser, getClientSession, getEpisodeHomeworkCompletions } =
+		await getHomeworkCompletionServerServices()
+	const headers = {
+		'Cache-Control': 'private, max-age=0, must-revalidate',
+		Vary: 'Cookie',
+	}
+	const url = new URL(request.url)
+	const submission = HomeworkCompletionQuerySchema.safeParse({
+		contentId: url.searchParams.get('contentId'),
+	})
+	if (!submission.success) {
+		return json(
+			{ completed: false, authenticated: false, error: 'INVALID_QUERY' },
+			{ status: 400, headers },
+		)
+	}
+
+	const parsedContentId = parseEpisodeHomeworkContentId(submission.data.contentId)
+	if (!parsedContentId) {
+		return json(
+			{ completed: false, authenticated: false, error: 'INVALID_CONTENT_ID' },
+			{ status: 400, headers },
+		)
+	}
+
+	const user = await getUser(request)
+	const clientSession = await getClientSession(request, user)
+	const clientId = clientSession.getClientId()
+	const completionIds = await getEpisodeHomeworkCompletions({
+		seasonNumber: parsedContentId.seasonNumber,
+		episodeNumber: parsedContentId.episodeNumber,
+		...(user ? { userId: user.id } : clientId ? { clientId } : {}),
+	})
+	return json(
+		{
+			completed: completionIds.has(submission.data.contentId),
+			authenticated: Boolean(user),
+		} satisfies HomeworkCompletionResponse,
+		{
+			headers: await clientSession.getHeaders(headers),
+		},
+	)
+}
+
+export const headers: HeadersFunction = reuseUsefulLoaderHeaders
+
+export { homeworkCompletionResourceRoute }

--- a/services/site/app/routes/resources/homework-completion.tsx
+++ b/services/site/app/routes/resources/homework-completion.tsx
@@ -36,6 +36,15 @@ function isHomeworkCompletionResponse(
 	)
 }
 
+function isHomeworkCompletionSuccessResponse(
+	data: unknown,
+): data is HomeworkCompletionResponse & { error?: undefined } {
+	return (
+		isHomeworkCompletionResponse(data) &&
+		(!('error' in data) || data.error === undefined)
+	)
+}
+
 export function HomeworkCompletionToggle({
 	seasonNumber,
 	episodeNumber,
@@ -63,7 +72,7 @@ export function HomeworkCompletionToggle({
 			: fetcher.formData?.get('completed') === 'false'
 				? false
 				: undefined
-	const fetchedCompleted = isHomeworkCompletionResponse(fetcher.data)
+	const fetchedCompleted = isHomeworkCompletionSuccessResponse(fetcher.data)
 		? fetcher.data.completed
 		: undefined
 	const isCompleted =
@@ -276,6 +285,26 @@ export async function loader({ request }: Route.LoaderArgs) {
 	)
 }
 
-export const headers: HeadersFunction = reuseUsefulLoaderHeaders
+export const headers: HeadersFunction = ({
+	loaderHeaders,
+	parentHeaders,
+	actionHeaders,
+	errorHeaders,
+}) => {
+	const headers = new Headers(
+		reuseUsefulLoaderHeaders({
+			loaderHeaders,
+			parentHeaders,
+			actionHeaders,
+			errorHeaders,
+		}),
+	)
+	for (const [headerName, headerValue] of loaderHeaders.entries()) {
+		if (headerName.toLowerCase() === 'set-cookie') {
+			headers.append('Set-Cookie', headerValue)
+		}
+	}
+	return headers
+}
 
 export { homeworkCompletionResourceRoute }

--- a/services/site/app/routes/resources/homework-completion.tsx
+++ b/services/site/app/routes/resources/homework-completion.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react'
-import {
-	data as json,
-	Link,
-	useFetcher,
-	type HeadersFunction,
-} from 'react-router'
+import { data as json, useFetcher, type HeadersFunction } from 'react-router'
 import { z } from 'zod'
 import { clsx } from 'clsx'
-import { CheckIcon, CheckCircledIcon, SpinnerIcon } from '#app/components/icons.tsx'
+import {
+	CheckIcon,
+	CheckCircledIcon,
+	SpinnerIcon,
+} from '#app/components/icons.tsx'
 import {
 	getEpisodeHomeworkContentId,
 	parseEpisodeHomeworkContentId,
@@ -33,15 +32,6 @@ function isHomeworkCompletionResponse(
 		typeof (data as HomeworkCompletionResponse).completed === 'boolean' &&
 		'authenticated' in data &&
 		typeof (data as HomeworkCompletionResponse).authenticated === 'boolean'
-	)
-}
-
-function isHomeworkCompletionSuccessResponse(
-	data: unknown,
-): data is HomeworkCompletionResponse & { error?: undefined } {
-	return (
-		isHomeworkCompletionResponse(data) &&
-		(!('error' in data) || data.error === undefined)
 	)
 }
 
@@ -72,9 +62,10 @@ export function HomeworkCompletionToggle({
 			: fetcher.formData?.get('completed') === 'false'
 				? false
 				: undefined
-	const fetchedCompleted = isHomeworkCompletionSuccessResponse(fetcher.data)
-		? fetcher.data.completed
-		: undefined
+	const fetchedCompleted =
+		isHomeworkCompletionResponse(fetcher.data) && !fetcher.data.error
+			? fetcher.data.completed
+			: undefined
 	const isCompleted =
 		optimisticCompleted ?? fetchedCompleted ?? initialCompleted ?? false
 	const isBusy = fetcher.state !== 'idle'
@@ -101,9 +92,7 @@ export function HomeworkCompletionToggle({
 			<span
 				className={clsx(
 					'min-w-0 transition',
-					isCompleted
-						? 'text-primary'
-						: 'text-primary/90 dark:text-white/90',
+					isCompleted ? 'text-primary' : 'text-primary/90 dark:text-white/90',
 				)}
 			>
 				{children}
@@ -111,29 +100,10 @@ export function HomeworkCompletionToggle({
 		</>
 	)
 
-	if (
-		fetcher.data &&
-		isHomeworkCompletionResponse(fetcher.data) &&
-		fetcher.data.error === 'LOGIN_REQUIRED'
-	) {
-		return (
-			<Link
-				to="/login"
-				className="group focus-ring flex w-full items-start rounded-lg px-2 py-2 text-left transition focus:outline-none"
-			>
-				{buttonContents}
-			</Link>
-		)
-	}
-
 	return (
 		<fetcher.Form method="POST" action={homeworkCompletionResourceRoute}>
 			<input type="hidden" name="contentId" value={contentId} />
-			<input
-				type="hidden"
-				name="completed"
-				value={String(!isCompleted)}
-			/>
+			<input type="hidden" name="completed" value={String(!isCompleted)} />
 			<button
 				type="submit"
 				disabled={isBusy}
@@ -195,7 +165,9 @@ export async function action({ request }: Route.ActionArgs) {
 		)
 	}
 
-	const parsedContentId = parseEpisodeHomeworkContentId(submission.data.contentId)
+	const parsedContentId = parseEpisodeHomeworkContentId(
+		submission.data.contentId,
+	)
 	if (!parsedContentId) {
 		return json(
 			{ completed: false, authenticated: false, error: 'INVALID_CONTENT_ID' },
@@ -258,7 +230,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 		)
 	}
 
-	const parsedContentId = parseEpisodeHomeworkContentId(submission.data.contentId)
+	const parsedContentId = parseEpisodeHomeworkContentId(
+		submission.data.contentId,
+	)
 	if (!parsedContentId) {
 		return json(
 			{ completed: false, authenticated: false, error: 'INVALID_CONTENT_ID' },
@@ -306,5 +280,3 @@ export const headers: HeadersFunction = ({
 	}
 	return headers
 }
-
-export { homeworkCompletionResourceRoute }

--- a/services/site/app/routes/signup.tsx
+++ b/services/site/app/routes/signup.tsx
@@ -31,7 +31,10 @@ import {
 	getPasswordHash,
 	getPasswordStrengthError,
 } from '#app/utils/password.server.ts'
-import { prisma } from '#app/utils/prisma.server.ts'
+import {
+	migrateHomeworkCompletionsToUser,
+	prisma,
+} from '#app/utils/prisma.server.ts'
 import { sendSignupVerificationEmail } from '#app/utils/send-email.server.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
 import { useTeam } from '#app/utils/team-provider.tsx'
@@ -342,6 +345,10 @@ export async function action({ request }: Route.ActionArgs) {
 				await prisma.postRead.updateMany({
 					data: { userId: user.id, clientId: null },
 					where: { clientId },
+				})
+				await migrateHomeworkCompletionsToUser({
+					userId: user.id,
+					clientId,
 				})
 			}
 			clientSession.setUser({})

--- a/services/site/app/utils/favorites.ts
+++ b/services/site/app/utils/favorites.ts
@@ -36,3 +36,34 @@ export function parseEpisodeFavoriteContentId(contentId: string) {
 	if (String(episodeNumber) !== episodeRaw) return null
 	return { seasonNumber, episodeNumber }
 }
+
+/**
+ * Canonical identifier for one homework item within a Chats with Kent episode.
+ * Stored without leading zeroes so we have exactly one representation.
+ */
+export function getEpisodeHomeworkContentId({
+	seasonNumber,
+	episodeNumber,
+	itemIndex,
+}: {
+	seasonNumber: number
+	episodeNumber: number
+	itemIndex: number
+}) {
+	return `${String(seasonNumber)}:${String(episodeNumber)}:${String(itemIndex)}`
+}
+
+export function parseEpisodeHomeworkContentId(contentId: string) {
+	const [seasonRaw, episodeRaw, itemIndexRaw, ...rest] = contentId.split(':')
+	if (!seasonRaw || !episodeRaw || !itemIndexRaw || rest.length) return null
+	const seasonNumber = Number(seasonRaw)
+	const episodeNumber = Number(episodeRaw)
+	const itemIndex = Number(itemIndexRaw)
+	if (!Number.isInteger(seasonNumber) || seasonNumber < 1) return null
+	if (!Number.isInteger(episodeNumber) || episodeNumber < 1) return null
+	if (!Number.isInteger(itemIndex) || itemIndex < 0) return null
+	if (String(seasonNumber) !== seasonRaw) return null
+	if (String(episodeNumber) !== episodeRaw) return null
+	if (String(itemIndex) !== itemIndexRaw) return null
+	return { seasonNumber, episodeNumber, itemIndex }
+}

--- a/services/site/app/utils/prisma.server.ts
+++ b/services/site/app/utils/prisma.server.ts
@@ -4,8 +4,9 @@ import chalk from 'chalk'
 import pProps from 'p-props'
 import { type Session } from '#app/types.ts'
 import { getEnv } from '#app/utils/env.server.ts'
+import { getEpisodeHomeworkContentId } from '#app/utils/favorites.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
-import { PrismaClient } from './prisma-generated.server/client.ts'
+import { Prisma, PrismaClient } from './prisma-generated.server/client.ts'
 import { time, type Timings } from './timing.server.ts'
 
 const logThreshold = 500
@@ -156,13 +157,196 @@ async function addPostRead({
 	}
 }
 
+async function getEpisodeHomeworkCompletions({
+	seasonNumber,
+	episodeNumber,
+	userId,
+	clientId,
+}: {
+	seasonNumber: number
+	episodeNumber: number
+} & (
+	| { userId: string; clientId?: undefined | null }
+	| { userId?: undefined | null; clientId: string }
+	| { userId?: undefined | null; clientId?: undefined | null }
+)) {
+	const ownerWhere = userId ? { userId } : clientId ? { clientId } : null
+	if (!ownerWhere) return new Set<string>()
+	const completions = await prisma.homeworkCompletion.findMany({
+		where: {
+			...ownerWhere,
+			seasonNumber,
+			episodeNumber,
+		},
+		select: { itemIndex: true },
+	})
+	return new Set(
+		completions.map((completion) =>
+			getEpisodeHomeworkContentId({
+				seasonNumber,
+				episodeNumber,
+				itemIndex: completion.itemIndex,
+			}),
+		),
+	)
+}
+
+async function setEpisodeHomeworkCompletion({
+	seasonNumber,
+	episodeNumber,
+	itemIndex,
+	userId,
+	clientId,
+	completed,
+}: {
+	seasonNumber: number
+	episodeNumber: number
+	itemIndex: number
+	completed: boolean
+} & (
+	| { userId: string; clientId?: undefined | null }
+	| { userId?: undefined | null; clientId: string }
+)) {
+	if (userId) {
+		if (completed) {
+			await prisma.homeworkCompletion.upsert({
+				where: {
+					userId_seasonNumber_episodeNumber_itemIndex: {
+						userId,
+						seasonNumber,
+						episodeNumber,
+						itemIndex,
+					},
+				},
+				create: {
+					userId,
+					seasonNumber,
+					episodeNumber,
+					itemIndex,
+				},
+				update: {
+					updatedAt: new Date(),
+				},
+			})
+			return true
+		}
+
+		await prisma.homeworkCompletion.deleteMany({
+			where: {
+				userId,
+				seasonNumber,
+				episodeNumber,
+				itemIndex,
+			},
+		})
+		return false
+	}
+
+	const anonymousClientId = clientId
+	if (!anonymousClientId) {
+		throw new Error('clientId is required when userId is absent')
+	}
+
+	if (completed) {
+		await prisma.homeworkCompletion.upsert({
+			where: {
+				clientId_seasonNumber_episodeNumber_itemIndex: {
+					clientId: anonymousClientId,
+					seasonNumber,
+					episodeNumber,
+					itemIndex,
+				},
+			},
+			create: {
+				clientId: anonymousClientId,
+				seasonNumber,
+				episodeNumber,
+				itemIndex,
+			},
+			update: {
+				updatedAt: new Date(),
+			},
+		})
+		return true
+	}
+
+	await prisma.homeworkCompletion.deleteMany({
+		where: {
+			clientId: anonymousClientId,
+			seasonNumber,
+			episodeNumber,
+			itemIndex,
+		},
+	})
+	return false
+}
+
+async function migrateHomeworkCompletionsToUser({
+	userId,
+	clientId,
+}: {
+	userId: string
+	clientId: string
+}) {
+	const completions = await prisma.homeworkCompletion.findMany({
+		where: { clientId },
+		select: {
+			id: true,
+			seasonNumber: true,
+			episodeNumber: true,
+			itemIndex: true,
+		},
+	})
+	if (completions.length === 0) return 0
+
+	await prisma.$transaction(async (tx) => {
+		for (const completion of completions) {
+			try {
+				await tx.homeworkCompletion.upsert({
+					where: {
+						userId_seasonNumber_episodeNumber_itemIndex: {
+							userId,
+							seasonNumber: completion.seasonNumber,
+							episodeNumber: completion.episodeNumber,
+							itemIndex: completion.itemIndex,
+						},
+					},
+					create: {
+						userId,
+						seasonNumber: completion.seasonNumber,
+						episodeNumber: completion.episodeNumber,
+						itemIndex: completion.itemIndex,
+					},
+					update: {
+						updatedAt: new Date(),
+					},
+				})
+			} catch (error) {
+				if (
+					!(error instanceof Prisma.PrismaClientKnownRequestError) ||
+					error.code !== 'P2002'
+				) {
+					throw error
+				}
+			}
+		}
+
+		await tx.homeworkCompletion.deleteMany({ where: { clientId } })
+	})
+
+	return completions.length
+}
+
 export {
 	addPostRead,
 	createSession,
 	deleteExpiredSessions,
 	deleteExpiredVerifications,
 	getAllUserData,
+	getEpisodeHomeworkCompletions,
 	getUserFromSessionId,
+	migrateHomeworkCompletionsToUser,
 	prisma,
+	setEpisodeHomeworkCompletion,
 	sessionExpirationTime,
 }

--- a/services/site/app/utils/prisma.server.ts
+++ b/services/site/app/utils/prisma.server.ts
@@ -288,18 +288,18 @@ async function migrateHomeworkCompletionsToUser({
 	userId: string
 	clientId: string
 }) {
-	const completions = await prisma.homeworkCompletion.findMany({
-		where: { clientId },
-		select: {
-			id: true,
-			seasonNumber: true,
-			episodeNumber: true,
-			itemIndex: true,
-		},
-	})
-	if (completions.length === 0) return 0
+	return prisma.$transaction(async (tx) => {
+		const completions = await tx.homeworkCompletion.findMany({
+			where: { clientId },
+			select: {
+				id: true,
+				seasonNumber: true,
+				episodeNumber: true,
+				itemIndex: true,
+			},
+		})
+		if (completions.length === 0) return 0
 
-	await prisma.$transaction(async (tx) => {
 		for (const completion of completions) {
 			try {
 				await tx.homeworkCompletion.upsert({
@@ -332,9 +332,8 @@ async function migrateHomeworkCompletionsToUser({
 		}
 
 		await tx.homeworkCompletion.deleteMany({ where: { clientId } })
+		return completions.length
 	})
-
-	return completions.length
 }
 
 export {

--- a/services/site/app/utils/prisma.server.ts
+++ b/services/site/app/utils/prisma.server.ts
@@ -288,7 +288,8 @@ async function migrateHomeworkCompletionsToUser({
 	userId: string
 	clientId: string
 }) {
-	return prisma.$transaction(async (tx) => {
+	let completionCount = 0
+	await prisma.$transaction(async (tx) => {
 		const completions = await tx.homeworkCompletion.findMany({
 			where: { clientId },
 			select: {
@@ -298,7 +299,10 @@ async function migrateHomeworkCompletionsToUser({
 				itemIndex: true,
 			},
 		})
-		if (completions.length === 0) return 0
+		if (completions.length === 0) {
+			return
+		}
+		completionCount = completions.length
 
 		for (const completion of completions) {
 			try {
@@ -332,8 +336,9 @@ async function migrateHomeworkCompletionsToUser({
 		}
 
 		await tx.homeworkCompletion.deleteMany({ where: { clientId } })
-		return completions.length
 	})
+
+	return completionCount
 }
 
 export {

--- a/services/site/prisma/migrations/20260401162552_homework_completions/migration.sql
+++ b/services/site/prisma/migrations/20260401162552_homework_completions/migration.sql
@@ -8,7 +8,8 @@ CREATE TABLE "HomeworkCompletion" (
     "seasonNumber" INTEGER NOT NULL,
     "episodeNumber" INTEGER NOT NULL,
     "itemIndex" INTEGER NOT NULL,
-    CONSTRAINT "HomeworkCompletion_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT "HomeworkCompletion_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "HomeworkCompletion_owner_check" CHECK ("userId" IS NOT NULL OR "clientId" IS NOT NULL)
 );
 
 -- CreateIndex

--- a/services/site/prisma/migrations/20260401162552_homework_completions/migration.sql
+++ b/services/site/prisma/migrations/20260401162552_homework_completions/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "HomeworkCompletion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT,
+    "clientId" TEXT,
+    "seasonNumber" INTEGER NOT NULL,
+    "episodeNumber" INTEGER NOT NULL,
+    "itemIndex" INTEGER NOT NULL,
+    CONSTRAINT "HomeworkCompletion_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "HomeworkCompletion_userId_seasonNumber_episodeNumber_idx" ON "HomeworkCompletion"("userId", "seasonNumber", "episodeNumber");
+
+-- CreateIndex
+CREATE INDEX "HomeworkCompletion_clientId_seasonNumber_episodeNumber_idx" ON "HomeworkCompletion"("clientId", "seasonNumber", "episodeNumber");
+
+-- CreateIndex
+CREATE INDEX "HomeworkCompletion_seasonNumber_episodeNumber_itemIndex_createdAt_idx" ON "HomeworkCompletion"("seasonNumber", "episodeNumber", "itemIndex", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HomeworkCompletion_userId_seasonNumber_episodeNumber_itemIndex_key" ON "HomeworkCompletion"("userId", "seasonNumber", "episodeNumber", "itemIndex");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HomeworkCompletion_clientId_seasonNumber_episodeNumber_itemIndex_key" ON "HomeworkCompletion"("clientId", "seasonNumber", "episodeNumber", "itemIndex");

--- a/services/site/prisma/schema.prisma
+++ b/services/site/prisma/schema.prisma
@@ -34,6 +34,7 @@ model User {
   sessions  Session[]
   postReads PostRead[]
   favorites Favorite[]
+  homeworkCompletions HomeworkCompletion[]
 
   @@index([team])
   @@index([createdAt])
@@ -209,4 +210,22 @@ model Favorite {
   @@unique([userId, contentType, contentId])
   @@index([userId, createdAt])
   @@index([contentType, contentId])
+}
+
+model HomeworkCompletion {
+  id            String   @id @default(uuid())
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  user          User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId        String?
+  clientId      String?
+  seasonNumber  Int
+  episodeNumber Int
+  itemIndex     Int
+
+  @@unique([userId, seasonNumber, episodeNumber, itemIndex])
+  @@unique([clientId, seasonNumber, episodeNumber, itemIndex])
+  @@index([userId, seasonNumber, episodeNumber])
+  @@index([clientId, seasonNumber, episodeNumber])
+  @@index([seasonNumber, episodeNumber, itemIndex, createdAt])
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `HomeworkCompletion` Prisma model and migration for per-episode homework item state
- add a resource route plus auth migration hooks so homework completion persists for anonymous and signed-in users
- make Chats with Kent homework checkboxes interactive with green checked styling that works in light and dark mode
- address review feedback by preserving `Set-Cookie`, ignoring error responses when deriving checkbox state, tightening homework migration atomicity, and adding authenticated resource-route coverage

## Testing
- `npx prisma migrate dev --name homework-completions`
- `npm run lint`
- `npm run typecheck`
- `npx vitest --run --config vitest.config.ts app/routes/resources/__tests__/homework-completion.test.ts`
- manual browser walkthrough on `/chats/05/01/communis-sunt-appono` showing toggle in light mode, reload persistence, dark mode styling, and uncheck flow

[homework-checkboxes-light-dark-persistence-demo.mp4](https://cursor.com/agents/bc-0d9a289a-f5a3-4065-8b98-d6fa82c89dca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomework-checkboxes-light-dark-persistence-demo.mp4)
[Homework checkbox checked in light mode](https://cursor.com/agents/bc-0d9a289a-f5a3-4065-8b98-d6fa82c89dca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomework-checkbox-checked-light.webp)
[Homework checkbox checked in dark mode](https://cursor.com/agents/bc-0d9a289a-f5a3-4065-8b98-d6fa82c89dca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomework-checkbox-checked-dark.webp)
[Homework checkbox persists after reload](https://cursor.com/agents/bc-0d9a289a-f5a3-4065-8b98-d6fa82c89dca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomework-checkbox-persists-after-reload.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d9a289a-f5a3-4065-8b98-d6fa82c89dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d9a289a-f5a3-4065-8b98-d6fa82c89dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homework is now server-driven with per-item completion toggles that persist for anonymous and signed-in users; toggles show loading state and disable while saving.
  * Anonymous homework progress is migrated into accounts on signup, login, and password reset.
  * Added canonical IDs/parsing for homework items and a new persistence backend (DB/table + server APIs).

* **Tests**
  * Added tests covering loader/action flows and persistence for anonymous and authenticated states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->