### PR TITLE
Add browser WebMCP site tools

### DIFF
--- a/services/site/app/entry.client.tsx
+++ b/services/site/app/entry.client.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { hydrateRoot } from 'react-dom/client'
 import { HydratedRouter } from 'react-router/dom'
+import { installSiteWebMcpTools } from './web-mcp.client.ts'
 
 if (ENV.MODE === 'production' && ENV.SENTRY_DSN) {
 	void import('./utils/feature-gate.ts').then(({ hasModernFeatureSet }) => {
@@ -9,6 +10,8 @@ if (ENV.MODE === 'production' && ENV.SENTRY_DSN) {
 		}
 	})
 }
+
+installSiteWebMcpTools()
 
 function hydrate() {
 	React.startTransition(() => {

--- a/services/site/app/web-mcp.client.ts
+++ b/services/site/app/web-mcp.client.ts
@@ -75,7 +75,7 @@ export function installSiteWebMcpTools() {
 	window.__kcdWebMcpCleanup = registerSiteWebMcpTools()
 }
 
-export function registerSiteWebMcpTools() {
+function registerSiteWebMcpTools() {
 	const modelContext = navigator.modelContext
 	if (!modelContext) return () => {}
 
@@ -161,7 +161,7 @@ function tryRegisterTools(
 	} catch (error) {
 		console.warn('WebMCP registerTool registration failed', error)
 		abortController.abort()
-		for (const cleanup of cleanupCallbacks) cleanup()
+		runCleanupCallbacks(cleanupCallbacks)
 		return null
 	}
 }

--- a/services/site/app/web-mcp.client.ts
+++ b/services/site/app/web-mcp.client.ts
@@ -71,7 +71,11 @@ declare global {
 }
 
 export function installSiteWebMcpTools() {
-	window.__kcdWebMcpCleanup?.()
+	try {
+		window.__kcdWebMcpCleanup?.()
+	} catch (error) {
+		console.warn('WebMCP previous cleanup failed', error)
+	}
 	window.__kcdWebMcpCleanup = registerSiteWebMcpTools()
 }
 
@@ -117,7 +121,9 @@ function createCleanup(
 }
 
 function runCleanupCallbacks(cleanupCallbacks: Array<() => void>) {
-	for (const cleanup of cleanupCallbacks) {
+	for (let index = cleanupCallbacks.length - 1; index >= 0; index--) {
+		const cleanup = cleanupCallbacks[index]
+		if (!cleanup) continue
 		try {
 			cleanup()
 		} catch (error) {
@@ -364,7 +370,10 @@ function truncateText(value: string, maxLength: number) {
 	return `${normalized.slice(0, maxLength - 3)}...`
 }
 
-async function navigateSite(input: ToolInput, client: ModelContextClientLike) {
+async function navigateSite(
+	input: ToolInput,
+	client: ModelContextClientLike | undefined,
+) {
 	const destinationKey = getTrimmedString(input, 'destination')
 	if (!destinationKey) {
 		throw new Error('destination is required')
@@ -384,16 +393,18 @@ async function navigateSite(input: ToolInput, client: ModelContextClientLike) {
 		if (query) url.searchParams.set('q', query)
 	}
 
-	if (client.requestUserInteraction) {
-		const shouldNavigate = await client.requestUserInteraction(async () =>
-			Promise.resolve(window.confirm(`Allow navigation to ${url.toString()}?`)),
-		)
-		if (!shouldNavigate) {
-			return {
-				cancelled: true,
-				destination: destinationKey,
-				url: url.toString(),
-			}
+	const shouldNavigate = client?.requestUserInteraction
+		? await client.requestUserInteraction(async () =>
+				Promise.resolve(
+					window.confirm(`Allow navigation to ${url.toString()}?`),
+				),
+			)
+		: window.confirm(`Allow navigation to ${url.toString()}?`)
+	if (!shouldNavigate) {
+		return {
+			cancelled: true,
+			destination: destinationKey,
+			url: url.toString(),
 		}
 	}
 

--- a/services/site/app/web-mcp.client.ts
+++ b/services/site/app/web-mcp.client.ts
@@ -112,7 +112,17 @@ function createCleanup(
 		if (cleanedUp) return
 		cleanedUp = true
 		abortController.abort()
-		for (const cleanup of cleanupCallbacks) cleanup()
+		runCleanupCallbacks(cleanupCallbacks)
+	}
+}
+
+function runCleanupCallbacks(cleanupCallbacks: Array<() => void>) {
+	for (const cleanup of cleanupCallbacks) {
+		try {
+			cleanup()
+		} catch (error) {
+			console.warn('WebMCP cleanup callback failed', error)
+		}
 	}
 }
 
@@ -221,8 +231,8 @@ function createSiteTools(): Array<ModelContextToolLike> {
 				required: ['destination'],
 				additionalProperties: false,
 			},
-			async execute(input) {
-				return navigateSite(asToolInput(input))
+			async execute(input, client) {
+				return navigateSite(asToolInput(input), client)
 			},
 		},
 	]
@@ -312,6 +322,7 @@ function getCurrentPageContext() {
 	const main = document.querySelector('main')
 	const mainText =
 		main instanceof HTMLElement ? main.innerText : document.body.innerText
+	const canonicalLink = document.querySelector('link[rel="canonical"]')
 	const headingElements = document.querySelectorAll('main h1, main h2, main h3')
 	const headings = Array.from(headingElements)
 		.map((heading) => heading.textContent?.trim())
@@ -320,7 +331,10 @@ function getCurrentPageContext() {
 
 	return {
 		title: document.title,
-		url: window.location.href,
+		url:
+			canonicalLink instanceof HTMLLinkElement && canonicalLink.href
+				? canonicalLink.href
+				: window.location.href,
 		path: window.location.pathname,
 		description: getPageDescription(),
 		headings,
@@ -350,7 +364,7 @@ function truncateText(value: string, maxLength: number) {
 	return `${normalized.slice(0, maxLength - 3)}...`
 }
 
-async function navigateSite(input: ToolInput) {
+async function navigateSite(input: ToolInput, client: ModelContextClientLike) {
 	const destinationKey = getTrimmedString(input, 'destination')
 	if (!destinationKey) {
 		throw new Error('destination is required')
@@ -368,6 +382,19 @@ async function navigateSite(input: ToolInput) {
 	if (destinationKey === 'search') {
 		const query = getTrimmedString(input, 'query')
 		if (query) url.searchParams.set('q', query)
+	}
+
+	if (client.requestUserInteraction) {
+		const shouldNavigate = await client.requestUserInteraction(async () =>
+			Promise.resolve(window.confirm(`Allow navigation to ${url.toString()}?`)),
+		)
+		if (!shouldNavigate) {
+			return {
+				cancelled: true,
+				destination: destinationKey,
+				url: url.toString(),
+			}
+		}
 	}
 
 	window.location.assign(url.toString())

--- a/services/site/app/web-mcp.client.ts
+++ b/services/site/app/web-mcp.client.ts
@@ -92,7 +92,7 @@ export function registerSiteWebMcpTools() {
 	const registerToolCleanup = tryRegisterTools(
 		modelContext,
 		tools,
-		abortController.signal,
+		abortController,
 	)
 	if (registerToolCleanup) {
 		cleanupCallbacks.push(...registerToolCleanup)
@@ -134,18 +134,24 @@ function tryProvideContext(
 function tryRegisterTools(
 	modelContext: ModelContextLike,
 	tools: Array<ModelContextToolLike>,
-	signal: AbortSignal,
+	abortController: AbortController,
 ) {
 	if (typeof modelContext.registerTool !== 'function') return null
 
+	const cleanupCallbacks: Array<() => void> = []
+
 	try {
-		const cleanupCallbacks = tools.flatMap((tool) => {
-			const cleanup = modelContext.registerTool?.(tool, { signal })
-			return typeof cleanup === 'function' ? [cleanup] : []
-		})
+		for (const tool of tools) {
+			const cleanup = modelContext.registerTool?.(tool, {
+				signal: abortController.signal,
+			})
+			if (typeof cleanup === 'function') cleanupCallbacks.push(cleanup)
+		}
 		return cleanupCallbacks
 	} catch (error) {
 		console.warn('WebMCP registerTool registration failed', error)
+		abortController.abort()
+		for (const cleanup of cleanupCallbacks) cleanup()
 		return null
 	}
 }

--- a/services/site/app/web-mcp.client.ts
+++ b/services/site/app/web-mcp.client.ts
@@ -1,0 +1,363 @@
+type JsonSchema = {
+	type: 'object'
+	properties: Record<string, unknown>
+	required?: Array<string>
+	additionalProperties?: boolean
+}
+
+type ToolAnnotations = {
+	readOnlyHint?: boolean
+}
+
+type ToolResult = Record<string, unknown>
+
+type ToolInput = Record<string, unknown>
+
+type ModelContextClientLike = {
+	requestUserInteraction?: <T>(callback: () => Promise<T>) => Promise<T>
+}
+
+type ModelContextToolLike = {
+	name: string
+	title?: string
+	description: string
+	inputSchema?: JsonSchema
+	annotations?: ToolAnnotations
+	execute: (
+		input: ToolInput,
+		client: ModelContextClientLike,
+	) => Promise<ToolResult> | ToolResult
+}
+
+type ModelContextLike = {
+	provideContext?: (context: {
+		tools: Array<ModelContextToolLike>
+	}) => void | (() => void)
+	registerTool?: (
+		tool: ModelContextToolLike,
+		options?: { signal?: AbortSignal },
+	) => void | (() => void)
+}
+
+const DEFAULT_SEARCH_RESULT_LIMIT = 5
+const SEARCH_RESULT_LIMIT = 8
+const PAGE_TEXT_PREVIEW_LENGTH = 1200
+
+const NAVIGATION_DESTINATIONS = {
+	about: '/about',
+	blog: '/blog',
+	calls: '/calls',
+	chats: '/chats',
+	contact: '/contact',
+	courses: '/courses',
+	credits: '/credits',
+	discord: '/discord',
+	home: '/',
+	resume: '/resume',
+	search: '/search',
+	subscribe: '/subscribe',
+	talks: '/talks',
+	testimonials: '/testimonials',
+} as const satisfies Record<string, string>
+
+const WEB_MCP_TOOL_NAMES = [
+	'search_site_content',
+	'get_current_page_context',
+	'navigate_site',
+] as const
+
+declare global {
+	interface Navigator {
+		modelContext?: ModelContextLike
+	}
+
+	interface Window {
+		__kcdWebMcpCleanup?: (() => void) | undefined
+	}
+}
+
+export function installSiteWebMcpTools() {
+	window.__kcdWebMcpCleanup?.()
+	window.__kcdWebMcpCleanup = registerSiteWebMcpTools()
+}
+
+export function registerSiteWebMcpTools() {
+	const modelContext = navigator.modelContext
+	if (!modelContext) return () => {}
+
+	const tools = createSiteTools()
+	const abortController = new AbortController()
+	const cleanupCallbacks: Array<() => void> = []
+
+	const provideContextCleanup = tryProvideContext(modelContext, tools)
+	if (provideContextCleanup) {
+		cleanupCallbacks.push(provideContextCleanup)
+		return createCleanup(abortController, cleanupCallbacks)
+	}
+
+	const registerToolCleanup = tryRegisterTools(
+		modelContext,
+		tools,
+		abortController.signal,
+	)
+	if (registerToolCleanup) {
+		cleanupCallbacks.push(...registerToolCleanup)
+		return createCleanup(abortController, cleanupCallbacks)
+	}
+
+	return () => {}
+}
+
+export function getSiteWebMcpToolNames() {
+	return [...WEB_MCP_TOOL_NAMES]
+}
+
+function createCleanup(
+	abortController: AbortController,
+	cleanupCallbacks: Array<() => void>,
+) {
+	let cleanedUp = false
+
+	return () => {
+		if (cleanedUp) return
+		cleanedUp = true
+		abortController.abort()
+		for (const cleanup of cleanupCallbacks) cleanup()
+	}
+}
+
+function tryProvideContext(
+	modelContext: ModelContextLike,
+	tools: Array<ModelContextToolLike>,
+) {
+	if (typeof modelContext.provideContext !== 'function') return null
+
+	try {
+		const cleanup = modelContext.provideContext({ tools })
+		return typeof cleanup === 'function' ? cleanup : () => {}
+	} catch (error) {
+		console.warn('WebMCP provideContext registration failed', error)
+		return null
+	}
+}
+
+function tryRegisterTools(
+	modelContext: ModelContextLike,
+	tools: Array<ModelContextToolLike>,
+	signal: AbortSignal,
+) {
+	if (typeof modelContext.registerTool !== 'function') return null
+
+	try {
+		const cleanupCallbacks = tools.flatMap((tool) => {
+			const cleanup = modelContext.registerTool?.(tool, { signal })
+			return typeof cleanup === 'function' ? [cleanup] : []
+		})
+		return cleanupCallbacks
+	} catch (error) {
+		console.warn('WebMCP registerTool registration failed', error)
+		return null
+	}
+}
+
+function createSiteTools(): Array<ModelContextToolLike> {
+	return [
+		{
+			name: 'search_site_content',
+			title: 'Search site content',
+			description:
+				'Search Kent C. Dodds site content and return structured results from the site search index.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					query: {
+						type: 'string',
+						description:
+							'Search query. Short natural-language phrases work best.',
+					},
+					maxResults: {
+						type: 'number',
+						description: `Maximum number of results to return (1-${SEARCH_RESULT_LIMIT}).`,
+					},
+				},
+				required: ['query'],
+				additionalProperties: false,
+			},
+			annotations: { readOnlyHint: true },
+			async execute(input) {
+				return executeSearchSiteContent(asToolInput(input))
+			},
+		},
+		{
+			name: 'get_current_page_context',
+			title: 'Get current page context',
+			description:
+				'Return structured context about the current page, including title, canonical URL, headings, and a text preview.',
+			inputSchema: {
+				type: 'object',
+				properties: {},
+				additionalProperties: false,
+			},
+			annotations: { readOnlyHint: true },
+			async execute() {
+				return getCurrentPageContext()
+			},
+		},
+		{
+			name: 'navigate_site',
+			title: 'Navigate site',
+			description:
+				'Navigate to a key section of kentcdodds.com or open the site search page for a query.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					destination: {
+						type: 'string',
+						enum: Object.keys(NAVIGATION_DESTINATIONS),
+						description: 'Named destination on the site.',
+					},
+					query: {
+						type: 'string',
+						description:
+							'Optional search query used when destination is "search".',
+					},
+				},
+				required: ['destination'],
+				additionalProperties: false,
+			},
+			async execute(input) {
+				return navigateSite(asToolInput(input))
+			},
+		},
+	]
+}
+
+function asToolInput(input: unknown): ToolInput {
+	if (!input || typeof input !== 'object' || Array.isArray(input)) return {}
+	return input as ToolInput
+}
+
+function clampResultLimit(value: unknown) {
+	if (typeof value !== 'number' || Number.isNaN(value)) {
+		return DEFAULT_SEARCH_RESULT_LIMIT
+	}
+
+	return Math.max(1, Math.min(SEARCH_RESULT_LIMIT, Math.floor(value)))
+}
+
+function getTrimmedString(input: ToolInput, key: string): string | undefined {
+	const value = Reflect.get(input, key)
+	if (typeof value !== 'string') return undefined
+	const trimmed = value.trim()
+	return trimmed ? trimmed : undefined
+}
+
+async function executeSearchSiteContent(input: ToolInput) {
+	const query = getTrimmedString(input, 'query')
+	if (!query) {
+		throw new Error('query is required')
+	}
+
+	const maxResults = clampResultLimit(Reflect.get(input, 'maxResults'))
+	const response = await fetch(
+		`/resources/search?query=${encodeURIComponent(query)}`,
+		{
+			credentials: 'same-origin',
+			headers: { accept: 'application/json' },
+		},
+	)
+	const payload = (await response.json()) as
+		| {
+				error?: string
+				noCloseMatches?: boolean
+				results?: Array<Record<string, unknown>>
+		  }
+		| undefined
+
+	if (!response.ok) {
+		throw new Error(
+			payload?.error ?? `Search request failed (${response.status})`,
+		)
+	}
+
+	const results = Array.isArray(payload?.results)
+		? payload.results.slice(0, maxResults)
+		: []
+
+	return {
+		query,
+		noCloseMatches: Boolean(payload?.noCloseMatches),
+		resultCount: results.length,
+		results,
+	}
+}
+
+function getCurrentPageContext() {
+	const main = document.querySelector('main')
+	const mainText =
+		main instanceof HTMLElement ? main.innerText : document.body.innerText
+	const headingElements = document.querySelectorAll('main h1, main h2, main h3')
+	const headings = Array.from(headingElements)
+		.map((heading) => heading.textContent?.trim())
+		.filter((value): value is string => Boolean(value))
+		.slice(0, 12)
+
+	return {
+		title: document.title,
+		url: window.location.href,
+		path: window.location.pathname,
+		description: getPageDescription(),
+		headings,
+		textPreview: truncateText(mainText, PAGE_TEXT_PREVIEW_LENGTH),
+	}
+}
+
+function getPageDescription() {
+	const metaDescription = document.querySelector('meta[name="description"]')
+	if (metaDescription instanceof HTMLMetaElement && metaDescription.content) {
+		return metaDescription.content
+	}
+
+	const ogDescription = document.querySelector(
+		'meta[property="og:description"]',
+	)
+	if (ogDescription instanceof HTMLMetaElement && ogDescription.content) {
+		return ogDescription.content
+	}
+
+	return null
+}
+
+function truncateText(value: string, maxLength: number) {
+	const normalized = value.replace(/\s+/g, ' ').trim()
+	if (normalized.length <= maxLength) return normalized
+	return `${normalized.slice(0, maxLength - 3)}...`
+}
+
+async function navigateSite(input: ToolInput) {
+	const destinationKey = getTrimmedString(input, 'destination')
+	if (!destinationKey) {
+		throw new Error('destination is required')
+	}
+
+	if (!(destinationKey in NAVIGATION_DESTINATIONS)) {
+		throw new Error(`Unknown destination: ${destinationKey}`)
+	}
+
+	const destination =
+		NAVIGATION_DESTINATIONS[
+			destinationKey as keyof typeof NAVIGATION_DESTINATIONS
+		]
+	const url = new URL(destination, window.location.origin)
+	if (destinationKey === 'search') {
+		const query = getTrimmedString(input, 'query')
+		if (query) url.searchParams.set('q', query)
+	}
+
+	window.location.assign(url.toString())
+
+	return {
+		destination: destinationKey,
+		url: url.toString(),
+	}
+}

--- a/services/site/app/web-mcp.client.ts
+++ b/services/site/app/web-mcp.client.ts
@@ -60,12 +60,6 @@ const NAVIGATION_DESTINATIONS = {
 	testimonials: '/testimonials',
 } as const satisfies Record<string, string>
 
-const WEB_MCP_TOOL_NAMES = [
-	'search_site_content',
-	'get_current_page_context',
-	'navigate_site',
-] as const
-
 declare global {
 	interface Navigator {
 		modelContext?: ModelContextLike
@@ -106,10 +100,6 @@ export function registerSiteWebMcpTools() {
 	}
 
 	return () => {}
-}
-
-export function getSiteWebMcpToolNames() {
-	return [...WEB_MCP_TOOL_NAMES]
 }
 
 function createCleanup(
@@ -266,6 +256,32 @@ async function executeSearchSiteContent(input: ToolInput) {
 			headers: { accept: 'application/json' },
 		},
 	)
+	if (!response.ok) {
+		let payload:
+			| {
+					error?: string
+					noCloseMatches?: boolean
+					results?: Array<Record<string, unknown>>
+			  }
+			| undefined
+
+		try {
+			payload = (await response.json()) as
+				| {
+						error?: string
+						noCloseMatches?: boolean
+						results?: Array<Record<string, unknown>>
+				  }
+				| undefined
+		} catch (error) {
+			console.warn('Search response was not JSON', error)
+		}
+
+		throw new Error(
+			payload?.error ?? `Search request failed (${response.status})`,
+		)
+	}
+
 	const payload = (await response.json()) as
 		| {
 				error?: string
@@ -273,12 +289,6 @@ async function executeSearchSiteContent(input: ToolInput) {
 				results?: Array<Record<string, unknown>>
 		  }
 		| undefined
-
-	if (!response.ok) {
-		throw new Error(
-			payload?.error ?? `Search request failed (${response.status})`,
-		)
-	}
 
 	const results = Array.isArray(payload?.results)
 		? payload.results.slice(0, maxResults)
@@ -340,7 +350,7 @@ async function navigateSite(input: ToolInput) {
 		throw new Error('destination is required')
 	}
 
-	if (!(destinationKey in NAVIGATION_DESTINATIONS)) {
+	if (!Object.hasOwn(NAVIGATION_DESTINATIONS, destinationKey)) {
 		throw new Error(`Unknown destination: ${destinationKey}`)
 	}
 

--- a/services/site/e2e/web-mcp.spec.ts
+++ b/services/site/e2e/web-mcp.spec.ts
@@ -155,6 +155,17 @@ async function readRegisterToolState(page: Page) {
 	})
 }
 
+async function installThrowingCleanupState(page: Page) {
+	await page.addInitScript(() => {
+		Object.defineProperty(window, '__kcdWebMcpCleanup', {
+			configurable: true,
+			value: () => {
+				throw new Error('previous cleanup failed')
+			},
+		})
+	})
+}
+
 test('registers WebMCP tools on page load with provideContext', async ({
 	page,
 }) => {
@@ -220,4 +231,92 @@ test('falls back to registerTool and executes WebMCP tools', async ({
 	expect(toolSummary.pageResult?.title).toContain('Kent C. Dodds')
 	expect(toolSummary.pageResult?.headings.length).toBeGreaterThan(0)
 	expect(toolSummary.pageResult?.textPreview.length).toBeGreaterThan(0)
+})
+
+test('reinstalls WebMCP tools even if the previous cleanup throws', async ({
+	page,
+}) => {
+	await installProvideContextShim(page)
+	await installThrowingCleanupState(page)
+	await page.goto('/')
+	await expect(page.getByRole('navigation')).toBeVisible()
+
+	await expect
+		.poll(() => readProvideContextState(page))
+		.toMatchObject({
+			provideContextCalls: 1,
+			names: [
+				'search_site_content',
+				'get_current_page_context',
+				'navigate_site',
+			],
+		})
+})
+
+test('navigate_site asks for confirmation without requestUserInteraction', async ({
+	page,
+}) => {
+	await installRegisterToolShim(page)
+	await page.goto('/')
+	await expect(page.getByRole('navigation')).toBeVisible()
+
+	await expect
+		.poll(() => readRegisterToolState(page))
+		.toMatchObject({
+			registerToolCalls: 3,
+			toolNames: [
+				'search_site_content',
+				'get_current_page_context',
+				'navigate_site',
+			],
+		})
+
+	const outcome = await page.evaluate(async () => {
+		const state = (
+			window as unknown as {
+				__webMcpTestState: {
+					tools: Array<RegisteredTool>
+				}
+			}
+		).__webMcpTestState
+		const navigateTool = state.tools.find(
+			(tool) => tool.name === 'navigate_site',
+		)
+		if (!navigateTool) throw new Error('Expected navigate_site tool')
+
+		const confirmCalls: Array<string> = []
+		const originalConfirm = window.confirm
+		window.confirm = (message?: string) => {
+			confirmCalls.push(message ?? '')
+			return false
+		}
+
+		try {
+			const result = (await navigateTool.execute({
+				destination: 'blog',
+			})) as {
+				cancelled?: boolean
+				destination?: string
+				url?: string
+			}
+
+			return {
+				result,
+				confirmCalls,
+				locationHref: window.location.href,
+			}
+		} finally {
+			window.confirm = originalConfirm
+		}
+	})
+
+	expect(outcome.confirmCalls).toEqual([
+		'Allow navigation to http://localhost:3000/blog?',
+	])
+	expect(outcome.result).toMatchObject({
+		cancelled: true,
+		destination: 'blog',
+		url: 'http://localhost:3000/blog',
+	})
+	expect(outcome.locationHref).toBe('http://localhost:3000/')
 })

--- a/services/site/e2e/web-mcp.spec.ts
+++ b/services/site/e2e/web-mcp.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { type Page, expect, test } from '@playwright/test'
 
 type RegisteredTool = {
 	name: string
@@ -8,9 +8,7 @@ type RegisteredTool = {
 	execute: (input?: Record<string, unknown>) => Promise<unknown> | unknown
 }
 
-async function installProvideContextShim(
-	page: Parameters<typeof test>[0]['page'],
-) {
+async function installProvideContextShim(page: Page) {
 	await page.addInitScript(() => {
 		type RegisteredTool = {
 			name: string
@@ -45,9 +43,7 @@ async function installProvideContextShim(
 	})
 }
 
-async function installRegisterToolShim(
-	page: Parameters<typeof test>[0]['page'],
-) {
+async function installRegisterToolShim(page: Page) {
 	await page.addInitScript(() => {
 		type RegisteredTool = {
 			name: string
@@ -89,16 +85,10 @@ async function installRegisterToolShim(
 	})
 }
 
-test('registers WebMCP tools on page load with provideContext', async ({
-	page,
-}) => {
-	await installProvideContextShim(page)
-	await page.goto('/')
-	await expect(page.getByRole('navigation')).toBeVisible()
-
-	const toolSummary = await page.evaluate(() => {
+async function readProvideContextState(page: Page) {
+	return page.evaluate(() => {
 		const state = (
-			window as Window & {
+			window as unknown as {
 				__webMcpTestState: {
 					provideContextCalls: number
 					tools: Array<RegisteredTool>
@@ -114,30 +104,12 @@ test('registers WebMCP tools on page load with provideContext', async ({
 			)?.inputSchema,
 		}
 	})
+}
 
-	expect(toolSummary.provideContextCalls).toBe(1)
-	expect(toolSummary.names).toEqual([
-		'search_site_content',
-		'get_current_page_context',
-		'navigate_site',
-	])
-	expect(toolSummary.searchToolSchema).toMatchObject({
-		type: 'object',
-		required: ['query'],
-		additionalProperties: false,
-	})
-})
-
-test('falls back to registerTool and executes WebMCP tools', async ({
-	page,
-}) => {
-	await installRegisterToolShim(page)
-	await page.goto('/')
-	await expect(page.getByRole('navigation')).toBeVisible()
-
-	const toolSummary = await page.evaluate(async () => {
+async function readRegisterToolState(page: Page) {
+	return page.evaluate(async () => {
 		const state = (
-			window as Window & {
+			window as unknown as {
 				__webMcpTestState: {
 					registerToolCalls: number
 					tools: Array<RegisteredTool>
@@ -152,7 +124,12 @@ test('falls back to registerTool and executes WebMCP tools', async ({
 			(tool) => tool.name === 'get_current_page_context',
 		)
 		if (!searchTool || !pageTool) {
-			throw new Error('Expected WebMCP tools to be registered')
+			return {
+				registerToolCalls: state.registerToolCalls,
+				toolNames: state.tools.map((tool) => tool.name),
+				searchResult: null,
+				pageResult: null,
+			}
 		}
 
 		const searchResult = (await searchTool.execute({
@@ -176,6 +153,60 @@ test('falls back to registerTool and executes WebMCP tools', async ({
 			pageResult,
 		}
 	})
+}
+
+test('registers WebMCP tools on page load with provideContext', async ({
+	page,
+}) => {
+	await installProvideContextShim(page)
+	await page.goto('/')
+	await expect(page.getByRole('navigation')).toBeVisible()
+
+	await expect
+		.poll(() => readProvideContextState(page))
+		.toMatchObject({
+			provideContextCalls: 1,
+			names: [
+				'search_site_content',
+				'get_current_page_context',
+				'navigate_site',
+			],
+		})
+
+	const toolSummary = await readProvideContextState(page)
+
+	expect(toolSummary.provideContextCalls).toBe(1)
+	expect(toolSummary.names).toEqual([
+		'search_site_content',
+		'get_current_page_context',
+		'navigate_site',
+	])
+	expect(toolSummary.searchToolSchema).toMatchObject({
+		type: 'object',
+		required: ['query'],
+		additionalProperties: false,
+	})
+})
+
+test('falls back to registerTool and executes WebMCP tools', async ({
+	page,
+}) => {
+	await installRegisterToolShim(page)
+	await page.goto('/')
+	await expect(page.getByRole('navigation')).toBeVisible()
+
+	await expect
+		.poll(() => readRegisterToolState(page))
+		.toMatchObject({
+			registerToolCalls: 3,
+			toolNames: [
+				'search_site_content',
+				'get_current_page_context',
+				'navigate_site',
+			],
+		})
+
+	const toolSummary = await readRegisterToolState(page)
 
 	expect(toolSummary.registerToolCalls).toBe(3)
 	expect(toolSummary.toolNames).toEqual([
@@ -183,10 +214,10 @@ test('falls back to registerTool and executes WebMCP tools', async ({
 		'get_current_page_context',
 		'navigate_site',
 	])
-	expect(toolSummary.searchResult.resultCount).toBeGreaterThan(0)
-	expect(toolSummary.searchResult.results[0]?.url).toContain('/calls/1/1')
-	expect(toolSummary.pageResult.path).toBe('/')
-	expect(toolSummary.pageResult.title).toContain('Kent C. Dodds')
-	expect(toolSummary.pageResult.headings.length).toBeGreaterThan(0)
-	expect(toolSummary.pageResult.textPreview.length).toBeGreaterThan(0)
+	expect(toolSummary.searchResult?.resultCount).toBeGreaterThan(0)
+	expect(toolSummary.searchResult?.results[0]?.url).toContain('/calls/1/1')
+	expect(toolSummary.pageResult?.path).toBe('/')
+	expect(toolSummary.pageResult?.title).toContain('Kent C. Dodds')
+	expect(toolSummary.pageResult?.headings.length).toBeGreaterThan(0)
+	expect(toolSummary.pageResult?.textPreview.length).toBeGreaterThan(0)
 })

--- a/services/site/e2e/web-mcp.spec.ts
+++ b/services/site/e2e/web-mcp.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from '@playwright/test'
+
+type RegisteredTool = {
+	name: string
+	description: string
+	inputSchema?: Record<string, unknown>
+	annotations?: { readOnlyHint?: boolean }
+	execute: (input?: Record<string, unknown>) => Promise<unknown> | unknown
+}
+
+async function installProvideContextShim(
+	page: Parameters<typeof test>[0]['page'],
+) {
+	await page.addInitScript(() => {
+		type RegisteredTool = {
+			name: string
+			description: string
+			inputSchema?: Record<string, unknown>
+			annotations?: { readOnlyHint?: boolean }
+			execute: (input?: Record<string, unknown>) => Promise<unknown> | unknown
+		}
+
+		const state = {
+			provideContextCalls: 0,
+			tools: [] as Array<RegisteredTool>,
+		}
+
+		Object.defineProperty(navigator, 'modelContext', {
+			configurable: true,
+			value: {
+				provideContext(context: { tools?: Array<RegisteredTool> }) {
+					state.provideContextCalls += 1
+					state.tools = [...(context.tools ?? [])]
+					return () => {
+						state.tools = []
+					}
+				},
+			},
+		})
+
+		Object.defineProperty(window, '__webMcpTestState', {
+			configurable: true,
+			value: state,
+		})
+	})
+}
+
+async function installRegisterToolShim(
+	page: Parameters<typeof test>[0]['page'],
+) {
+	await page.addInitScript(() => {
+		type RegisteredTool = {
+			name: string
+			description: string
+			inputSchema?: Record<string, unknown>
+			annotations?: { readOnlyHint?: boolean }
+			execute: (input?: Record<string, unknown>) => Promise<unknown> | unknown
+		}
+
+		const state = {
+			registerToolCalls: 0,
+			tools: [] as Array<RegisteredTool>,
+		}
+
+		Object.defineProperty(navigator, 'modelContext', {
+			configurable: true,
+			value: {
+				registerTool(tool: RegisteredTool, options?: { signal?: AbortSignal }) {
+					state.registerToolCalls += 1
+					state.tools.push(tool)
+					options?.signal?.addEventListener('abort', () => {
+						state.tools = state.tools.filter(
+							(entry) => entry.name !== tool.name,
+						)
+					})
+					return () => {
+						state.tools = state.tools.filter(
+							(entry) => entry.name !== tool.name,
+						)
+					}
+				},
+			},
+		})
+
+		Object.defineProperty(window, '__webMcpTestState', {
+			configurable: true,
+			value: state,
+		})
+	})
+}
+
+test('registers WebMCP tools on page load with provideContext', async ({
+	page,
+}) => {
+	await installProvideContextShim(page)
+	await page.goto('/')
+	await expect(page.getByRole('navigation')).toBeVisible()
+
+	const toolSummary = await page.evaluate(() => {
+		const state = (
+			window as Window & {
+				__webMcpTestState: {
+					provideContextCalls: number
+					tools: Array<RegisteredTool>
+				}
+			}
+		).__webMcpTestState
+
+		return {
+			provideContextCalls: state.provideContextCalls,
+			names: state.tools.map((tool) => tool.name),
+			searchToolSchema: state.tools.find(
+				(tool) => tool.name === 'search_site_content',
+			)?.inputSchema,
+		}
+	})
+
+	expect(toolSummary.provideContextCalls).toBe(1)
+	expect(toolSummary.names).toEqual([
+		'search_site_content',
+		'get_current_page_context',
+		'navigate_site',
+	])
+	expect(toolSummary.searchToolSchema).toMatchObject({
+		type: 'object',
+		required: ['query'],
+		additionalProperties: false,
+	})
+})
+
+test('falls back to registerTool and executes WebMCP tools', async ({
+	page,
+}) => {
+	await installRegisterToolShim(page)
+	await page.goto('/')
+	await expect(page.getByRole('navigation')).toBeVisible()
+
+	const toolSummary = await page.evaluate(async () => {
+		const state = (
+			window as Window & {
+				__webMcpTestState: {
+					registerToolCalls: number
+					tools: Array<RegisteredTool>
+				}
+			}
+		).__webMcpTestState
+
+		const searchTool = state.tools.find(
+			(tool) => tool.name === 'search_site_content',
+		)
+		const pageTool = state.tools.find(
+			(tool) => tool.name === 'get_current_page_context',
+		)
+		if (!searchTool || !pageTool) {
+			throw new Error('Expected WebMCP tools to be registered')
+		}
+
+		const searchResult = (await searchTool.execute({
+			query: 'authentication',
+			maxResults: 2,
+		})) as {
+			resultCount: number
+			results: Array<{ title?: string; url?: string }>
+		}
+		const pageResult = (await pageTool.execute({})) as {
+			title: string
+			path: string
+			headings: Array<string>
+			textPreview: string
+		}
+
+		return {
+			registerToolCalls: state.registerToolCalls,
+			toolNames: state.tools.map((tool) => tool.name),
+			searchResult,
+			pageResult,
+		}
+	})
+
+	expect(toolSummary.registerToolCalls).toBe(3)
+	expect(toolSummary.toolNames).toEqual([
+		'search_site_content',
+		'get_current_page_context',
+		'navigate_site',
+	])
+	expect(toolSummary.searchResult.resultCount).toBeGreaterThan(0)
+	expect(toolSummary.searchResult.results[0]?.url).toContain('/calls/1/1')
+	expect(toolSummary.pageResult.path).toBe('/')
+	expect(toolSummary.pageResult.title).toContain('Kent C. Dodds')
+	expect(toolSummary.pageResult.headings.length).toBeGreaterThan(0)
+	expect(toolSummary.pageResult.textPreview.length).toBeGreaterThan(0)
+})

--- a/services/site/e2e/web-mcp.spec.ts
+++ b/services/site/e2e/web-mcp.spec.ts
@@ -159,6 +159,7 @@ async function installThrowingCleanupState(page: Page) {
 	await page.addInitScript(() => {
 		Object.defineProperty(window, '__kcdWebMcpCleanup', {
 			configurable: true,
+			writable: true,
 			value: () => {
 				throw new Error('previous cleanup failed')
 			},
@@ -251,6 +252,15 @@ test('reinstalls WebMCP tools even if the previous cleanup throws', async ({
 				'navigate_site',
 			],
 		})
+
+	const cleanupReplaced = await page.evaluate(
+		() =>
+			typeof (window as Window).__kcdWebMcpCleanup === 'function' &&
+			(window as Window).__kcdWebMcpCleanup
+				?.toString()
+				.includes('cleanedUp') === true,
+	)
+	expect(cleanupReplaced).toBe(true)
 })
 
 test('navigate_site asks for confirmation without requestUserInteraction', async ({

--- a/services/site/e2e/web-mcp.spec.ts
+++ b/services/site/e2e/web-mcp.spec.ts
@@ -157,12 +157,20 @@ async function readRegisterToolState(page: Page) {
 
 async function installThrowingCleanupState(page: Page) {
 	await page.addInitScript(() => {
+		const throwingCleanup = () => {
+			throw new Error('previous cleanup failed')
+		}
+
+		Object.defineProperty(window, '__previousKcdWebMcpCleanup', {
+			configurable: true,
+			writable: true,
+			value: throwingCleanup,
+		})
+
 		Object.defineProperty(window, '__kcdWebMcpCleanup', {
 			configurable: true,
 			writable: true,
-			value: () => {
-				throw new Error('previous cleanup failed')
-			},
+			value: throwingCleanup,
 		})
 	})
 }
@@ -253,13 +261,17 @@ test('reinstalls WebMCP tools even if the previous cleanup throws', async ({
 			],
 		})
 
-	const cleanupReplaced = await page.evaluate(
-		() =>
-			typeof (window as Window).__kcdWebMcpCleanup === 'function' &&
-			(window as Window).__kcdWebMcpCleanup
-				?.toString()
-				.includes('cleanedUp') === true,
-	)
+	const cleanupReplaced = await page.evaluate(() => {
+		const testWindow = window as Window & {
+			__previousKcdWebMcpCleanup?: (() => void) | undefined
+		}
+
+		return (
+			typeof testWindow.__kcdWebMcpCleanup === 'function' &&
+			typeof testWindow.__previousKcdWebMcpCleanup === 'function' &&
+			testWindow.__kcdWebMcpCleanup !== testWindow.__previousKcdWebMcpCleanup
+		)
+	})
 	expect(cleanupReplaced).toBe(true)
 })
 
@@ -320,13 +332,18 @@ test('navigate_site asks for confirmation without requestUserInteraction', async
 		}
 	})
 
+	const expectedUrl = new URL('/blog', 'http://localhost').toString()
+	const expectedConfirmation = `Allow navigation to ${expectedUrl}?`
+
 	expect(outcome.confirmCalls).toEqual([
-		'Allow navigation to http://localhost:3000/blog?',
+		outcome.result?.url
+			? `Allow navigation to ${outcome.result.url}?`
+			: expectedConfirmation,
 	])
 	expect(outcome.result).toMatchObject({
 		cancelled: true,
 		destination: 'blog',
-		url: 'http://localhost:3000/blog',
 	})
-	expect(outcome.locationHref).toBe('http://localhost:3000/')
+	expect(outcome.result?.url).toMatch(/\/blog$/)
+	expect(outcome.locationHref).toMatch(/\/$/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- register browser-side WebMCP tools on page load from the client entrypoint
- expose structured tools for site search, current-page context, and key-site navigation
- prefer canonical page URLs in page-context results, harden host cleanup callbacks, and gate navigation tools through confirmation whether or not `requestUserInteraction` is available
- make WebMCP reinstall resilient when a previous teardown throws, and run cleanup callbacks in reverse registration order
- add focused Playwright coverage for initial registration, fallback `registerTool()` behavior, reinstall-after-throw, and confirmation fallback
- stabilize the WebMCP e2e assertions for CI by checking cleanup replacement by identity instead of function source text, and by avoiding hard-coded localhost ports in confirmation assertions

## Testing
- `npm run lint --workspace kentcdodds.com`
- `npm run typecheck --workspace kentcdodds.com`
- `PORT=8811 SEARCH_WORKER_URL="https://mock.search-worker.local" SEARCH_WORKER_TOKEN="local-dev-search-token" npx playwright test web-mcp.spec.ts` (run from `services/site`)

## Notes
- The latest failing CI job was the Playwright job, not the deploy planner wrapper itself.
- The actionable failures were both in `services/site/e2e/web-mcp.spec.ts`:
  - a reinstall assertion that depended on `Function#toString()` internals
  - a confirmation assertion that hard-coded `localhost:3000` even though CI runs Playwright on port `8811`
- I fixed those assertions and verified the updated spec on the CI-like port locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa91052e-8888-4559-b799-93d8f0e311b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa91052e-8888-4559-b799-93d8f0e311b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI tools added: site search, current page context (title, URL, headings, preview) and in-site navigation (with optional confirmation). Tools initialize on page load and include lifecycle cleanup with robust fallback handling.

* **Tests**
  * End-to-end tests added to validate tool registration paths and execution of search, page-context, and navigation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->