### PR TITLE
Add self-reported podcast listens

### DIFF
--- a/services/site/app/components/__tests__/team-stats.test.browser.tsx
+++ b/services/site/app/components/__tests__/team-stats.test.browser.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { MemoryRouter } from 'react-router'
 import { render } from 'vitest-browser-react'
 import { expect, test, vi } from 'vitest'
+import { type TeamRanking } from '#app/utils/team-rankings.ts'
 
 const { mockUseRootData, mockUseOptionalUser, mockUseTeam } = vi.hoisted(() => ({
 	mockUseRootData: vi.fn(),
@@ -20,7 +21,7 @@ vi.mock('#app/utils/team-provider.tsx', () => ({
 
 import { TeamStats } from '#app/components/team-stats.tsx'
 
-const rankings = [
+const rankings: Array<TeamRanking> = [
 	{ team: 'RED', ranking: 1, totalCount: 12, percent: 1 },
 	{ team: 'BLUE', ranking: 2, totalCount: 8, percent: 0.67 },
 	{ team: 'YELLOW', ranking: 3, totalCount: 4, percent: 0.33 },

--- a/services/site/app/components/__tests__/team-stats.test.browser.tsx
+++ b/services/site/app/components/__tests__/team-stats.test.browser.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router'
+import { render } from 'vitest-browser-react'
+import { expect, test, vi } from 'vitest'
+
+const { mockUseRootData, mockUseOptionalUser, mockUseTeam } = vi.hoisted(() => ({
+	mockUseRootData: vi.fn(),
+	mockUseOptionalUser: vi.fn(),
+	mockUseTeam: vi.fn(),
+}))
+
+vi.mock('#app/utils/use-root-data.ts', () => ({
+	useRootData: () => mockUseRootData(),
+	useOptionalUser: () => mockUseOptionalUser(),
+}))
+
+vi.mock('#app/utils/team-provider.tsx', () => ({
+	useTeam: () => mockUseTeam(),
+}))
+
+import { TeamStats } from '#app/components/team-stats.tsx'
+
+const rankings = [
+	{ team: 'RED', ranking: 1, totalCount: 12, percent: 1 },
+	{ team: 'BLUE', ranking: 2, totalCount: 8, percent: 0.67 },
+	{ team: 'YELLOW', ranking: 3, totalCount: 4, percent: 0.33 },
+]
+
+function renderTeamStats(whatsThisHref?: string) {
+	return render(
+		<MemoryRouter>
+			<TeamStats
+				totalCount="24"
+				rankings={rankings}
+				direction="down"
+				pull="left"
+				totalLabel="listens"
+				whatsThisHref={whatsThisHref}
+			/>
+		</MemoryRouter>,
+	)
+}
+
+test('uses the listen rankings help link when provided', async () => {
+	mockUseRootData.mockReturnValue({ user: null, userInfo: null })
+	mockUseOptionalUser.mockReturnValue(null)
+	mockUseTeam.mockReturnValue(['BLUE', vi.fn()])
+
+	const screen = await renderTeamStats('/teams#listen-rankings')
+
+	await expect
+		.element(screen.getByRole('link', { name: "what's this?" }))
+		.toHaveAttribute('href', '/teams#listen-rankings')
+})
+
+test('defaults to the read rankings help link', async () => {
+	mockUseRootData.mockReturnValue({ user: null, userInfo: null })
+	mockUseOptionalUser.mockReturnValue(null)
+	mockUseTeam.mockReturnValue(['BLUE', vi.fn()])
+
+	const screen = await renderTeamStats()
+
+	await expect
+		.element(screen.getByRole('link', { name: "what's this?" }))
+		.toHaveAttribute('href', '/teams#read-rankings')
+})

--- a/services/site/app/components/team-stats.tsx
+++ b/services/site/app/components/team-stats.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router'
 import { kodyProfiles } from '#app/images.tsx'
 import { type Team } from '#app/types.ts'
 import { formatNumber, getOptionalTeam } from '#app/utils/misc.ts'
+import { type TeamRanking } from '#app/utils/team-rankings.ts'
 import { useTeam } from '#app/utils/team-provider.tsx'
 import { useOptionalUser, useRootData } from '#app/utils/use-root-data.ts'
 
@@ -14,25 +15,20 @@ const barColors: Record<Team, string> = {
 	BLUE: 'bg-team-blue',
 }
 
-type ReadRanking = {
-	totalReads: number
-	team: Team
-	percent: number
-	ranking: number
-}
-
 function Stat({
-	totalReads,
+	totalCount,
 	team,
 	percent,
 	ranking,
 	direction,
 	display,
 	onClick,
-}: ReadRanking & {
+	totalLabel,
+}: TeamRanking & {
 	direction: 'up' | 'down'
-	display: 'ranking' | 'reads'
+	display: 'ranking' | 'count'
 	onClick?: () => void
+	totalLabel: string
 }) {
 	const { userInfo } = useRootData()
 	const [currentTeam] = useTeam()
@@ -53,7 +49,7 @@ function Stat({
 			title={
 				display === 'ranking'
 					? `Rank of the ${team.toLowerCase()} team`
-					: `Total reads by the ${team.toLowerCase()} team`
+					: `Total ${totalLabel} by the ${team.toLowerCase()} team`
 			}
 			initial="initial"
 			whileHover="hover"
@@ -99,7 +95,7 @@ function Stat({
 						'top-0': direction === 'up',
 					})}
 				>
-					{formatNumber(display === 'ranking' ? ranking : totalReads)}
+					{formatNumber(display === 'ranking' ? ranking : totalCount)}
 				</motion.span>
 			</motion.div>
 
@@ -143,17 +139,21 @@ function Stat({
 }
 
 function TeamStats({
-	totalReads,
+	totalCount,
 	rankings,
 	direction,
 	pull,
 	onStatClick,
+	totalLabel = 'reads',
+	whatsThisHref = '/teams#read-rankings',
 }: {
-	totalReads: string
-	rankings: Array<ReadRanking>
+	totalCount: string
+	rankings: Array<TeamRanking>
 	direction: 'up' | 'down'
 	pull: 'left' | 'right'
 	onStatClick?: (team: Team) => void
+	totalLabel?: string
+	whatsThisHref?: string
 }) {
 	const optionalUser = useOptionalUser()
 	const [altDown, setAltDown] = React.useState(false)
@@ -205,12 +205,12 @@ function TeamStats({
 					},
 				)}
 			>
-				<span title="Total reads" className="text-primary">
-					{totalReads}{' '}
+				<span title={`Total ${totalLabel}`} className="text-primary">
+					{totalCount}{' '}
 				</span>
 				<Link
 					className="text-secondary underlined hover:text-team-current focus:text-team-current"
-					to="/teams#read-rankings"
+					to={whatsThisHref}
 				>
 					{`what's this?`}
 				</Link>
@@ -232,7 +232,8 @@ function TeamStats({
 							key={ranking.percent}
 							{...ranking}
 							direction={direction}
-							display={altDown ? 'reads' : 'ranking'}
+							display={altDown ? 'count' : 'ranking'}
+							totalLabel={totalLabel}
 							onClick={
 								onStatClick ? () => onStatClick(ranking.team) : undefined
 							}

--- a/services/site/app/routes/blog.tsx
+++ b/services/site/app/routes/blog.tsx
@@ -543,7 +543,7 @@ function BlogHome({ loaderData: data }: Route.ComponentProps) {
 				<div className="relative col-span-full h-20">
 					<div className="absolute">
 						<TeamStats
-							totalReads={data.totalReads}
+							totalCount={data.totalReads}
 							rankings={data.readRankings}
 							pull="left"
 							direction="down"

--- a/services/site/app/routes/blog_/$slug.tsx
+++ b/services/site/app/routes/blog_/$slug.tsx
@@ -409,7 +409,7 @@ export default function MdxScreen({ loaderData: data }: Route.ComponentProps) {
 				<div className="col-span-full flex justify-between lg:col-span-8 lg:col-start-3">
 					<BackLink to="/blog">Back to overview</BackLink>
 					<TeamStats
-						totalReads={data.totalReads}
+						totalCount={data.totalReads}
 						rankings={data.readRankings}
 						direction="down"
 						pull="right"
@@ -600,7 +600,7 @@ export default function MdxScreen({ loaderData: data }: Route.ComponentProps) {
 			<Grid className="mb-24">
 				<div className="col-span-full flex justify-end lg:col-span-8 lg:col-start-3">
 					<TeamStats
-						totalReads={data.totalReads}
+						totalCount={data.totalReads}
 						rankings={data.readRankings}
 						direction="up"
 						pull="right"

--- a/services/site/app/routes/chats/$season.tsx
+++ b/services/site/app/routes/chats/$season.tsx
@@ -12,7 +12,7 @@ import { TriangleIcon } from '#app/components/icons.tsx'
 import { MissingSomething } from '#app/components/kifs.tsx'
 import { H3, Paragraph } from '#app/components/typography.tsx'
 import { type KCDHandle, type Team } from '#app/types.ts'
-import { getPodcastListenRankings } from '#app/utils/blog.server.ts'
+import { getPodcastListenLeadersBySeason } from '#app/utils/blog.server.ts'
 import { getCWKEpisodePath } from '#app/utils/chats-with-kent.ts'
 import { orderBy } from '#app/utils/cjs/lodash.ts'
 import {
@@ -23,7 +23,6 @@ import {
 } from '#app/utils/misc-react.tsx'
 import { useChatsEpisodeUIState } from '#app/utils/providers.tsx'
 import { getSeasonListItems } from '#app/utils/simplecast.server.ts'
-import { getRankingLeader } from '#app/utils/team-rankings.ts'
 import { getServerTimeHeader } from '#app/utils/timing.server.ts'
 import { type Route } from './+types/$season'
 
@@ -56,22 +55,11 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 		throw new Response(`No season for ${params.season}`, { status: 404 })
 	}
 
-	const listenRankingsByEpisode = Object.fromEntries(
-		await Promise.all(
-			season.episodes.map(async (episode) => {
-				const rankings = await getPodcastListenRankings({
-					request,
-					seasonNumber: episode.seasonNumber,
-					episodeNumber: episode.episodeNumber,
-					timings,
-				})
-				return [
-					String(episode.episodeNumber),
-					getRankingLeader(rankings)?.team ?? null,
-				] as const
-			}),
-		),
-	)
+	const listenRankingsByEpisode = await getPodcastListenLeadersBySeason({
+		request,
+		seasonNumber: season.seasonNumber,
+		timings,
+	})
 
 	return json(
 		{ season, listenRankingsByEpisode },

--- a/services/site/app/routes/chats/$season.tsx
+++ b/services/site/app/routes/chats/$season.tsx
@@ -11,7 +11,8 @@ import { Grid } from '#app/components/grid.tsx'
 import { TriangleIcon } from '#app/components/icons.tsx'
 import { MissingSomething } from '#app/components/kifs.tsx'
 import { H3, Paragraph } from '#app/components/typography.tsx'
-import { type KCDHandle } from '#app/types.ts'
+import { type KCDHandle, type Team } from '#app/types.ts'
+import { getPodcastListenRankings } from '#app/utils/blog.server.ts'
 import { getCWKEpisodePath } from '#app/utils/chats-with-kent.ts'
 import { orderBy } from '#app/utils/cjs/lodash.ts'
 import {
@@ -22,8 +23,14 @@ import {
 } from '#app/utils/misc-react.tsx'
 import { useChatsEpisodeUIState } from '#app/utils/providers.tsx'
 import { getSeasonListItems } from '#app/utils/simplecast.server.ts'
+import { getRankingLeader } from '#app/utils/team-rankings.ts'
 import { getServerTimeHeader } from '#app/utils/timing.server.ts'
 import { type Route } from './+types/$season'
+
+function getTeamDotClass(leadingTeam: Team | null) {
+	if (!leadingTeam) return null
+	return `bg-team-current set-color-team-current-${leadingTeam.toLowerCase()}`
+}
 
 export const handle: KCDHandle = {
 	getSitemapEntries: serverOnly$(async (request: Request) => {
@@ -49,8 +56,25 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 		throw new Response(`No season for ${params.season}`, { status: 404 })
 	}
 
+	const listenRankingsByEpisode = Object.fromEntries(
+		await Promise.all(
+			season.episodes.map(async (episode) => {
+				const rankings = await getPodcastListenRankings({
+					request,
+					seasonNumber: episode.seasonNumber,
+					episodeNumber: episode.episodeNumber,
+					timings,
+				})
+				return [
+					String(episode.episodeNumber),
+					getRankingLeader(rankings)?.team ?? null,
+				] as const
+			}),
+		),
+	)
+
 	return json(
-		{ season },
+		{ season, listenRankingsByEpisode },
 		{
 			headers: {
 				'Cache-Control': 'public, max-age=600',
@@ -63,53 +87,65 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 export const headers: HeadersFunction = reuseUsefulLoaderHeaders
 
 export default function ChatsSeason({ loaderData }: Route.ComponentProps) {
-	const { season } = loaderData
+	const { season, listenRankingsByEpisode } = loaderData
 	const { sortOrder } = useChatsEpisodeUIState()
 	const episodes = orderBy(season.episodes, 'episodeNumber', sortOrder)
-	return episodes.map((episode) => (
-		<Link
-			className="group focus:outline-none"
-			key={episode.slug}
-			to={getCWKEpisodePath(episode)}
-		>
-			<Grid
-				nested
-				className="relative border-b border-gray-200 py-10 lg:py-5 dark:border-gray-600"
-			>
-				<div className="bg-secondary absolute -inset-px -mx-6 hidden rounded-lg group-hover:block group-focus:block" />
+	return episodes.map((episode) => {
+		const leadingTeam =
+			listenRankingsByEpisode[String(episode.episodeNumber)] ?? null
 
-				<div className="relative col-span-1 flex-none">
-					<div className="absolute inset-0 flex scale-0 transform items-center justify-center opacity-0 transition group-hover:scale-100 group-hover:opacity-100 group-focus:opacity-100">
-						<div className="flex-none rounded-full bg-white p-4 text-gray-800">
-							<TriangleIcon size={12} />
+		return (
+			<Link
+				className="group focus:outline-none"
+				key={episode.slug}
+				to={getCWKEpisodePath(episode)}
+			>
+				<Grid
+					nested
+					className="relative border-b border-gray-200 py-10 lg:py-5 dark:border-gray-600"
+				>
+					<div className="bg-secondary absolute -inset-px -mx-6 hidden rounded-lg group-hover:block group-focus:block" />
+					{leadingTeam ? (
+						<div
+							className={`absolute top-6 right-0 h-4 w-4 rounded-full ${getTeamDotClass(
+								leadingTeam,
+							)}`}
+						/>
+					) : null}
+
+					<div className="relative col-span-1 flex-none">
+						<div className="absolute inset-0 flex scale-0 transform items-center justify-center opacity-0 transition group-hover:scale-100 group-hover:opacity-100 group-focus:opacity-100">
+							<div className="flex-none rounded-full bg-white p-4 text-gray-800">
+								<TriangleIcon size={12} />
+							</div>
+						</div>
+						<img
+							className="h-16 w-full rounded-lg object-cover"
+							src={episode.image}
+							alt={episode.title}
+							loading="lazy"
+						/>
+					</div>
+					<div className="text-primary relative col-span-3 flex flex-col md:col-span-7 lg:col-span-11 lg:flex-row lg:items-center lg:justify-between">
+						<div className="mb-3 text-xl font-medium lg:mb-0">
+							<span className="inline-block w-10 lg:text-lg">
+								{`${episode.episodeNumber.toString().padStart(2, '0')}.`}
+							</span>
+							{episode.title}
+						</div>
+						<div className="text-lg font-medium text-gray-400 lg:text-right">
+							<div>
+								<time dateTime={episode.publishedAt}>
+									{formatDate(episode.publishedAt)}
+								</time>
+							</div>
+							<div>{formatDuration(episode.duration)}</div>
 						</div>
 					</div>
-					<img
-						className="h-16 w-full rounded-lg object-cover"
-						src={episode.image}
-						alt={episode.title}
-						loading="lazy"
-					/>
-				</div>
-				<div className="text-primary relative col-span-3 flex flex-col md:col-span-7 lg:col-span-11 lg:flex-row lg:items-center lg:justify-between">
-					<div className="mb-3 text-xl font-medium lg:mb-0">
-						<span className="inline-block w-10 lg:text-lg">
-							{`${episode.episodeNumber.toString().padStart(2, '0')}.`}
-						</span>
-						{episode.title}
-					</div>
-					<div className="text-lg font-medium text-gray-400 lg:text-right">
-						<div>
-							<time dateTime={episode.publishedAt}>
-								{formatDate(episode.publishedAt)}
-							</time>
-						</div>
-						<div>{formatDuration(episode.duration)}</div>
-					</div>
-				</div>
-			</Grid>
-		</Link>
-	))
+				</Grid>
+			</Link>
+		)
+	})
 }
 
 export function ErrorBoundary() {

--- a/services/site/app/routes/chats/__tests__/podcast-team-stats-links.test.ts
+++ b/services/site/app/routes/chats/__tests__/podcast-team-stats-links.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+
+import chatsLayoutSource from '#app/routes/chats/_layout.tsx?raw'
+import podcastEpisodeSource from '#app/routes/chats_/$season.$episode_.$slug.tsx?raw'
+import teamsPageSource from '#app/../content/pages/teams.mdx?raw'
+
+test('podcast overview TeamStats links to listen rankings', () => {
+	expect(chatsLayoutSource).toContain('whatsThisHref="/teams#listen-rankings"')
+})
+
+test('podcast episode TeamStats links to listen rankings', () => {
+	expect(podcastEpisodeSource).toContain(
+		'whatsThisHref="/teams#listen-rankings"',
+	)
+})
+
+test('teams page includes a listen rankings section', () => {
+	expect(teamsPageSource).toContain('## Listen Rankings')
+})

--- a/services/site/app/routes/chats/_layout.tsx
+++ b/services/site/app/routes/chats/_layout.tsx
@@ -172,6 +172,7 @@ function PodcastHome({ loaderData: data }: Route.ComponentProps) {
 							pull="left"
 							direction="down"
 							totalLabel="listens"
+							whatsThisHref="/teams#listen-rankings"
 						/>
 					</div>
 				</div>

--- a/services/site/app/routes/chats/_layout.tsx
+++ b/services/site/app/routes/chats/_layout.tsx
@@ -18,6 +18,7 @@ import { BlogSection } from '#app/components/sections/blog-section.tsx'
 import { FeaturedSection } from '#app/components/sections/featured-section.tsx'
 import { HeroSection } from '#app/components/sections/hero-section.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
+import { TeamStats } from '#app/components/team-stats.tsx'
 import { H4, H6, Paragraph } from '#app/components/typography.tsx'
 import { externalLinks } from '#app/external-links.tsx'
 import {
@@ -27,7 +28,11 @@ import {
 	images,
 } from '#app/images.tsx'
 import { type RootLoaderType } from '#app/root.tsx'
-import { getBlogRecommendations } from '#app/utils/blog.server.ts'
+import {
+	getBlogRecommendations,
+	getPodcastListenRankings,
+	getTotalPodcastEpisodeListens,
+} from '#app/utils/blog.server.ts'
 import {
 	getCWKEpisodePath,
 	getFeaturedEpisode,
@@ -35,6 +40,7 @@ import {
 import {
 	formatDate,
 	formatDuration,
+	formatNumber,
 	getDisplayUrl,
 	getOrigin,
 	getUrl,
@@ -44,18 +50,29 @@ import {
 import { ChatsEpisodeUIStateProvider } from '#app/utils/providers.tsx'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { getSeasonListItems } from '#app/utils/simplecast.server.ts'
+import { getRankingLeader } from '#app/utils/team-rankings.ts'
+import { useTeam } from '#app/utils/team-provider.tsx'
 import { getServerTimeHeader } from '#app/utils/timing.server.ts'
 import { type Route } from './+types/_layout'
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
-	const blogRecommendations = await getBlogRecommendations({ request, timings })
+	const [blogRecommendations, seasons, listenRankings, totalListens] =
+		await Promise.all([
+			getBlogRecommendations({ request, timings }),
+			getSeasonListItems({ request }),
+			getPodcastListenRankings({ request, timings }),
+			getTotalPodcastEpisodeListens({ request, timings }),
+		])
 
 	return json(
 		{
 			// we show the seasons in reverse order
-			seasons: (await getSeasonListItems({ request })).reverse(),
+			seasons: seasons.reverse(),
 			blogRecommendations,
+			listenRankings,
+			totalListens: formatNumber(totalListens),
+			overallLeadingTeam: getRankingLeader(listenRankings)?.team ?? null,
 		},
 		{
 			headers: {
@@ -104,6 +121,7 @@ function PodcastHome({ loaderData: data }: Route.ComponentProps) {
 	const [sortOrder, setSortOrder] = React.useState<'desc' | 'asc'>('asc')
 	const navigate = useNavigate()
 	const matches = useMatches()
+	const [userTeam] = useTeam()
 	const last = matches[matches.length - 1]
 
 	const seasonNumber = last?.params.season
@@ -131,13 +149,71 @@ function PodcastHome({ loaderData: data }: Route.ComponentProps) {
 	const featured = getFeaturedEpisode(allEpisodes)
 
 	return (
-		<>
+		<div
+			className={
+				data.overallLeadingTeam
+					? `set-color-team-current-${data.overallLeadingTeam.toLowerCase()}`
+					: undefined
+			}
+		>
 			<HeroSection
 				title="Listen to chats with Kent C. Dodds here."
 				subtitle="Find all episodes of my podcast below."
 				imageBuilder={images.kayak}
 				imageSize="large"
 			/>
+
+			<Grid className="mb-14">
+				<div className="relative col-span-full h-20">
+					<div className="absolute">
+						<TeamStats
+							totalCount={data.totalListens}
+							rankings={data.listenRankings}
+							pull="left"
+							direction="down"
+							totalLabel="listens"
+						/>
+					</div>
+				</div>
+
+				<Spacer size="2xs" className="col-span-full" />
+
+				<Paragraph className="col-span-full" prose={false}>
+					{data.overallLeadingTeam ? (
+						<>
+							{`The `}
+							<strong
+								className={`text-team-current set-color-team-current-${data.overallLeadingTeam.toLowerCase()}`}
+							>
+								{data.overallLeadingTeam.toLowerCase()}
+							</strong>
+							{` team is leading the Chats with Kent rankings. `}
+							{userTeam === 'UNKNOWN' ? (
+								<>
+									<Link to="/login" className="underlined">
+										Login or sign up
+									</Link>
+									{` to choose your team and count your listens.`}
+								</>
+							) : userTeam === data.overallLeadingTeam ? (
+								`That’s your team. Keep the momentum going.`
+							) : (
+								<>
+									{`Self-report your listens to help the `}
+									<strong
+										className={`text-team-current set-color-team-current-${userTeam.toLowerCase()}`}
+									>
+										{userTeam.toLowerCase()}
+									</strong>{' '}
+									{`team take the top spot.`}
+								</>
+							)}
+						</>
+					) : (
+						`No team is leading yet. Start listening and claim the board.`
+					)}
+				</Paragraph>
+			</Grid>
 
 			<Grid>
 				<H6 as="div" className="col-span-full mb-6">
@@ -167,6 +243,7 @@ function PodcastHome({ loaderData: data }: Route.ComponentProps) {
 						href={getCWKEpisodePath(featured)}
 						imageUrl={featured.image}
 						imageAlt={listify(featured.guests.map((g) => g.name))}
+						leadingTeam={null}
 					/>
 				</>
 			) : null}
@@ -364,7 +441,7 @@ function PodcastHome({ loaderData: data }: Route.ComponentProps) {
 				title="Looking for more content?"
 				description="Have a look at these articles."
 			/>
-		</>
+		</div>
 	)
 }
 

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -58,6 +58,7 @@ import {
 import {
 	formatDate,
 	formatDuration,
+	formatNumber,
 	getDisplayUrl,
 	getOrigin,
 	getUrl,
@@ -72,6 +73,7 @@ import {
 	prisma,
 } from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
+import { getClientSession } from '#app/utils/client.server.ts'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { getUser } from '#app/utils/session.server.ts'
 import { getSeasons } from '#app/utils/simplecast.server.ts'
@@ -161,6 +163,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		getUser(request, { timings }),
 		getSeasons({ request, timings }),
 	])
+	const clientSession = await getClientSession(request, user)
+	const clientId = clientSession.getClientId()
 	const season = seasons.find((s) => s.seasonNumber === seasonNumber)
 	if (!season) {
 		throw new Response(`Season ${seasonNumber} not found`, { status: 404 })
@@ -200,18 +204,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		seasonNumber: episode.seasonNumber,
 		episodeNumber: episode.episodeNumber,
 	})
-	const completedHomeworkIds = await getEpisodeHomeworkCompletions(
-		user
-			? {
-					seasonNumber: episode.seasonNumber,
-					episodeNumber: episode.episodeNumber,
-					userId: user.id,
-				}
-			: {
-					seasonNumber: episode.seasonNumber,
-					episodeNumber: episode.episodeNumber,
-				},
-	)
+	const completedHomeworkIds = await getEpisodeHomeworkCompletions({
+		seasonNumber: episode.seasonNumber,
+		episodeNumber: episode.episodeNumber,
+		...(user ? { userId: user.id } : clientId ? { clientId } : {}),
+	})
 	const [listenRankings, totalListens] = await Promise.all([
 		getPodcastListenRankings({
 			request,
@@ -256,18 +253,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 			isListened: listenedEpisodeIds.has(episodeListenContentId),
 			listenContentId: episodeListenContentId,
 			listenRankings,
-			totalListens: String(totalListens),
+			totalListens: formatNumber(totalListens),
 			leadingTeam: getRankingLeader(listenRankings)?.team ?? null,
 			favoriteContentType,
 			favoriteContentId,
 			isFavorite: Boolean(favorite),
 		},
 		{
-			headers: {
+			headers: await clientSession.getHeaders({
 				'Cache-Control': 'private, max-age=600',
 				Vary: 'Cookie',
 				'Server-Timing': getServerTimeHeader(timings),
-			},
+			}),
 		},
 	)
 }

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -274,36 +274,6 @@ export const links: LinksFunction = () => {
 	return youTubeEmbedLinks()
 }
 
-function EpisodeListenSummary({
-	episodeTitle,
-	leadingTeam,
-}: {
-	episodeTitle: string
-	leadingTeam: string | null
-}) {
-	if (!leadingTeam) {
-		return (
-			<Paragraph prose={false} className="text-secondary mt-4">
-				No team has claimed this episode yet. Be the first to self-report that
-				you listened.
-			</Paragraph>
-		)
-	}
-
-	return (
-		<Paragraph prose={false} className="text-secondary mt-4">
-			The{' '}
-			<strong
-				className={`text-team-current set-color-team-current-${leadingTeam.toLowerCase()}`}
-			>
-				{leadingTeam.toLowerCase()}
-			</strong>{' '}
-			team currently owns this episode. Self-reporting that you listened to{' '}
-			<strong>{episodeTitle}</strong> affects the ranking.
-		</Paragraph>
-	)
-}
-
 function Homework({
 	homeworkItems,
 	seasonNumber,
@@ -651,10 +621,6 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 							{formatDate(episode.publishedAt)}
 						</time>
 					</H6>
-					<EpisodeListenSummary
-						episodeTitle={episode.title}
-						leadingTeam={leadingTeam}
-					/>
 				</div>
 			</Grid>
 

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -200,10 +200,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 	const listenedEpisodeIds = await getEpisodePodcastListens({
 		userId: user?.id,
 	})
-	const episodeListenContentId = getEpisodeListenContentId({
-		seasonNumber: episode.seasonNumber,
-		episodeNumber: episode.episodeNumber,
-	})
 	const completedHomeworkIds = await getEpisodeHomeworkCompletions({
 		seasonNumber: episode.seasonNumber,
 		episodeNumber: episode.episodeNumber,
@@ -250,8 +246,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 			),
 			episode,
 			homeworkItems,
-			isListened: listenedEpisodeIds.has(episodeListenContentId),
-			listenContentId: episodeListenContentId,
+			isListened: listenedEpisodeIds.has(
+				getEpisodeListenContentId({
+					seasonNumber: episode.seasonNumber,
+					episodeNumber: episode.episodeNumber,
+				}),
+			),
 			listenRankings,
 			totalListens: formatNumber(totalListens),
 			leadingTeam: getRankingLeader(listenRankings)?.team ?? null,

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -30,16 +30,22 @@ import {
 } from '#app/components/icons.tsx'
 import { FeaturedSection } from '#app/components/sections/featured-section.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
+import { TeamStats } from '#app/components/team-stats.tsx'
 import { H2, H3, H6, Paragraph } from '#app/components/typography.tsx'
 import { getSocialImageWithPreTitle } from '#app/images.tsx'
 import { type RootLoaderType } from '#app/root.tsx'
 import { FavoriteToggle } from '#app/routes/resources/favorite.tsx'
 import { HomeworkCompletionToggle } from '#app/routes/resources/homework-completion.tsx'
+import { PodcastListenToggle } from '#app/routes/resources/podcast-listen.tsx'
 import {
 	type CWKEpisode,
 	type CWKListItem,
 	type KCDHandle,
 } from '#app/types.ts'
+import {
+	getPodcastListenRankings,
+	getTotalPodcastEpisodeListens,
+} from '#app/utils/blog.server.ts'
 import {
 	getCWKEpisodePath,
 	getFeaturedEpisode,
@@ -47,6 +53,7 @@ import {
 import {
 	getEpisodeFavoriteContentId,
 	getEpisodeHomeworkContentId,
+	getEpisodeListenContentId,
 } from '#app/utils/favorites.ts'
 import {
 	formatDate,
@@ -59,15 +66,16 @@ import {
 	typedBoolean,
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
-import { getClientSession } from '#app/utils/client.server.ts'
 import {
 	getEpisodeHomeworkCompletions,
+	getEpisodePodcastListens,
 	prisma,
 } from '#app/utils/prisma.server.ts'
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { getUser } from '#app/utils/session.server.ts'
 import { getSeasons } from '#app/utils/simplecast.server.ts'
+import { getRankingLeader } from '#app/utils/team-rankings.ts'
 import { Themed } from '#app/utils/theme.tsx'
 import { getServerTimeHeader } from '#app/utils/timing.server.ts'
 import { useRootData } from '#app/utils/use-root-data.ts'
@@ -153,8 +161,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		getUser(request, { timings }),
 		getSeasons({ request, timings }),
 	])
-	const clientSession = await getClientSession(request, user)
-	const clientId = clientSession.getClientId()
 	const season = seasons.find((s) => s.seasonNumber === seasonNumber)
 	if (!season) {
 		throw new Response(`Season ${seasonNumber} not found`, { status: 404 })
@@ -187,11 +193,39 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 				select: { id: true },
 			})
 		: null
-	const completedHomeworkIds = await getEpisodeHomeworkCompletions({
+	const listenedEpisodeIds = await getEpisodePodcastListens({
+		userId: user?.id,
+	})
+	const episodeListenContentId = getEpisodeListenContentId({
 		seasonNumber: episode.seasonNumber,
 		episodeNumber: episode.episodeNumber,
-		...(user ? { userId: user.id } : clientId ? { clientId } : {}),
 	})
+	const completedHomeworkIds = await getEpisodeHomeworkCompletions(
+		user
+			? {
+					seasonNumber: episode.seasonNumber,
+					episodeNumber: episode.episodeNumber,
+					userId: user.id,
+				}
+			: {
+					seasonNumber: episode.seasonNumber,
+					episodeNumber: episode.episodeNumber,
+				},
+	)
+	const [listenRankings, totalListens] = await Promise.all([
+		getPodcastListenRankings({
+			request,
+			seasonNumber: episode.seasonNumber,
+			episodeNumber: episode.episodeNumber,
+			timings,
+		}),
+		getTotalPodcastEpisodeListens({
+			request,
+			seasonNumber: episode.seasonNumber,
+			episodeNumber: episode.episodeNumber,
+			timings,
+		}),
+	])
 	const homeworkItems = episode.homeworkHTMLs.map((homeworkHTML, itemIndex) => {
 		const id = getEpisodeHomeworkContentId({
 			seasonNumber: episode.seasonNumber,
@@ -219,6 +253,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 			),
 			episode,
 			homeworkItems,
+			isListened: listenedEpisodeIds.has(episodeListenContentId),
+			listenContentId: episodeListenContentId,
+			listenRankings,
+			totalListens: String(totalListens),
+			leadingTeam: getRankingLeader(listenRankings)?.team ?? null,
 			favoriteContentType,
 			favoriteContentId,
 			isFavorite: Boolean(favorite),
@@ -237,6 +276,36 @@ export const headers: HeadersFunction = reuseUsefulLoaderHeaders
 
 export const links: LinksFunction = () => {
 	return youTubeEmbedLinks()
+}
+
+function EpisodeListenSummary({
+	episodeTitle,
+	leadingTeam,
+}: {
+	episodeTitle: string
+	leadingTeam: string | null
+}) {
+	if (!leadingTeam) {
+		return (
+			<Paragraph prose={false} className="text-secondary mt-4">
+				No team has claimed this episode yet. Be the first to self-report that
+				you listened.
+			</Paragraph>
+		)
+	}
+
+	return (
+		<Paragraph prose={false} className="text-secondary mt-4">
+			The{' '}
+			<strong
+				className={`text-team-current set-color-team-current-${leadingTeam.toLowerCase()}`}
+			>
+				{leadingTeam.toLowerCase()}
+			</strong>{' '}
+			team currently owns this episode. Self-reporting listens to{' '}
+			<strong>{episodeTitle}</strong> affects the ranking.
+		</Paragraph>
+	)
 }
 
 function Homework({
@@ -545,6 +614,10 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 		featured,
 		nextEpisode,
 		prevEpisode,
+		isListened,
+		listenRankings,
+		totalListens,
+		leadingTeam,
 		favoriteContentType,
 		favoriteContentId,
 		isFavorite,
@@ -552,14 +625,24 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 	const permalink = `${requestInfo.origin}${getCWKEpisodePath(episode)}`
 
 	return (
-		<>
+		<div
+			className={
+				leadingTeam
+					? `set-color-team-current-${leadingTeam.toLowerCase()}`
+					: undefined
+			}
+		>
 			<Grid className="mt-24 mb-10 lg:mb-24">
-				<BackLink
-					to="/chats"
-					className="col-span-full lg:col-span-8 lg:col-start-3"
-				>
-					Back to overview
-				</BackLink>
+				<div className="col-span-full flex justify-between gap-6 lg:col-span-8 lg:col-start-3">
+					<BackLink to="/chats">Back to overview</BackLink>
+					<TeamStats
+						totalCount={totalListens}
+						rankings={listenRankings}
+						direction="down"
+						pull="right"
+						totalLabel="listens"
+					/>
+				</div>
 			</Grid>
 
 			<Grid as="header" className="mb-12">
@@ -571,6 +654,10 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 							{formatDate(episode.publishedAt)}
 						</time>
 					</H6>
+					<EpisodeListenSummary
+						episodeTitle={episode.title}
+						leadingTeam={leadingTeam}
+					/>
 				</div>
 			</Grid>
 
@@ -636,12 +723,21 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 
 				<div className="col-span-full lg:col-span-8 lg:col-start-3">
 					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-						<FavoriteToggle
-							contentType={favoriteContentType}
-							contentId={favoriteContentId}
-							initialIsFavorite={isFavorite}
-							label="Favorite episode"
-						/>
+						<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+							<PodcastListenToggle
+								contentId={getEpisodeListenContentId({
+									seasonNumber: episode.seasonNumber,
+									episodeNumber: episode.episodeNumber,
+								})}
+								initialListened={isListened}
+							/>
+							<FavoriteToggle
+								contentType={favoriteContentType}
+								contentId={favoriteContentId}
+								initialIsFavorite={isFavorite}
+								label="Favorite episode"
+							/>
+						</div>
 						<IconLink
 							className="flex gap-2"
 							target="_blank"
@@ -719,7 +815,7 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 					imageAlt={listify(featured.guests.map((g) => g.name))}
 				/>
 			) : null}
-		</>
+		</div>
 	)
 }
 

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -638,6 +638,7 @@ export default function PodcastDetail({ loaderData }: Route.ComponentProps) {
 						direction="down"
 						pull="right"
 						totalLabel="listens"
+						whatsThisHref="/teams#listen-rankings"
 					/>
 				</div>
 			</Grid>

--- a/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
+++ b/services/site/app/routes/chats_/$season.$episode_.$slug.tsx
@@ -185,27 +185,26 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 		seasonNumber: episode.seasonNumber,
 		episodeNumber: episode.episodeNumber,
 	})
-	const favorite = user
-		? await prisma.favorite.findUnique({
-				where: {
-					userId_contentType_contentId: {
-						userId: user.id,
-						contentType: favoriteContentType,
-						contentId: favoriteContentId,
-					},
-				},
-				select: { id: true },
-			})
-		: null
-	const listenedEpisodeIds = await getEpisodePodcastListens({
-		userId: user?.id,
-	})
-	const completedHomeworkIds = await getEpisodeHomeworkCompletions({
-		seasonNumber: episode.seasonNumber,
-		episodeNumber: episode.episodeNumber,
-		...(user ? { userId: user.id } : clientId ? { clientId } : {}),
-	})
-	const [listenRankings, totalListens] = await Promise.all([
+	const [favorite, listenedEpisodeIds, completedHomeworkIds, listenRankings, totalListens] =
+		await Promise.all([
+			user
+				? prisma.favorite.findUnique({
+						where: {
+							userId_contentType_contentId: {
+								userId: user.id,
+								contentType: favoriteContentType,
+								contentId: favoriteContentId,
+							},
+						},
+						select: { id: true },
+					})
+				: Promise.resolve(null),
+			getEpisodePodcastListens({ userId: user?.id }),
+			getEpisodeHomeworkCompletions({
+				seasonNumber: episode.seasonNumber,
+				episodeNumber: episode.episodeNumber,
+				...(user ? { userId: user.id } : clientId ? { clientId } : {}),
+			}),
 		getPodcastListenRankings({
 			request,
 			seasonNumber: episode.seasonNumber,
@@ -218,7 +217,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 			episodeNumber: episode.episodeNumber,
 			timings,
 		}),
-	])
+		])
 	const homeworkItems = episode.homeworkHTMLs.map((homeworkHTML, itemIndex) => {
 		const id = getEpisodeHomeworkContentId({
 			seasonNumber: episode.seasonNumber,
@@ -299,7 +298,7 @@ function EpisodeListenSummary({
 			>
 				{leadingTeam.toLowerCase()}
 			</strong>{' '}
-			team currently owns this episode. Self-reporting listens to{' '}
+			team currently owns this episode. Self-reporting that you listened to{' '}
 			<strong>{episodeTitle}</strong> affects the ranking.
 		</Paragraph>
 	)

--- a/services/site/app/routes/resources/__tests__/podcast-listen.test.ts
+++ b/services/site/app/routes/resources/__tests__/podcast-listen.test.ts
@@ -164,3 +164,36 @@ test('action stores listen for authenticated user', async () => {
 		listened: true,
 	})
 })
+
+test('action removes listen for authenticated user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
+	blogServerMocks.getPodcastListenRankings
+		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
+		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
+	prismaServerMocks.setEpisodePodcastListen.mockResolvedValue(false)
+
+	const formData = new FormData()
+	formData.set('contentId', '7:12')
+	formData.set('listened', 'false')
+
+	const request = new Request('http://localhost/resources/podcast-listen', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ listened: false, authenticated: true })
+	expect(litefsServerMocks.ensurePrimary).toHaveBeenCalledTimes(1)
+	expect(prismaServerMocks.setEpisodePodcastListen).toHaveBeenCalledWith({
+		seasonNumber: 7,
+		episodeNumber: 12,
+		userId: 'user-1',
+		listened: false,
+	})
+})

--- a/services/site/app/routes/resources/__tests__/podcast-listen.test.ts
+++ b/services/site/app/routes/resources/__tests__/podcast-listen.test.ts
@@ -10,10 +10,13 @@ const litefsServerMocks = vi.hoisted(() => ({
 	getInstanceInfoSync: vi.fn().mockReturnValue({ currentIsPrimary: true }),
 }))
 
-const prismaServerMocks = vi.hoisted(() => ({
-	getEpisodePodcastListens: vi.fn(),
+const blogServerMocks = vi.hoisted(() => ({
 	getPodcastListenRankings: vi.fn(),
 	getTotalPodcastEpisodeListens: vi.fn(),
+}))
+
+const prismaServerMocks = vi.hoisted(() => ({
+	getEpisodePodcastListens: vi.fn(),
 	setEpisodePodcastListen: vi.fn(),
 }))
 
@@ -21,8 +24,8 @@ vi.mock('#app/utils/session.server.ts', () => sessionServerMocks)
 vi.mock('#app/utils/litefs-js.server.ts', () => litefsServerMocks)
 vi.mock('#app/utils/prisma.server.ts', () => prismaServerMocks)
 vi.mock('#app/utils/blog.server.ts', () => ({
-	getPodcastListenRankings: prismaServerMocks.getPodcastListenRankings,
-	getTotalPodcastEpisodeListens: prismaServerMocks.getTotalPodcastEpisodeListens,
+	getPodcastListenRankings: blogServerMocks.getPodcastListenRankings,
+	getTotalPodcastEpisodeListens: blogServerMocks.getTotalPodcastEpisodeListens,
 }))
 vi.mock('vite-env-only/macros', () => ({
 	serverOnly$: (fn: unknown) => fn,
@@ -129,12 +132,12 @@ test('action requires login', async () => {
 test('action stores listen for authenticated user', async () => {
 	vi.clearAllMocks()
 	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
-	prismaServerMocks.getPodcastListenRankings
+	blogServerMocks.getPodcastListenRankings
 		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
 		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
 		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
 		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
-	prismaServerMocks.getTotalPodcastEpisodeListens.mockResolvedValue(1)
+	blogServerMocks.getTotalPodcastEpisodeListens.mockResolvedValue(1)
 	prismaServerMocks.setEpisodePodcastListen.mockResolvedValue(true)
 
 	const formData = new FormData()

--- a/services/site/app/routes/resources/__tests__/podcast-listen.test.ts
+++ b/services/site/app/routes/resources/__tests__/podcast-listen.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+import { expect, test, vi } from 'vitest'
+
+const sessionServerMocks = vi.hoisted(() => ({
+	getUser: vi.fn(),
+}))
+
+const litefsServerMocks = vi.hoisted(() => ({
+	ensurePrimary: vi.fn(),
+	getInstanceInfoSync: vi.fn().mockReturnValue({ currentIsPrimary: true }),
+}))
+
+const prismaServerMocks = vi.hoisted(() => ({
+	getEpisodePodcastListens: vi.fn(),
+	getPodcastListenRankings: vi.fn(),
+	getTotalPodcastEpisodeListens: vi.fn(),
+	setEpisodePodcastListen: vi.fn(),
+}))
+
+vi.mock('#app/utils/session.server.ts', () => sessionServerMocks)
+vi.mock('#app/utils/litefs-js.server.ts', () => litefsServerMocks)
+vi.mock('#app/utils/prisma.server.ts', () => prismaServerMocks)
+vi.mock('#app/utils/blog.server.ts', () => ({
+	getPodcastListenRankings: prismaServerMocks.getPodcastListenRankings,
+	getTotalPodcastEpisodeListens: prismaServerMocks.getTotalPodcastEpisodeListens,
+}))
+vi.mock('vite-env-only/macros', () => ({
+	serverOnly$: (fn: unknown) => fn,
+}))
+
+import { action, loader } from '../podcast-listen.tsx'
+
+test('loader returns listen status for authenticated user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
+	prismaServerMocks.getEpisodePodcastListens.mockResolvedValue(new Set(['7:12']))
+
+	const request = new Request(
+		'http://localhost/resources/podcast-listen?contentId=7:12',
+	)
+	const result = (await loader({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ listened: true, authenticated: true })
+	expect(prismaServerMocks.getEpisodePodcastListens).toHaveBeenCalledWith({
+		userId: 'user-1',
+	})
+})
+
+test('loader returns unauthenticated status for anonymous user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue(null)
+
+	const request = new Request(
+		'http://localhost/resources/podcast-listen?contentId=7:12',
+	)
+	const result = (await loader({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ listened: false, authenticated: false })
+	expect(prismaServerMocks.getEpisodePodcastListens).not.toHaveBeenCalled()
+})
+
+test('action validates content ids', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
+
+	const formData = new FormData()
+	formData.set('contentId', 'bad-id')
+	formData.set('listened', 'true')
+
+	const request = new Request('http://localhost/resources/podcast-listen', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(400)
+	expect(result.data).toEqual({
+		listened: false,
+		authenticated: false,
+		error: 'INVALID_CONTENT_ID',
+	})
+	expect(litefsServerMocks.ensurePrimary).not.toHaveBeenCalled()
+	expect(prismaServerMocks.setEpisodePodcastListen).not.toHaveBeenCalled()
+})
+
+test('action requires login', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue(null)
+
+	const formData = new FormData()
+	formData.set('contentId', '7:12')
+	formData.set('listened', 'true')
+
+	const request = new Request('http://localhost/resources/podcast-listen', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(401)
+	expect(result.data).toEqual({
+		listened: false,
+		authenticated: false,
+		error: 'LOGIN_REQUIRED',
+	})
+	expect(litefsServerMocks.ensurePrimary).not.toHaveBeenCalled()
+})
+
+test('action stores listen for authenticated user', async () => {
+	vi.clearAllMocks()
+	sessionServerMocks.getUser.mockResolvedValue({ id: 'user-1' })
+	prismaServerMocks.getPodcastListenRankings
+		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
+		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
+		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
+		.mockResolvedValueOnce([{ team: 'BLUE', ranking: 1, totalCount: 1, percent: 1 }])
+	prismaServerMocks.getTotalPodcastEpisodeListens.mockResolvedValue(1)
+	prismaServerMocks.setEpisodePodcastListen.mockResolvedValue(true)
+
+	const formData = new FormData()
+	formData.set('contentId', '7:12')
+	formData.set('listened', 'true')
+
+	const request = new Request('http://localhost/resources/podcast-listen', {
+		method: 'POST',
+		body: formData,
+	})
+	const result = (await action({ request } as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({ listened: true, authenticated: true })
+	expect(litefsServerMocks.ensurePrimary).toHaveBeenCalledTimes(1)
+	expect(prismaServerMocks.setEpisodePodcastListen).toHaveBeenCalledWith({
+		seasonNumber: 7,
+		episodeNumber: 12,
+		userId: 'user-1',
+		listened: true,
+	})
+})

--- a/services/site/app/routes/resources/podcast-listen.tsx
+++ b/services/site/app/routes/resources/podcast-listen.tsx
@@ -7,7 +7,6 @@ import {
 	CheckCircledIcon,
 	SpinnerIcon,
 } from '#app/components/icons.tsx'
-import { getPodcastListenRankings } from '#app/utils/blog.server.ts'
 import { parseEpisodeListenContentId } from '#app/utils/favorites.ts'
 import { reuseUsefulLoaderHeaders } from '#app/utils/misc.ts'
 import { getRankingLeader } from '#app/utils/team-rankings.ts'
@@ -118,16 +117,22 @@ export function PodcastListenToggle({
 }
 
 async function getPodcastListenServerServices() {
-	const [{ ensurePrimary }, { getUser }, { setEpisodePodcastListen }] =
-		await Promise.all([
-			import('#app/utils/litefs-js.server.ts'),
-			import('#app/utils/session.server.ts'),
-			import('#app/utils/prisma.server.ts'),
-		])
+	const [
+		{ ensurePrimary },
+		{ getUser },
+		{ setEpisodePodcastListen },
+		{ getPodcastListenRankings },
+	] = await Promise.all([
+		import('#app/utils/litefs-js.server.ts'),
+		import('#app/utils/session.server.ts'),
+		import('#app/utils/prisma.server.ts'),
+		import('#app/utils/blog.server.ts'),
+	])
 	return {
 		ensurePrimary,
 		getUser,
 		setEpisodePodcastListen,
+		getPodcastListenRankings,
 	}
 }
 
@@ -137,7 +142,12 @@ const PodcastListenFormSchema = z.object({
 })
 
 export async function action({ request }: Route.ActionArgs) {
-	const { ensurePrimary, getUser, setEpisodePodcastListen } =
+	const {
+		ensurePrimary,
+		getUser,
+		setEpisodePodcastListen,
+		getPodcastListenRankings,
+	} =
 		await getPodcastListenServerServices()
 	const formData = await request.formData()
 	const submission = PodcastListenFormSchema.safeParse(

--- a/services/site/app/routes/resources/podcast-listen.tsx
+++ b/services/site/app/routes/resources/podcast-listen.tsx
@@ -9,7 +9,6 @@ import {
 } from '#app/components/icons.tsx'
 import { parseEpisodeListenContentId } from '#app/utils/favorites.ts'
 import { reuseUsefulLoaderHeaders } from '#app/utils/misc.ts'
-import { getRankingLeader } from '#app/utils/team-rankings.ts'
 import { useOptionalUser } from '#app/utils/use-root-data.ts'
 import { type Route } from './+types/podcast-listen'
 
@@ -189,8 +188,8 @@ export async function action({ request }: Route.ActionArgs) {
 			seasonNumber: parsedContentId.seasonNumber,
 			episodeNumber: parsedContentId.episodeNumber,
 			forceFresh: true,
-		}).then(getRankingLeader),
-		getPodcastListenRankings({ request, forceFresh: true }).then(getRankingLeader),
+		}),
+		getPodcastListenRankings({ request, forceFresh: true }),
 	])
 
 	return json({

--- a/services/site/app/routes/resources/podcast-listen.tsx
+++ b/services/site/app/routes/resources/podcast-listen.tsx
@@ -1,0 +1,260 @@
+import * as React from 'react'
+import { clsx } from 'clsx'
+import { data as json, Link, useFetcher, type HeadersFunction } from 'react-router'
+import { z } from 'zod'
+import {
+	CheckIcon,
+	CheckCircledIcon,
+	SpinnerIcon,
+} from '#app/components/icons.tsx'
+import { getPodcastListenRankings } from '#app/utils/blog.server.ts'
+import {
+	getEpisodeListenContentId,
+	parseEpisodeListenContentId,
+} from '#app/utils/favorites.ts'
+import { reuseUsefulLoaderHeaders } from '#app/utils/misc.ts'
+import { getRankingLeader } from '#app/utils/team-rankings.ts'
+import { useOptionalUser } from '#app/utils/use-root-data.ts'
+import { type Route } from './+types/podcast-listen'
+
+const podcastListenResourceRoute = '/resources/podcast-listen'
+
+type PodcastListenResponse = {
+	listened: boolean
+	authenticated: boolean
+	error?: string
+}
+
+function isPodcastListenResponse(
+	data: unknown,
+): data is PodcastListenResponse {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'listened' in data &&
+		typeof (data as PodcastListenResponse).listened === 'boolean' &&
+		'authenticated' in data &&
+		typeof (data as PodcastListenResponse).authenticated === 'boolean'
+	)
+}
+
+export function PodcastListenToggle({
+	contentId,
+	initialListened = false,
+	className,
+}: {
+	contentId: string
+	initialListened?: boolean
+	className?: string
+}) {
+	const parsedContentId = parseEpisodeListenContentId(contentId)
+	if (!parsedContentId) {
+		throw new Error(`Invalid podcast listen content id: ${contentId}`)
+	}
+	const { seasonNumber, episodeNumber } = parsedContentId
+	const user = useOptionalUser()
+	const fetcherKey = `podcast-listen:${seasonNumber}:${episodeNumber}`
+	const fetcher = useFetcher<PodcastListenResponse>({ key: fetcherKey })
+
+	const optimisticListened =
+		fetcher.formData?.get('listened') === 'true'
+			? true
+			: fetcher.formData?.get('listened') === 'false'
+				? false
+				: undefined
+	const fetchedListened =
+		isPodcastListenResponse(fetcher.data) && !fetcher.data.error
+			? fetcher.data.listened
+			: undefined
+	const isAuthenticated =
+		isPodcastListenResponse(fetcher.data) && fetcher.data.authenticated
+	const listened =
+		optimisticListened ?? fetchedListened ?? initialListened ?? false
+	const isBusy = fetcher.state !== 'idle'
+
+	if (!user || (isPodcastListenResponse(fetcher.data) && !fetcher.data.authenticated)) {
+		return (
+			<Link
+				to="/login"
+				className={clsx(
+					'focus-ring bg-secondary text-primary hover:text-team-current inline-flex items-center gap-3 rounded-full px-6 py-3 text-lg font-medium transition focus:outline-none',
+					className,
+				)}
+			>
+				<CheckCircledIcon size={20} className="opacity-65" />
+				<span>Login to count your listen</span>
+			</Link>
+		)
+	}
+
+	return (
+		<fetcher.Form
+			method="POST"
+			action={podcastListenResourceRoute}
+			className={className}
+		>
+			<input type="hidden" name="contentId" value={contentId} />
+			<input type="hidden" name="listened" value={String(!listened)} />
+			<button
+				type="submit"
+				disabled={isBusy}
+				aria-pressed={listened}
+				className={clsx(
+					'focus-ring inline-flex items-center gap-3 rounded-full px-6 py-3 text-lg font-medium transition focus:outline-none',
+					listened
+						? 'bg-emerald-600 text-white hover:bg-emerald-500'
+						: 'bg-secondary text-primary hover:text-team-current',
+				)}
+			>
+				{isBusy ? (
+					<SpinnerIcon size={18} className="animate-spin" />
+				) : listened ? (
+					<CheckIcon />
+				) : (
+					<CheckCircledIcon size={20} className="opacity-65" />
+				)}
+				<span>{listened ? 'Listened' : 'Count my listen'}</span>
+			</button>
+		</fetcher.Form>
+	)
+}
+
+async function getPodcastListenServerServices() {
+	const [{ ensurePrimary }, { getUser }, { setEpisodePodcastListen }] =
+		await Promise.all([
+			import('#app/utils/litefs-js.server.ts'),
+			import('#app/utils/session.server.ts'),
+			import('#app/utils/prisma.server.ts'),
+		])
+	return {
+		ensurePrimary,
+		getUser,
+		setEpisodePodcastListen,
+	}
+}
+
+const PodcastListenFormSchema = z.object({
+	contentId: z.string().min(1).max(200),
+	listened: z.enum(['true', 'false']).transform((value) => value === 'true'),
+})
+
+export async function action({ request }: Route.ActionArgs) {
+	const { ensurePrimary, getUser, setEpisodePodcastListen } =
+		await getPodcastListenServerServices()
+	const formData = await request.formData()
+	const submission = PodcastListenFormSchema.safeParse(
+		Object.fromEntries(formData),
+	)
+	if (!submission.success) {
+		return json(
+			{ listened: false, authenticated: false, error: 'INVALID_FORM_DATA' },
+			{ status: 400 },
+		)
+	}
+
+	const parsedContentId = parseEpisodeListenContentId(submission.data.contentId)
+	if (!parsedContentId) {
+		return json(
+			{ listened: false, authenticated: false, error: 'INVALID_CONTENT_ID' },
+			{ status: 400 },
+		)
+	}
+
+	const user = await getUser(request)
+	if (!user) {
+		return json(
+			{ listened: false, authenticated: false, error: 'LOGIN_REQUIRED' },
+			{ status: 401 },
+		)
+	}
+
+	const [beforeEpisodeLeader, beforeOverallLeader] = await Promise.all([
+		getPodcastListenRankings({
+			request,
+			seasonNumber: parsedContentId.seasonNumber,
+			episodeNumber: parsedContentId.episodeNumber,
+		}).then(getRankingLeader),
+		getPodcastListenRankings({ request }).then(getRankingLeader),
+	])
+
+	await ensurePrimary()
+	const listened = await setEpisodePodcastListen({
+		...parsedContentId,
+		listened: submission.data.listened,
+		userId: user.id,
+	})
+
+	const [afterEpisodeLeader, afterOverallLeader] = await Promise.all([
+		getPodcastListenRankings({
+			request,
+			seasonNumber: parsedContentId.seasonNumber,
+			episodeNumber: parsedContentId.episodeNumber,
+			forceFresh: true,
+		}).then(getRankingLeader),
+		getPodcastListenRankings({ request, forceFresh: true }).then(getRankingLeader),
+	])
+	void beforeEpisodeLeader
+	void beforeOverallLeader
+	void afterEpisodeLeader
+	void afterOverallLeader
+
+	return json({
+		listened,
+		authenticated: true,
+	} satisfies PodcastListenResponse)
+}
+
+const PodcastListenQuerySchema = z.object({
+	contentId: z.string().min(1).max(200),
+})
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const { getUser } = await getPodcastListenServerServices()
+	const headers = {
+		'Cache-Control': 'private, max-age=0, must-revalidate',
+		Vary: 'Cookie',
+	}
+	const url = new URL(request.url)
+	const submission = PodcastListenQuerySchema.safeParse({
+		contentId: url.searchParams.get('contentId'),
+	})
+	if (!submission.success) {
+		return json(
+			{ listened: false, authenticated: false, error: 'INVALID_QUERY' },
+			{ status: 400, headers },
+		)
+	}
+
+	const parsedContentId = parseEpisodeListenContentId(submission.data.contentId)
+	if (!parsedContentId) {
+		return json(
+			{ listened: false, authenticated: false, error: 'INVALID_CONTENT_ID' },
+			{ status: 400, headers },
+		)
+	}
+
+	const user = await getUser(request)
+	if (!user) {
+		return json(
+			{ listened: false, authenticated: false } satisfies PodcastListenResponse,
+			{ headers },
+		)
+	}
+
+	const [{ getEpisodePodcastListens }] = await Promise.all([
+		import('#app/utils/prisma.server.ts'),
+	])
+	const listenIds = await getEpisodePodcastListens({ userId: user.id })
+
+	return json(
+		{
+			listened: listenIds.has(submission.data.contentId),
+			authenticated: true,
+		} satisfies PodcastListenResponse,
+		{ headers },
+	)
+}
+
+export const headers: HeadersFunction = reuseUsefulLoaderHeaders
+
+export { podcastListenResourceRoute }

--- a/services/site/app/routes/resources/podcast-listen.tsx
+++ b/services/site/app/routes/resources/podcast-listen.tsx
@@ -8,10 +8,7 @@ import {
 	SpinnerIcon,
 } from '#app/components/icons.tsx'
 import { getPodcastListenRankings } from '#app/utils/blog.server.ts'
-import {
-	getEpisodeListenContentId,
-	parseEpisodeListenContentId,
-} from '#app/utils/favorites.ts'
+import { parseEpisodeListenContentId } from '#app/utils/favorites.ts'
 import { reuseUsefulLoaderHeaders } from '#app/utils/misc.ts'
 import { getRankingLeader } from '#app/utils/team-rankings.ts'
 import { useOptionalUser } from '#app/utils/use-root-data.ts'
@@ -66,13 +63,14 @@ export function PodcastListenToggle({
 		isPodcastListenResponse(fetcher.data) && !fetcher.data.error
 			? fetcher.data.listened
 			: undefined
-	const isAuthenticated =
-		isPodcastListenResponse(fetcher.data) && fetcher.data.authenticated
 	const listened =
 		optimisticListened ?? fetchedListened ?? initialListened ?? false
 	const isBusy = fetcher.state !== 'idle'
 
-	if (!user || (isPodcastListenResponse(fetcher.data) && !fetcher.data.authenticated)) {
+	if (
+		!user ||
+		(isPodcastListenResponse(fetcher.data) && !fetcher.data.authenticated)
+	) {
 		return (
 			<Link
 				to="/login"
@@ -168,15 +166,6 @@ export async function action({ request }: Route.ActionArgs) {
 		)
 	}
 
-	const [beforeEpisodeLeader, beforeOverallLeader] = await Promise.all([
-		getPodcastListenRankings({
-			request,
-			seasonNumber: parsedContentId.seasonNumber,
-			episodeNumber: parsedContentId.episodeNumber,
-		}).then(getRankingLeader),
-		getPodcastListenRankings({ request }).then(getRankingLeader),
-	])
-
 	await ensurePrimary()
 	const listened = await setEpisodePodcastListen({
 		...parsedContentId,
@@ -184,7 +173,7 @@ export async function action({ request }: Route.ActionArgs) {
 		userId: user.id,
 	})
 
-	const [afterEpisodeLeader, afterOverallLeader] = await Promise.all([
+	await Promise.all([
 		getPodcastListenRankings({
 			request,
 			seasonNumber: parsedContentId.seasonNumber,
@@ -193,10 +182,6 @@ export async function action({ request }: Route.ActionArgs) {
 		}).then(getRankingLeader),
 		getPodcastListenRankings({ request, forceFresh: true }).then(getRankingLeader),
 	])
-	void beforeEpisodeLeader
-	void beforeOverallLeader
-	void afterEpisodeLeader
-	void afterOverallLeader
 
 	return json({
 		listened,
@@ -241,9 +226,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		)
 	}
 
-	const [{ getEpisodePodcastListens }] = await Promise.all([
-		import('#app/utils/prisma.server.ts'),
-	])
+	const { getEpisodePodcastListens } = await import('#app/utils/prisma.server.ts')
 	const listenIds = await getEpisodePodcastListens({ userId: user.id })
 
 	return json(

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -553,7 +553,10 @@ async function getTotalPodcastEpisodeListens({
 		timings,
 		checkValue: (value: unknown) => typeof value === 'number',
 		getFreshValue: async () => {
-			const listenCounts = await getPodcastEpisodeListenCounts({ request, timings })
+			const listenCounts = await getPodcastEpisodeListenCounts({
+				request,
+				timings,
+			})
 			if (seasonNumber && episodeNumber) {
 				return listenCounts[`${seasonNumber}:${episodeNumber}`] ?? 0
 			}
@@ -644,6 +647,95 @@ async function getPodcastListenRankings({
 	)
 }
 
+async function getPodcastListenLeadersBySeason({
+	request,
+	seasonNumber,
+	forceFresh,
+	timings,
+}: {
+	request?: Request
+	seasonNumber: number
+	forceFresh?: boolean
+	timings?: Timings
+}) {
+	const key = `podcast:${seasonNumber}:episode-leaders`
+	return cachified({
+		key,
+		cache,
+		request,
+		timings,
+		ttl: 1000 * 60 * 60 * 24 * 7,
+		staleWhileRevalidate: 1000 * 60 * 60 * 24,
+		forceFresh,
+		checkValue: (value: unknown) =>
+			value &&
+			typeof value === 'object' &&
+			!Array.isArray(value) &&
+			Object.values(value).every(
+				(team) => team === null || teams.includes(team as Team),
+			),
+		getFreshValue: async () => {
+			const [activeMembersEntries, recentListensEntries] = await Promise.all([
+				Promise.all(
+					teams.map(async (team) => [
+						team,
+						await getPodcastActiveMembers({ team, timings }),
+					]),
+				),
+				Promise.all(
+					teams.map(async (team) => [
+						team,
+						await getRecentPodcastListensByEpisode({
+							seasonNumber,
+							team,
+							timings,
+						}),
+					]),
+				),
+			])
+			const activeMembersByTeam = Object.fromEntries(
+				activeMembersEntries,
+			) as Record<Team, number>
+			const recentListensByTeam = Object.fromEntries(
+				recentListensEntries,
+			) as Record<Team, Record<number, number>>
+
+			const episodeNumbers = new Set<number>()
+			for (const team of teams) {
+				for (const episodeNumber of Object.keys(
+					recentListensByTeam[team] ?? {},
+				)) {
+					episodeNumbers.add(Number(episodeNumber))
+				}
+			}
+
+			const leadersByEpisode: Record<string, Team | null> = {}
+			for (const episodeNumber of episodeNumbers) {
+				const rankings = teams.map((team) => {
+					const activeMembers = activeMembersByTeam[team] ?? 0
+					const recentListens = recentListensByTeam[team]?.[episodeNumber] ?? 0
+					const ranking = activeMembers
+						? Number((recentListens / activeMembers).toFixed(4))
+						: 0
+					return { team, ranking }
+				})
+				const maxRanking = Math.max(...rankings.map((entry) => entry.ranking))
+				if (maxRanking <= 0) {
+					leadersByEpisode[String(episodeNumber)] = null
+					continue
+				}
+				const tiedLeaders = rankings.filter(
+					(entry) => entry.ranking === maxRanking,
+				)
+				const chosenLeader =
+					tiedLeaders[Math.floor(Math.random() * tiedLeaders.length)]
+				leadersByEpisode[String(episodeNumber)] = chosenLeader?.team ?? null
+			}
+			return leadersByEpisode
+		},
+	})
+}
+
 async function getRecentPodcastListens({
 	seasonNumber,
 	episodeNumber,
@@ -659,7 +751,9 @@ async function getRecentPodcastListens({
 	const count = await time(
 		prisma.podcastEpisodeListen.count({
 			where: {
-				...(seasonNumber && episodeNumber ? { seasonNumber, episodeNumber } : {}),
+				...(seasonNumber && episodeNumber
+					? { seasonNumber, episodeNumber }
+					: {}),
 				createdAt: { gt: withinTheLastSixMonths },
 				user: { team },
 			},
@@ -673,6 +767,37 @@ async function getRecentPodcastListens({
 		},
 	)
 	return count
+}
+
+async function getRecentPodcastListensByEpisode({
+	seasonNumber,
+	team,
+	timings,
+}: {
+	seasonNumber: number
+	team: Team
+	timings?: Timings
+}) {
+	const withinTheLastSixMonths = subMonths(new Date(), 6)
+	const rows = await time(
+		prisma.podcastEpisodeListen.groupBy({
+			by: ['episodeNumber'],
+			where: {
+				seasonNumber,
+				createdAt: { gt: withinTheLastSixMonths },
+				user: { team },
+			},
+			_count: { _all: true },
+		}),
+		{
+			timings,
+			type: 'getRecentPodcastListensByEpisode',
+			desc: `Getting podcast listens of season ${seasonNumber} by ${team} within the last 6 months`,
+		},
+	)
+	return Object.fromEntries(
+		rows.map((row) => [row.episodeNumber, row._count._all]),
+	)
 }
 
 async function getPodcastActiveMembers({
@@ -825,6 +950,7 @@ export {
 	getSlugReadsByUser,
 	getBlogPostReadCounts,
 	getPodcastEpisodeListenCounts,
+	getPodcastListenLeadersBySeason,
 	getPodcastListenRankings,
 	getTotalPodcastEpisodeListens,
 	getTotalPostReads,

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -486,9 +486,11 @@ async function getSlugReadsByUser({
 async function getPodcastEpisodeListenCounts({
 	request,
 	timings,
+	forceFresh,
 }: {
 	request?: Request
 	timings?: Timings
+	forceFresh?: boolean
 }) {
 	return cachified({
 		key: 'podcast:episode-listen-counts',
@@ -497,6 +499,7 @@ async function getPodcastEpisodeListenCounts({
 		cache: lruCache,
 		request,
 		timings,
+		forceFresh,
 		checkValue: (value: unknown) =>
 			typeof value === 'object' &&
 			value !== null &&
@@ -535,11 +538,13 @@ async function getTotalPodcastEpisodeListens({
 	seasonNumber,
 	episodeNumber,
 	timings,
+	forceFresh,
 }: {
 	request?: Request
 	seasonNumber?: number
 	episodeNumber?: number
 	timings?: Timings
+	forceFresh?: boolean
 }) {
 	const hasEpisode = seasonNumber !== undefined && episodeNumber !== undefined
 	const key = hasEpisode
@@ -552,11 +557,13 @@ async function getTotalPodcastEpisodeListens({
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
 		request,
 		timings,
+		forceFresh,
 		checkValue: (value: unknown) => typeof value === 'number',
 		getFreshValue: async () => {
 			const listenCounts = await getPodcastEpisodeListenCounts({
 				request,
 				timings,
+				forceFresh,
 			})
 			if (hasEpisode) {
 				return listenCounts[`${seasonNumber}:${episodeNumber}`] ?? 0
@@ -664,11 +671,11 @@ async function getPodcastListenLeadersBySeason({
 		ttl: 1000 * 60 * 60 * 24 * 7,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
 		forceFresh,
-		checkValue: (value: unknown) =>
-			value &&
+		checkValue: (value: unknown): value is Record<string, Team | null> =>
+			value !== null &&
 			typeof value === 'object' &&
 			!Array.isArray(value) &&
-			Object.values(value).every(
+			Object.values(value as Record<string, Team | null>).every(
 				(team) => team === null || teams.includes(team as Team),
 			),
 		getFreshValue: async () => {
@@ -748,7 +755,7 @@ async function getRecentPodcastListens({
 	const count = await time(
 		prisma.podcastEpisodeListen.count({
 			where: {
-				...(seasonNumber && episodeNumber
+				...(seasonNumber !== undefined && episodeNumber !== undefined
 					? { seasonNumber, episodeNumber }
 					: {}),
 				createdAt: { gt: withinTheLastSixMonths },

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -541,7 +541,8 @@ async function getTotalPodcastEpisodeListens({
 	episodeNumber?: number
 	timings?: Timings
 }) {
-	const key = seasonNumber
+	const hasEpisode = seasonNumber !== undefined && episodeNumber !== undefined
+	const key = hasEpisode
 		? `total-podcast-episode-listens:${seasonNumber}:${episodeNumber}`
 		: 'total-podcast-episode-listens:__all__'
 	return cachified({
@@ -557,7 +558,7 @@ async function getTotalPodcastEpisodeListens({
 				request,
 				timings,
 			})
-			if (seasonNumber && episodeNumber) {
+			if (hasEpisode) {
 				return listenCounts[`${seasonNumber}:${episodeNumber}`] ?? 0
 			}
 			return Object.values(listenCounts).reduce((sum, count) => sum + count, 0)
@@ -578,20 +579,16 @@ async function getPodcastListenRankings({
 	forceFresh?: boolean
 	timings?: Timings
 }) {
+	const hasEpisode = seasonNumber !== undefined && episodeNumber !== undefined
 	const episodeKey =
-		seasonNumber && episodeNumber
-			? `${seasonNumber}:${episodeNumber}`
-			: '__all_episodes__'
-	const key =
-		seasonNumber && episodeNumber
-			? `podcast:${episodeKey}:rankings`
-			: 'podcast:rankings'
+		hasEpisode ? `${seasonNumber}:${episodeNumber}` : '__all_episodes__'
+	const key = hasEpisode ? `podcast:${episodeKey}:rankings` : 'podcast:rankings'
 	const rankingObjs = await cachified({
 		key,
 		cache,
 		request,
 		timings,
-		ttl: seasonNumber ? 1000 * 60 * 60 * 24 * 7 : 1000 * 60 * 60,
+		ttl: hasEpisode ? 1000 * 60 * 60 * 24 * 7 : 1000 * 60 * 60,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
 		forceFresh,
 		checkValue: (value: unknown) =>
@@ -604,7 +601,7 @@ async function getPodcastListenRankings({
 					totalCount: number
 					ranking: number
 				}> {
-					const where = seasonNumber
+					const where = hasEpisode
 						? {
 								seasonNumber,
 								episodeNumber,

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -11,6 +11,7 @@ import { getBlogMdxListItems } from './mdx.server.ts'
 import { getDomainUrl, getOptionalTeam, teams, typedBoolean } from './misc.ts'
 import { prisma } from './prisma.server.ts'
 import { getUser } from './session.server.ts'
+import { type TeamRanking as SharedTeamRanking } from './team-rankings.ts'
 import { teamEmoji } from './team-provider.tsx'
 import { time, type Timings } from './timing.server.ts'
 
@@ -308,10 +309,10 @@ async function getBlogReadRankings({
 			const rawRankingData = await Promise.all(
 				teams.map(async function getRankingsForTeam(team): Promise<{
 					team: Team
-					totalReads: number
+					totalCount: number
 					ranking: number
 				}> {
-					const totalReads = await prisma.postRead.count({
+					const totalCount = await prisma.postRead.count({
 						where: {
 							postSlug: slug,
 							user: { team },
@@ -323,17 +324,17 @@ async function getBlogReadRankings({
 					if (activeMembers) {
 						ranking = Number((recentReads / activeMembers).toFixed(4))
 					}
-					return { team, totalReads, ranking }
+					return { team, totalCount, ranking }
 				}),
 			)
 			const rankings = rawRankingData.map((r) => r.ranking)
 			const maxRanking = Math.max(...rankings)
 			const minRanking = Math.min(...rankings)
 			const rankPercentages = rawRankingData.map(
-				({ team, totalReads, ranking }) => {
+				({ team, totalCount, ranking }) => {
 					return {
 						team,
-						totalReads,
+						totalCount,
 						ranking,
 						percent: Number(
 							((ranking - minRanking) / (maxRanking - minRanking || 1)).toFixed(
@@ -483,6 +484,251 @@ async function getSlugReadsByUser({
 	return Array.from(new Set(reads.map((read) => read.postSlug)))
 }
 
+async function getPodcastEpisodeListenCounts({
+	request,
+	timings,
+}: {
+	request?: Request
+	timings?: Timings
+}) {
+	return cachified({
+		key: 'podcast:episode-listen-counts',
+		ttl: 1000 * 60 * 30,
+		staleWhileRevalidate: 1000 * 60 * 60 * 24,
+		cache: lruCache,
+		request,
+		timings,
+		checkValue: (value: unknown) =>
+			typeof value === 'object' &&
+			value !== null &&
+			!Array.isArray(value) &&
+			Object.values(value as Record<string, unknown>).every(
+				(v) => typeof v === 'number',
+			),
+		getFreshValue: async (context) => {
+			try {
+				const timeoutMs = context.background ? 1000 * 10 : 1000 * 5
+				const result = await promiseWithTimeout(
+					prisma.podcastEpisodeListen.groupBy({
+						by: ['seasonNumber', 'episodeNumber'],
+						_count: { _all: true },
+					}),
+					timeoutMs,
+				)
+
+				return Object.fromEntries(
+					result.map((row) => [
+						`${row.seasonNumber}:${row.episodeNumber}`,
+						row._count._all,
+					]),
+				) as Record<string, number>
+			} catch (error: unknown) {
+				console.error(`Failed to get podcast episode listen counts`, error)
+				context.metadata.ttl = 1000 * 60
+				return {}
+			}
+		},
+	})
+}
+
+async function getTotalPodcastEpisodeListens({
+	request,
+	seasonNumber,
+	episodeNumber,
+	timings,
+}: {
+	request?: Request
+	seasonNumber?: number
+	episodeNumber?: number
+	timings?: Timings
+}) {
+	const key = seasonNumber
+		? `total-podcast-episode-listens:${seasonNumber}:${episodeNumber}`
+		: 'total-podcast-episode-listens:__all__'
+	return cachified({
+		key,
+		cache: lruCache,
+		ttl: 1000 * 60 * 30,
+		staleWhileRevalidate: 1000 * 60 * 60 * 24,
+		request,
+		timings,
+		checkValue: (value: unknown) => typeof value === 'number',
+		getFreshValue: async () => {
+			const listenCounts = await getPodcastEpisodeListenCounts({ request, timings })
+			if (seasonNumber && episodeNumber) {
+				return listenCounts[`${seasonNumber}:${episodeNumber}`] ?? 0
+			}
+			return Object.values(listenCounts).reduce((sum, count) => sum + count, 0)
+		},
+	})
+}
+
+async function getPodcastListenRankings({
+	request,
+	seasonNumber,
+	episodeNumber,
+	forceFresh,
+	timings,
+}: {
+	request?: Request
+	seasonNumber?: number
+	episodeNumber?: number
+	forceFresh?: boolean
+	timings?: Timings
+}) {
+	const episodeKey =
+		seasonNumber && episodeNumber
+			? `${seasonNumber}:${episodeNumber}`
+			: '__all_episodes__'
+	const key =
+		seasonNumber && episodeNumber
+			? `podcast:${episodeKey}:rankings`
+			: 'podcast:rankings'
+	const rankingObjs = await cachified({
+		key,
+		cache,
+		request,
+		timings,
+		ttl: seasonNumber ? 1000 * 60 * 60 * 24 * 7 : 1000 * 60 * 60,
+		staleWhileRevalidate: 1000 * 60 * 60 * 24,
+		forceFresh,
+		checkValue: (value: unknown) =>
+			Array.isArray(value) &&
+			value.every((v) => typeof v === 'object' && 'team' in v),
+		getFreshValue: async () => {
+			const rawRankingData = await Promise.all(
+				teams.map(async function getRankingsForTeam(team): Promise<{
+					team: Team
+					totalCount: number
+					ranking: number
+				}> {
+					const where = seasonNumber
+						? {
+								seasonNumber,
+								episodeNumber,
+								user: { team },
+							}
+						: {
+								user: { team },
+							}
+					const totalCount = await prisma.podcastEpisodeListen.count({ where })
+					const activeMembers = await getPodcastActiveMembers({ team, timings })
+					const recentListens = await getRecentPodcastListens({
+						seasonNumber,
+						episodeNumber,
+						team,
+						timings,
+					})
+					let ranking = 0
+					if (activeMembers) {
+						ranking = Number((recentListens / activeMembers).toFixed(4))
+					}
+					return { team, totalCount, ranking }
+				}),
+			)
+			const rankings = rawRankingData.map((r) => r.ranking)
+			const maxRanking = Math.max(...rankings)
+			const minRanking = Math.min(...rankings)
+			return rawRankingData.map(({ team, totalCount, ranking }) => ({
+				team,
+				totalCount,
+				ranking,
+				percent: Number(
+					((ranking - minRanking) / (maxRanking - minRanking || 1)).toFixed(2),
+				),
+			}))
+		},
+	})
+
+	return rankingObjs.sort(({ percent: a }, { percent: b }) =>
+		b === a ? (Math.random() > 0.5 ? -1 : 1) : a > b ? -1 : 1,
+	)
+}
+
+async function getRecentPodcastListens({
+	seasonNumber,
+	episodeNumber,
+	team,
+	timings,
+}: {
+	seasonNumber?: number
+	episodeNumber?: number
+	team: Team
+	timings?: Timings
+}) {
+	const withinTheLastSixMonths = subMonths(new Date(), 6)
+	const count = await time(
+		prisma.podcastEpisodeListen.count({
+			where: {
+				...(seasonNumber && episodeNumber ? { seasonNumber, episodeNumber } : {}),
+				createdAt: { gt: withinTheLastSixMonths },
+				user: { team },
+			},
+		}),
+		{
+			timings,
+			type: 'getRecentPodcastListens',
+			desc: `Getting podcast listens${
+				seasonNumber ? ` of ${seasonNumber}:${episodeNumber}` : ''
+			} by ${team} within the last 6 months`,
+		},
+	)
+	return count
+}
+
+async function getPodcastActiveMembers({
+	team,
+	timings,
+}: {
+	team: Team
+	timings?: Timings
+}) {
+	const withinTheLastYear = subYears(new Date(), 1)
+	const count = await time(
+		prisma.user.count({
+			where: {
+				team,
+				podcastEpisodeListens: {
+					some: {
+						createdAt: { gt: withinTheLastYear },
+					},
+				},
+			},
+		}),
+		{
+			timings,
+			type: 'getPodcastActiveMembers',
+			desc: `Getting active podcast listeners of ${team}`,
+		},
+	)
+	return count
+}
+
+async function getEpisodeListensByUser({
+	request,
+	timings,
+}: {
+	request: Request
+	timings?: Timings
+}) {
+	const user = await getUser(request)
+	if (!user) return []
+	const listens = await time(
+		prisma.podcastEpisodeListen.findMany({
+			where: { userId: user.id },
+			select: { seasonNumber: true, episodeNumber: true },
+		}),
+		{
+			timings,
+			type: 'getEpisodeListensByUser',
+			desc: `Getting podcast listens by ${user.id}`,
+		},
+	)
+	return Array.from(
+		new Set(listens.map((listen) => `${listen.seasonNumber}:${listen.episodeNumber}`)),
+	)
+}
+
 async function getPostJson(request: Request) {
 	const posts = await getBlogMdxListItems({ request })
 
@@ -602,8 +848,12 @@ export {
 	getBlogRecommendations,
 	getBlogReadRankings,
 	getAllBlogPostReadRankings,
+	getEpisodeListensByUser,
 	getSlugReadsByUser,
 	getBlogPostReadCounts,
+	getPodcastEpisodeListenCounts,
+	getPodcastListenRankings,
+	getTotalPodcastEpisodeListens,
 	getTotalPostReads,
 	getReaderCount,
 	getPostJson,

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -11,7 +11,6 @@ import { getBlogMdxListItems } from './mdx.server.ts'
 import { getDomainUrl, getOptionalTeam, teams, typedBoolean } from './misc.ts'
 import { prisma } from './prisma.server.ts'
 import { getUser } from './session.server.ts'
-import { type TeamRanking as SharedTeamRanking } from './team-rankings.ts'
 import { teamEmoji } from './team-provider.tsx'
 import { time, type Timings } from './timing.server.ts'
 
@@ -704,31 +703,6 @@ async function getPodcastActiveMembers({
 	return count
 }
 
-async function getEpisodeListensByUser({
-	request,
-	timings,
-}: {
-	request: Request
-	timings?: Timings
-}) {
-	const user = await getUser(request)
-	if (!user) return []
-	const listens = await time(
-		prisma.podcastEpisodeListen.findMany({
-			where: { userId: user.id },
-			select: { seasonNumber: true, episodeNumber: true },
-		}),
-		{
-			timings,
-			type: 'getEpisodeListensByUser',
-			desc: `Getting podcast listens by ${user.id}`,
-		},
-	)
-	return Array.from(
-		new Set(listens.map((listen) => `${listen.seasonNumber}:${listen.episodeNumber}`)),
-	)
-}
-
 async function getPostJson(request: Request) {
 	const posts = await getBlogMdxListItems({ request })
 
@@ -848,7 +822,6 @@ export {
 	getBlogRecommendations,
 	getBlogReadRankings,
 	getAllBlogPostReadRankings,
-	getEpisodeListensByUser,
 	getSlugReadsByUser,
 	getBlogPostReadCounts,
 	getPodcastEpisodeListenCounts,

--- a/services/site/app/utils/blog.ts
+++ b/services/site/app/utils/blog.ts
@@ -1,16 +1,6 @@
 import { matchSorter, rankings as matchSorterRankings } from 'match-sorter'
 import { type MdxListItem } from '#app/types.ts'
-import { type ReadRankings } from './blog.server.ts'
-
-function getRankingLeader(rankings?: ReadRankings) {
-	if (!rankings) return null
-
-	return rankings.reduce((leader: ReadRankings[number] | null, rank) => {
-		if (rank.ranking <= 0) return leader
-		if (!leader || rank.ranking > leader.ranking) return rank
-		return leader
-	}, null)
-}
+import { getRankingLeader } from './team-rankings.ts'
 
 function filterPosts(posts: Array<MdxListItem>, searchString: string) {
 	if (!searchString) return posts

--- a/services/site/app/utils/favorites.ts
+++ b/services/site/app/utils/favorites.ts
@@ -37,6 +37,10 @@ export function parseEpisodeFavoriteContentId(contentId: string) {
 	return { seasonNumber, episodeNumber }
 }
 
+export const getEpisodeListenContentId = getEpisodeFavoriteContentId
+
+export const parseEpisodeListenContentId = parseEpisodeFavoriteContentId
+
 /**
  * Canonical identifier for one homework item within a Chats with Kent episode.
  * Stored without leading zeroes so we have exactly one representation.

--- a/services/site/app/utils/prisma.server.ts
+++ b/services/site/app/utils/prisma.server.ts
@@ -4,7 +4,10 @@ import chalk from 'chalk'
 import pProps from 'p-props'
 import { type Session } from '#app/types.ts'
 import { getEnv } from '#app/utils/env.server.ts'
-import { getEpisodeHomeworkContentId } from '#app/utils/favorites.ts'
+import {
+	getEpisodeHomeworkContentId,
+	getEpisodeListenContentId,
+} from '#app/utils/favorites.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { Prisma, PrismaClient } from './prisma-generated.server/client.ts'
 import { time, type Timings } from './timing.server.ts'
@@ -125,6 +128,9 @@ async function getAllUserData(userId: string) {
 		}),
 		favorites: prisma.favorite.findMany({ where: { userId } }),
 		postReads: prisma.postRead.findMany({ where: { userId } }),
+		podcastEpisodeListens: prisma.podcastEpisodeListen.findMany({
+			where: { userId },
+		}),
 		sessions: prisma.session.findMany({ where: { userId } }),
 	})
 }
@@ -189,6 +195,68 @@ async function getEpisodeHomeworkCompletions({
 			}),
 		),
 	)
+}
+
+async function getEpisodePodcastListens({
+	userId,
+}: {
+	userId?: string | null
+}) {
+	if (!userId) return new Set<string>()
+	const listens = await prisma.podcastEpisodeListen.findMany({
+		where: { userId },
+		select: { seasonNumber: true, episodeNumber: true },
+	})
+	return new Set(
+		listens.map((listen) =>
+			getEpisodeListenContentId({
+				seasonNumber: listen.seasonNumber,
+				episodeNumber: listen.episodeNumber,
+			}),
+		),
+	)
+}
+
+async function setEpisodePodcastListen({
+	seasonNumber,
+	episodeNumber,
+	userId,
+	listened,
+}: {
+	seasonNumber: number
+	episodeNumber: number
+	userId: string
+	listened: boolean
+}) {
+	if (listened) {
+		await prisma.podcastEpisodeListen.upsert({
+			where: {
+				userId_seasonNumber_episodeNumber: {
+					userId,
+					seasonNumber,
+					episodeNumber,
+				},
+			},
+			create: {
+				userId,
+				seasonNumber,
+				episodeNumber,
+			},
+			update: {
+				updatedAt: new Date(),
+			},
+		})
+		return true
+	}
+
+	await prisma.podcastEpisodeListen.deleteMany({
+		where: {
+			userId,
+			seasonNumber,
+			episodeNumber,
+		},
+	})
+	return false
 }
 
 async function setEpisodeHomeworkCompletion({
@@ -346,11 +414,13 @@ export {
 	createSession,
 	deleteExpiredSessions,
 	deleteExpiredVerifications,
+	getEpisodePodcastListens,
 	getAllUserData,
 	getEpisodeHomeworkCompletions,
 	getUserFromSessionId,
 	migrateHomeworkCompletionsToUser,
 	prisma,
+	setEpisodePodcastListen,
 	setEpisodeHomeworkCompletion,
 	sessionExpirationTime,
 }

--- a/services/site/app/utils/team-rankings.ts
+++ b/services/site/app/utils/team-rankings.ts
@@ -1,0 +1,20 @@
+import { type Team } from '#app/types.ts'
+
+export type TeamRanking = {
+	totalCount: number
+	team: Team
+	percent: number
+	ranking: number
+}
+
+export function getRankingLeader<Ranking extends { ranking: number }>(
+	rankings?: Array<Ranking>,
+) {
+	if (!rankings) return null
+
+	return rankings.reduce((leader: Ranking | null, rank) => {
+		if (rank.ranking <= 0) return leader
+		if (!leader || rank.ranking > leader.ranking) return rank
+		return leader
+	}, null)
+}

--- a/services/site/content/pages/teams.mdx
+++ b/services/site/content/pages/teams.mdx
@@ -140,10 +140,14 @@ So here's how it works:
   the episode page.
 - Blog posts and podcast episodes each have their own rankings and overall
   leaderboards.
-- The team ranking is computed by taking the total number of recent reads or
-  listens divided by the total number of active members for that content type.
-- A team member is considered active if they've read a blog post or reported a
-  podcast listen in the last year for that leaderboard.
+- For the blog leaderboard, the team ranking is computed by taking the total
+  number of recent reads divided by the number of active blog readers.
+- For the podcast leaderboard, the team ranking is computed by taking the total
+  number of recent listens divided by the number of active podcast listeners.
+- For the blog leaderboard, a member is active if they've read a blog post in
+  the last year.
+- For the podcast leaderboard, a member is active if they've reported a podcast
+  listen in the last year.
 - A read or listen is considered "recent" if it happened within the last 6
   months.
 

--- a/services/site/content/pages/teams.mdx
+++ b/services/site/content/pages/teams.mdx
@@ -113,27 +113,34 @@ Koala 🐨 and it stuck.
 ## Read Rankings
 
 When you read a blog post, that's marked in the database and your team gets
-points (note, this requires that you're [logged in](/login) so the proper team
-to associate the read with is known). Whichever team has the most points gets
-the highest ranking and "owns" that blog post. You'll notice which team is
-winning based on the graph at the top and bottom of the post as well as the
-highlight color throughout the post. There's also an overall leader and that
-team color controls the color of the blog page.
+points. The Chats with Kent podcast now works similarly: because many podcast
+players don't report back, episode pages include a self-report button you can
+use after you've listened. Both of these actions require that you're
+[logged in](/login) so the proper team to associate the activity with is known.
+Whichever team has the most points gets the highest ranking and "owns" that
+piece of content. You'll notice which team is winning based on the graph at the
+top and bottom of the page as well as the highlight color throughout. There's
+also an overall leader and that team color controls the color of the overview
+pages.
 
 Because you can choose your own team, the teams can be different sizes, so we
-don't just compute the teams by total number of blog post reads. Additionally,
-you get credit for every time you read a blog post.
+don't just compute the teams by total raw activity. Instead, rankings are
+normalized by active members.
 
 So here's how it works:
 
 - A blog post is marked as "read" when you've scrolled through the whole thing
   and you've been on the page for long enough to have actually read it.
-- For any given post, you get a recorded read every 7 days.
-- The team ranking is computed by taking the total number of recent reads
-  divided by the total number of active members.
-- A team member is considered active if they've read a blog post in the last
-  year.
-- A read is considered "recent" if it was read within the last 6 months.
+- A podcast episode is marked as listened when you use the self-report button on
+  the episode page.
+- Blog posts and podcast episodes each have their own rankings and overall
+  leaderboards.
+- The team ranking is computed by taking the total number of recent reads or
+  listens divided by the total number of active members for that content type.
+- A team member is considered active if they've read a blog post or reported a
+  podcast listen in the last year for that leaderboard.
+- A read or listen is considered "recent" if it happened within the last 6
+  months.
 
 So there you go. That's what the ranking is all about.
 

--- a/services/site/content/pages/teams.mdx
+++ b/services/site/content/pages/teams.mdx
@@ -113,15 +113,20 @@ Koala 🐨 and it stuck.
 ## Read Rankings
 
 When you read a blog post, that's marked in the database and your team gets
-points. The Chats with Kent podcast now works similarly: because many podcast
-players don't report back, episode pages include a self-report button you can
-use after you've listened. Both of these actions require that you're
-[logged in](/login) so the proper team to associate the activity with is known.
-Whichever team has the most points gets the highest ranking and "owns" that
-piece of content. You'll notice which team is winning based on the graph at the
-top and bottom of the page as well as the highlight color throughout. There's
-also an overall leader and that team color controls the color of the overview
-pages.
+points. Whichever team has the most points gets the highest ranking and "owns"
+that post.
+
+## Listen Rankings
+
+The Chats with Kent podcast works similarly: because many podcast players don't
+report back, episode pages include a self-report button you can use after
+you've listened. Podcast listens have their own ranking graph and leaderboard.
+
+Both of these actions require that you're [logged in](/login) so the proper
+team to associate the activity with is known. You'll notice which team is
+winning based on the graph at the top and bottom of the page as well as the
+highlight color throughout. There's also an overall leader and that team color
+controls the color of the overview pages.
 
 Because you can choose your own team, the teams can be different sizes, so we
 don't just compute the teams by total raw activity. Instead, rankings are

--- a/services/site/prisma/migrations/20260402050056_podcast_episode_listens/migration.sql
+++ b/services/site/prisma/migrations/20260402050056_podcast_episode_listens/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "PodcastEpisodeListen" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    "seasonNumber" INTEGER NOT NULL,
+    "episodeNumber" INTEGER NOT NULL,
+    CONSTRAINT "PodcastEpisodeListen_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "PodcastEpisodeListen_userId_seasonNumber_episodeNumber_idx" ON "PodcastEpisodeListen"("userId", "seasonNumber", "episodeNumber");
+
+-- CreateIndex
+CREATE INDEX "PodcastEpisodeListen_seasonNumber_episodeNumber_createdAt_idx" ON "PodcastEpisodeListen"("seasonNumber", "episodeNumber", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PodcastEpisodeListen_createdAt_userId_idx" ON "PodcastEpisodeListen"("createdAt", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PodcastEpisodeListen_userId_seasonNumber_episodeNumber_key" ON "PodcastEpisodeListen"("userId", "seasonNumber", "episodeNumber");

--- a/services/site/prisma/schema.prisma
+++ b/services/site/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   callKentCallerEpisodes CallKentCallerEpisode[]
   sessions  Session[]
   postReads PostRead[]
+  podcastEpisodeListens PodcastEpisodeListen[]
   favorites Favorite[]
   homeworkCompletions HomeworkCompletion[]
 
@@ -178,6 +179,21 @@ model PostRead {
   @@index([userId, postSlug])
   @@index([clientId, postSlug])
   @@index([postSlug, createdAt])
+  @@index([createdAt, userId])
+}
+
+model PodcastEpisodeListen {
+  id            String   @id @default(uuid())
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId        String
+  seasonNumber  Int
+  episodeNumber Int
+
+  @@unique([userId, seasonNumber, episodeNumber])
+  @@index([userId, seasonNumber, episodeNumber])
+  @@index([seasonNumber, episodeNumber, createdAt])
   @@index([createdAt, userId])
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add self-reported Chats with Kent listens via `PodcastEpisodeListen`, a new `/resources/podcast-listen` toggle, and cached episode/overall ranking helpers
- surface podcast team ownership on `/chats` overview and episode pages with ranking bars and per-episode leader dots
- tighten follow-up review fixes around cache freshness, episode-loader parallelism, wording, unlisten regression coverage, and remove redundant winner text from the episode page

## Testing
- ✅ `npm run ci:verify --workspace=kentcdodds.com`
- ✅ `npm run test:backend --workspace kentcdodds.com -- app/routes/resources/__tests__/podcast-listen.test.ts`
- ✅ `npm run typecheck --workspace kentcdodds.com`
- ✅ Manual Chrome walkthrough covering login, `/chats/05`, claiming episode `/chats/05/06/atqui-aegre-dolores`, seeing `Listened`, and returning to the overview
- ✅ Browser sanity check confirming the episode page no longer renders ranking explainer copy

## Artifacts
[podcast-listen-self-reporting-success.mp4](https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodcast-listen-self-reporting-success.mp4)
[Podcast listen episode state](https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodcast-listen-episode.png)
[Podcast listen overview](https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodcast-listen-overview.png)
[Podcast listen episode without ranking copy](https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodcast-listen-episode-no-copy.png)
[podcast-listen-typecheck.log](https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodcast-listen-typecheck.log)
[podcast-listen-backend-tests.log](https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodcast-listen-backend-tests.log)

## Summary by CodeRabbit

* **New Features**
  * Podcast listen toggle and endpoint; per-episode listen counts, leader dots, leading-team messages, and updated TeamStats with configurable label/link and count-based display.
* **Tests**
  * Added tests for listen endpoint and toggle covering auth, validation, persistence, and unlisten paths.
* **Database**
  * Added persistent per-user podcast listen records and indexes.
* **Documentation**
  * Updated ranking rules to include podcast listens alongside blog reads.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-161bf82f-62be-4485-8f04-89a483bd16dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-161bf82f-62be-4485-8f04-89a483bd16dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Podcast listen toggle and endpoint; per-episode listen counts, leader dots, leading-team messages, and updated TeamStats with configurable label/link and count-based display.
* **Tests**
  * Added tests for listen endpoint and toggle covering auth, validation, and persistence paths.
* **Database**
  * Added persistent per-user podcast listen records and indexes.
* **Documentation**
  * Updated ranking rules to include podcast listens alongside blog reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->