### PR TITLE
Auto-dismiss season 7 promo on chats routes

### DIFF
--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -38,6 +38,8 @@ import { Navbar } from './components/navbar.tsx'
 import { NotificationMessage } from './components/notification-message.tsx'
 import {
 	Promotification,
+	PROMO_HIDDEN_COOKIE_VALUE,
+	createPromoHiddenSetCookieHeader,
 	getPromoCookieValue,
 } from './routes/resources/promotification.tsx'
 import { Spacer } from './components/spacer.tsx'
@@ -54,6 +56,7 @@ import { getPublicEnv } from './utils/env.server.ts'
 import { getLoginInfoSession } from './utils/login.server.ts'
 import { useNonce } from './utils/nonce-provider.ts'
 import { getLatestPodcastSeasonLinks } from './utils/podcast-latest-season.server.ts'
+import { isSeason7ChatsPath } from './utils/season-7-promotification.ts'
 import { getSocialMetas } from './utils/seo.ts'
 import { getSession } from './utils/session.server.ts'
 import { TeamProvider, useTeam } from './utils/team-provider.tsx'
@@ -136,6 +139,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
 	const loaderStart = performance.now()
 	const podcastLinksAbortController = new AbortController()
+	const requestPath = new URL(request.url).pathname
 	const session = await getSession(request)
 	const [
 		user,
@@ -179,16 +183,18 @@ export async function loader({ request }: Route.LoaderArgs) {
 		user,
 		userInfo: user ? await getUserInfo(user, { request, timings }) : null,
 		latestPodcastSeasonLinks,
-		season7PromotificationCookieValue: getPromoCookieValue({
-			promoName: SEASON_7_PROMOTIFICATION_NAME,
-			request,
-		}),
+		season7PromotificationCookieValue: isSeason7ChatsPath(requestPath)
+			? PROMO_HIDDEN_COOKIE_VALUE
+			: getPromoCookieValue({
+					promoName: SEASON_7_PROMOTIFICATION_NAME,
+					request,
+			}),
 		ENV: getPublicEnv(),
 		randomFooterImageKey,
 		requestInfo: {
 			hints: getHints(request),
 			origin: getDomainUrl(request),
-			path: new URL(request.url).pathname,
+			path: requestPath,
 			flyPrimaryInstance: primaryInstance,
 			userPrefs: {
 				theme: getTheme(request),
@@ -208,6 +214,20 @@ export async function loader({ request }: Route.LoaderArgs) {
 	await session.getHeaders(headers)
 	await clientSession.getHeaders(headers)
 	await loginInfoSession.getHeaders(headers)
+	if (
+		isSeason7ChatsPath(requestPath) &&
+		getPromoCookieValue({
+			promoName: SEASON_7_PROMOTIFICATION_NAME,
+			request,
+		}) !== PROMO_HIDDEN_COOKIE_VALUE
+	) {
+		headers.append(
+			'Set-Cookie',
+			createPromoHiddenSetCookieHeader({
+				promoName: SEASON_7_PROMOTIFICATION_NAME,
+			}),
+		)
+	}
 	// Add root loader total for production diagnostics (visible in Server-Timing)
 	const rootLoaderTotal = performance.now() - loaderStart
 	const rootTimings = {

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -56,7 +56,10 @@ import { getPublicEnv } from './utils/env.server.ts'
 import { getLoginInfoSession } from './utils/login.server.ts'
 import { useNonce } from './utils/nonce-provider.ts'
 import { getLatestPodcastSeasonLinks } from './utils/podcast-latest-season.server.ts'
-import { isSeason7ChatsPath } from './utils/season-7-promotification.ts'
+import {
+	isSeason7ChatsPath,
+	SEASON_7_PROMOTIFICATION_NAME,
+} from './utils/season-7-promotification.ts'
 import { getSocialMetas } from './utils/seo.ts'
 import { getSession } from './utils/session.server.ts'
 import { TeamProvider, useTeam } from './utils/team-provider.tsx'
@@ -132,8 +135,6 @@ const PODCAST_LINKS_FALLBACK = {
 	chats: { latestSeasonNumber: null, latestSeasonPath: '/chats' },
 	calls: { latestSeasonNumber: null, latestSeasonPath: '/calls' },
 } as const
-
-const SEASON_7_PROMOTIFICATION_NAME = 'chats-with-kent-season-7'
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}

--- a/services/site/app/routes/resources/promotification.tsx
+++ b/services/site/app/routes/resources/promotification.tsx
@@ -15,6 +15,10 @@ import { Spinner } from '#app/components/spinner.tsx'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { type Route } from './+types/promotification'
 
+export const PROMO_HIDDEN_COOKIE_VALUE = 'hidden'
+const DEFAULT_PROMO_MAX_AGE_SECONDS = 60 * 60 * 24 * 7 * 2
+const MAX_PROMO_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10
+
 export function getPromoCookieValue({
 	promoName,
 	request,
@@ -24,6 +28,24 @@ export function getPromoCookieValue({
 }) {
 	const cookies = cookie.parseCookie(request.headers.get('Cookie') || '')
 	return cookies[promoName]
+}
+
+export function createPromoHiddenSetCookieHeader({
+	promoName,
+	maxAge = DEFAULT_PROMO_MAX_AGE_SECONDS,
+}: {
+	promoName: string
+	maxAge?: number
+}) {
+	return cookie.stringifySetCookie({
+		name: promoName,
+		value: PROMO_HIDDEN_COOKIE_VALUE,
+		httpOnly: true,
+		secure: true,
+		sameSite: 'lax',
+		path: '/',
+		maxAge,
+	})
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -39,23 +61,13 @@ export async function action({ request }: Route.ActionArgs) {
 		})
 	}
 
-	const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 * 7 * 2
-	const MAX_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10
 	const rawMaxAge = Number(formData.get('maxAge'))
 	const maxAge =
 		Number.isFinite(rawMaxAge) && rawMaxAge > 0
-			? Math.min(Math.floor(rawMaxAge), MAX_MAX_AGE_SECONDS)
-			: DEFAULT_MAX_AGE_SECONDS
+			? Math.min(Math.floor(rawMaxAge), MAX_PROMO_MAX_AGE_SECONDS)
+			: DEFAULT_PROMO_MAX_AGE_SECONDS
 
-	const cookieHeader = cookie.stringifySetCookie({
-		name: promoName,
-		value: 'hidden',
-		httpOnly: true,
-		secure: true,
-		sameSite: 'lax',
-		path: '/',
-		maxAge,
-	})
+	const cookieHeader = createPromoHiddenSetCookieHeader({ promoName, maxAge })
 	return json({ success: true } as const, {
 		headers: { 'Set-Cookie': cookieHeader },
 	})

--- a/services/site/app/utils/__tests__/season-7-promotification.test.ts
+++ b/services/site/app/utils/__tests__/season-7-promotification.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import { expect, test } from 'vitest'
+
+import {
+	isSeason7ChatsPath,
+	SEASON_7_PROMOTIFICATION_NAME,
+} from '../season-7-promotification.ts'
+import {
+	PROMO_HIDDEN_COOKIE_VALUE,
+	createPromoHiddenSetCookieHeader,
+} from '#app/routes/resources/promotification.tsx'
+
+test('matches season 7 chats landing and child routes', () => {
+	expect(isSeason7ChatsPath('/chats/07')).toBe(true)
+	expect(isSeason7ChatsPath('/chats/07/01/example-episode')).toBe(true)
+	expect(isSeason7ChatsPath('/chats/7')).toBe(true)
+	expect(isSeason7ChatsPath('/chats/7/1/example-episode')).toBe(true)
+})
+
+test('does not match other chats routes', () => {
+	expect(isSeason7ChatsPath('/chats')).toBe(false)
+	expect(isSeason7ChatsPath('/chats/06')).toBe(false)
+	expect(isSeason7ChatsPath('/chats/08/01/example-episode')).toBe(false)
+	expect(isSeason7ChatsPath('/calls/07')).toBe(false)
+})
+
+test('creates the hidden season 7 promo cookie header', () => {
+	const cookieHeader = createPromoHiddenSetCookieHeader({
+		promoName: SEASON_7_PROMOTIFICATION_NAME,
+	})
+
+	expect(cookieHeader).toContain(
+		`${SEASON_7_PROMOTIFICATION_NAME}=${PROMO_HIDDEN_COOKIE_VALUE}`,
+	)
+	expect(cookieHeader).toContain('HttpOnly')
+	expect(cookieHeader).toContain('Path=/')
+})

--- a/services/site/app/utils/season-7-promotification.ts
+++ b/services/site/app/utils/season-7-promotification.ts
@@ -1,0 +1,5 @@
+export const SEASON_7_PROMOTIFICATION_NAME = 'chats-with-kent-season-7'
+
+export function isSeason7ChatsPath(pathname: string) {
+	return /^\/chats\/(?:0?7)(?:\/|$)/.test(pathname)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- auto-dismiss the Season 7 Chats with Kent promotification on `/chats/07`, `/chats/7`, and their child routes
- persist the hidden promo cookie from the root loader on those routes so the banner does not flash on first render or later navigation
- add a focused regression test for the route matcher and promo cookie helper

## Testing
- `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/season-7-promotification.test.ts app/routes/resources/__tests__/promotification.test.ts`
- `npm run lint --workspace kentcdodds.com -- app/root.tsx app/routes/resources/promotification.tsx app/utils/season-7-promotification.ts app/utils/__tests__/season-7-promotification.test.ts`
- `npm run typecheck --workspace kentcdodds.com`
- manual browser verification on `http://127.0.0.1:3000/chats/07` and `http://127.0.0.1:3000/chats/07/01/example-episode` showing the promo banner stays absent
- HTTP verification showing both routes return `Set-Cookie: chats-with-kent-season-7=hidden` and do not include the promo copy in the rendered HTML

## Artifacts
[season-7-promo-auto-dismiss-clean.mp4](https://cursor.com/agents/bc-9e7189e5-3dc3-47be-aa68-c8617347aac2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseason-7-promo-auto-dismiss-clean.mp4)
[/chats/07 without promo banner](https://cursor.com/agents/bc-9e7189e5-3dc3-47be-aa68-c8617347aac2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats-07-no-promo-top-clean.webp)
[/chats/07 season area without promo banner](https://cursor.com/agents/bc-9e7189e5-3dc3-47be-aa68-c8617347aac2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats-07-no-promo-season-area-clean.webp)
[child route without promo banner](https://cursor.com/agents/bc-9e7189e5-3dc3-47be-aa68-c8617347aac2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats-07-child-no-promo-clean.webp)
[season-7-promo-http-checks.log](https://cursor.com/agents/bc-9e7189e5-3dc3-47be-aa68-c8617347aac2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseason-7-promo-http-checks.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7189e5-3dc3-47be-aa68-c8617347aac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7189e5-3dc3-47be-aa68-c8617347aac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved promo behavior for Season 7 content: the site now auto-hides promotional UI on Season 7 chat routes and standardizes dismissal cookies.

* **Bug Fixes**
  * Server-side cookie updates now ensure promo dismissal is persisted when visiting Season 7 pages.

* **Tests**
  * Added tests for Season 7 route detection and for the standardized promo cookie header format and attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->