### PR TITLE
Add MCP server card discovery route

### DIFF
--- a/services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts
+++ b/services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts
@@ -7,7 +7,6 @@ export function loader({ request }: Route.LoaderArgs) {
 
 	return new Response(string, {
 		headers: {
-			'Access-Control-Allow-Origin': '*',
 			'Access-Control-Allow-Headers': 'Content-Type',
 			'Access-Control-Allow-Methods': 'GET',
 			'Cache-Control': 'public, max-age=3600',

--- a/services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts
+++ b/services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts
@@ -1,0 +1,18 @@
+import { createMcpServerCard } from '#app/routes/mcp/server-card.ts'
+import { type Route } from './+types/server-card[.]json'
+
+export function loader({ request }: Route.LoaderArgs) {
+	const data = createMcpServerCard(request)
+	const string = JSON.stringify(data)
+
+	return new Response(string, {
+		headers: {
+			'Access-Control-Allow-Origin': '*',
+			'Access-Control-Allow-Headers': 'Content-Type',
+			'Access-Control-Allow-Methods': 'GET',
+			'Cache-Control': 'public, max-age=3600',
+			'Content-Length': String(Buffer.byteLength(string)),
+			'Content-Type': 'application/json',
+		},
+	})
+}

--- a/services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts
+++ b/services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts
@@ -7,6 +7,7 @@ export function loader({ request }: Route.LoaderArgs) {
 
 	return new Response(string, {
 		headers: {
+			'Access-Control-Allow-Origin': '*',
 			'Access-Control-Allow-Headers': 'Content-Type',
 			'Access-Control-Allow-Methods': 'GET',
 			'Cache-Control': 'public, max-age=3600',

--- a/services/site/app/routes/mcp/__tests__/server-card.test.ts
+++ b/services/site/app/routes/mcp/__tests__/server-card.test.ts
@@ -22,7 +22,7 @@ test('createMcpServerCard returns discovery metadata for the local MCP transport
 		endpoint: `https://kentcdodds.com${mcpServerTransportPath}`,
 	})
 	expect(card.capabilities).toEqual({
-		tools: { dynamic: true },
+		tools: { dynamic: false },
 		resources: { dynamic: false },
 		prompts: { dynamic: false },
 	})

--- a/services/site/app/routes/mcp/__tests__/server-card.test.ts
+++ b/services/site/app/routes/mcp/__tests__/server-card.test.ts
@@ -9,6 +9,7 @@ import {
 test('createMcpServerCard returns discovery metadata for the local MCP transport', () => {
 	const request = new Request(
 		'https://kentcdodds.com/.well-known/mcp/server-card.json',
+		{ headers: { host: 'kentcdodds.com' } },
 	)
 	const card = createMcpServerCard(request)
 

--- a/services/site/app/routes/mcp/__tests__/server-card.test.ts
+++ b/services/site/app/routes/mcp/__tests__/server-card.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+import {
+	createMcpServerCard,
+	mcpServerName,
+	mcpServerTransportPath,
+	mcpServerVersion,
+} from '../server-card.ts'
+
+test('createMcpServerCard returns discovery metadata for the local MCP transport', () => {
+	const request = new Request(
+		'https://kentcdodds.com/.well-known/mcp/server-card.json',
+	)
+	const card = createMcpServerCard(request)
+
+	expect(card.serverInfo).toEqual({
+		name: mcpServerName,
+		version: mcpServerVersion,
+	})
+	expect(card.transport).toEqual({
+		type: 'streamable-http',
+		endpoint: `https://kentcdodds.com${mcpServerTransportPath}`,
+	})
+	expect(card.capabilities).toEqual({
+		tools: { dynamic: true },
+		resources: { dynamic: false },
+		prompts: { dynamic: false },
+	})
+	expect(card.remotes).toEqual([
+		expect.objectContaining({
+			type: 'streamable-http',
+			url: `https://kentcdodds.com${mcpServerTransportPath}`,
+		}),
+	])
+})

--- a/services/site/app/routes/mcp/mcp.server.ts
+++ b/services/site/app/routes/mcp/mcp.server.ts
@@ -14,6 +14,7 @@ import { prisma } from '#app/utils/prisma.server.js'
 import { searchKCD } from '#app/utils/search.server.js'
 import { getSeasons as getChatsWithKentSeasons } from '#app/utils/simplecast.server.js'
 import { isEmailVerified } from '#app/utils/verifier.server.js'
+import { mcpServerName, mcpServerVersion } from './server-card.ts'
 
 export const requestStorage = new AsyncLocalStorage<Request>()
 
@@ -26,8 +27,8 @@ const transports = new Map<string, TransportEntry>()
 function createServer() {
 	const server = new McpServer(
 		{
-			name: 'kentcdodds.com',
-			version: '1.0.0',
+			name: mcpServerName,
+			version: mcpServerVersion,
 		},
 		{
 			capabilities: {

--- a/services/site/app/routes/mcp/server-card.ts
+++ b/services/site/app/routes/mcp/server-card.ts
@@ -23,7 +23,7 @@ export function createMcpServerCard(request: Request) {
 			version: mcpServerVersion,
 		},
 		capabilities: {
-			tools: { dynamic: true },
+			tools: { dynamic: false },
 			resources: { dynamic: false },
 			prompts: { dynamic: false },
 		},

--- a/services/site/app/routes/mcp/server-card.ts
+++ b/services/site/app/routes/mcp/server-card.ts
@@ -1,0 +1,42 @@
+import { SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/sdk/types.js'
+import { getDomainUrl } from '#app/utils/misc.js'
+
+export const mcpServerName = 'kentcdodds.com'
+export const mcpServerVersion = '1.0.0'
+export const mcpServerTransportPath = '/mcp'
+export const mcpSupportedProtocolVersions = SUPPORTED_PROTOCOL_VERSIONS
+
+export function createMcpServerCard(request: Request) {
+	const endpoint = `${getDomainUrl(request)}${mcpServerTransportPath}`
+
+	return {
+		$schema:
+			'https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json',
+		name: mcpServerName,
+		version: mcpServerVersion,
+		description:
+			'Authenticated MCP server for kentcdodds.com account, content, and search tools.',
+		title: 'Kent C. Dodds MCP Server',
+		websiteUrl: 'https://kentcdodds.com/about-mcp',
+		serverInfo: {
+			name: mcpServerName,
+			version: mcpServerVersion,
+		},
+		capabilities: {
+			tools: { dynamic: true },
+			resources: { dynamic: false },
+			prompts: { dynamic: false },
+		},
+		transport: {
+			type: 'streamable-http',
+			endpoint,
+		},
+		remotes: [
+			{
+				type: 'streamable-http',
+				url: endpoint,
+				supportedProtocolVersions: mcpSupportedProtocolVersions,
+			},
+		],
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- serve an MCP Server Card at `/.well-known/mcp/server-card.json`
- derive the discovery payload from the live `/mcp` transport metadata so name/version stay in sync
- add a focused regression test for the card generator and keep the well-known route headers explicit

## Testing
- `npx oxlint services/site/app/routes/mcp/server-card.ts services/site/app/routes/mcp/mcp.server.ts "services/site/app/routes/[.]well-known/mcp/server-card[.]json.ts" services/site/app/routes/mcp/__tests__/server-card.test.ts`
- `npm run test:backend --workspace kentcdodds.com -- __tests__/server-card.test.ts`
- `npm run typecheck --workspace kentcdodds.com`
- `curl -i --silent http://localhost:3100/.well-known/mcp/server-card.json` after booting `PORT=3100 npm run dev` with mock search-worker env values
- repo pre-push verification passed after installing Playwright browsers: `npm run test:e2e:install --workspace kentcdodds.com` followed by `git push -u origin cursor/mcp-server-card-406f`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3b281f9-8742-40e5-88b6-9e496cfc406f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3b281f9-8742-40e5-88b6-9e496cfc406f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new /.well-known/mcp/server-card.json endpoint exposing server identity, capabilities, transport endpoint, and remotes.
  * Server card is generated dynamically with configurable name, version, transport endpoint, and supported protocol versions.
  * Responses include permissive CORS and 1-hour public caching headers for cross-origin access.

* **Tests**
  * Added tests validating server-card content, transport/remotes URLs, capability flags, and advertised protocol versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->