### PR TITLE
Add markdown negotiation fallback for agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29722,6 +29722,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-slug": "^7.0.1",
+        "remark-stringify": "^11.0.0",
         "request-ip": "^3.3.0",
         "server-timing": "^3.3.3",
         "source-map-support": "^0.5.21",

--- a/services/site/package.json
+++ b/services/site/package.json
@@ -157,6 +157,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "remark-slug": "^7.0.1",
+    "remark-stringify": "^11.0.0",
     "request-ip": "^3.3.0",
     "server-timing": "^3.3.3",
     "source-map-support": "^0.5.21",

--- a/services/site/server/__tests__/markdown-negotiation.test.ts
+++ b/services/site/server/__tests__/markdown-negotiation.test.ts
@@ -51,7 +51,7 @@ test('maybeConvertHtmlResponseToMarkdown converts html responses', async () => {
 	expect(markdownResponse.headers.get('vary')).toBe('Cookie, Accept')
 	expect(markdownResponse.headers.get('x-markdown-tokens')).toBeTruthy()
 	expect(markdown).toContain('# Example page')
-	expect(markdown).toContain('## Heading')
+expect(markdown).toContain('# Heading')
 	expect(markdown).toContain('Hello **world**.')
 })
 

--- a/services/site/server/__tests__/markdown-negotiation.test.ts
+++ b/services/site/server/__tests__/markdown-negotiation.test.ts
@@ -5,6 +5,7 @@ import {
 	maybeConvertHtmlResponseToMarkdown,
 	requestPrefersMarkdown,
 } from '../markdown-negotiation.ts'
+import { getSetCookieHeaders } from '../react-router-express-with-markdown.ts'
 
 test('requestPrefersMarkdown returns true when markdown outranks html', () => {
 	const accepts = (types: Array<string>) =>
@@ -64,4 +65,19 @@ test('maybeConvertHtmlResponseToMarkdown leaves non-html responses alone', async
 	const result = await maybeConvertHtmlResponseToMarkdown(response)
 
 	expect(result).toBe(response)
+})
+
+test('getSetCookieHeaders preserves multiple set-cookie headers', () => {
+	const response = new Response('ok', {
+		headers: [
+			['Set-Cookie', 'a=1; Path=/'],
+			['Set-Cookie', 'b=2; Path=/'],
+			['X-Test', 'ok'],
+		],
+	})
+
+	expect(getSetCookieHeaders(response.headers)).toEqual([
+		'a=1; Path=/',
+		'b=2; Path=/',
+	])
 })

--- a/services/site/server/__tests__/markdown-negotiation.test.ts
+++ b/services/site/server/__tests__/markdown-negotiation.test.ts
@@ -51,7 +51,7 @@ test('maybeConvertHtmlResponseToMarkdown converts html responses', async () => {
 	expect(markdownResponse.headers.get('vary')).toBe('Cookie, Accept')
 	expect(markdownResponse.headers.get('x-markdown-tokens')).toBeTruthy()
 	expect(markdown).toContain('# Example page')
-expect(markdown).toContain('# Heading')
+	expect(markdown).toContain('# Heading')
 	expect(markdown).toContain('Hello **world**.')
 })
 

--- a/services/site/server/__tests__/markdown-negotiation.test.ts
+++ b/services/site/server/__tests__/markdown-negotiation.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { expect, test } from 'vitest'
+import {
+	markdownContentType,
+	maybeConvertHtmlResponseToMarkdown,
+	requestPrefersMarkdown,
+} from '../markdown-negotiation.ts'
+
+test('requestPrefersMarkdown returns true when markdown outranks html', () => {
+	const accepts = (types: Array<string>) =>
+		types.find((value) => value === 'text/markdown') ?? false
+
+	expect(requestPrefersMarkdown(accepts)).toBe(true)
+})
+
+test('requestPrefersMarkdown returns false when html is preferred', () => {
+	const accepts = (types: Array<string>) =>
+		types.find((value) => value === 'text/html') ?? false
+
+	expect(requestPrefersMarkdown(accepts)).toBe(false)
+})
+
+test('maybeConvertHtmlResponseToMarkdown converts html responses', async () => {
+	const response = new Response(
+		`<!doctype html>
+<html>
+	<head>
+		<title>Example page</title>
+	</head>
+	<body>
+		<main>
+			<h1>Heading</h1>
+			<p>Hello <strong>world</strong>.</p>
+		</main>
+	</body>
+</html>`,
+		{
+			headers: {
+				'content-type': 'text/html; charset=utf-8',
+				vary: 'Cookie',
+			},
+			status: 200,
+			statusText: 'OK',
+		},
+	)
+
+	const markdownResponse = await maybeConvertHtmlResponseToMarkdown(response)
+	const markdown = await markdownResponse.text()
+
+	expect(markdownResponse.headers.get('content-type')).toBe(markdownContentType)
+	expect(markdownResponse.headers.get('vary')).toBe('Cookie, Accept')
+	expect(markdownResponse.headers.get('x-markdown-tokens')).toBeTruthy()
+	expect(markdown).toContain('# Example page')
+	expect(markdown).toContain('## Heading')
+	expect(markdown).toContain('Hello **world**.')
+})
+
+test('maybeConvertHtmlResponseToMarkdown leaves non-html responses alone', async () => {
+	const response = new Response('{"ok":true}', {
+		headers: { 'content-type': 'application/json' },
+		status: 200,
+	})
+
+	const result = await maybeConvertHtmlResponseToMarkdown(response)
+
+	expect(result).toBe(response)
+})

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -4,10 +4,6 @@ import os from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import {
-	createRequestHandler,
-	type RequestHandler,
-} from '@react-router/express'
-import {
 	init as sentryInit,
 	setContext as sentrySetContext,
 } from '@sentry/react-router'
@@ -20,12 +16,13 @@ import getPort, { portNumbers } from 'get-port'
 import helmet from 'helmet'
 import morgan from 'morgan'
 import onFinished from 'on-finished'
-import { type ServerBuild } from 'react-router'
+import { type RequestHandler, type ServerBuild } from 'react-router'
 import serverTiming from 'server-timing'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
 import { getEnv } from '../app/utils/env.server.ts'
 import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
+import { createRequestHandlerWithMarkdown } from './react-router-express-with-markdown.ts'
 
 sourceMapSupport.install()
 
@@ -426,7 +423,7 @@ async function getRequestHandler(): Promise<RequestHandler> {
 	function getLoadContext(req: any, res: any) {
 		return { cspNonce: res.locals.cspNonce }
 	}
-	return createRequestHandler({
+	return createRequestHandlerWithMarkdown({
 		build: MODE === 'development' ? getBuild : await getBuild(),
 		mode: MODE,
 		getLoadContext,

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -16,7 +16,7 @@ import getPort, { portNumbers } from 'get-port'
 import helmet from 'helmet'
 import morgan from 'morgan'
 import onFinished from 'on-finished'
-import { type RequestHandler, type ServerBuild } from 'react-router'
+import { type ServerBuild } from 'react-router'
 import serverTiming from 'server-timing'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
@@ -419,7 +419,7 @@ app.use('/.well-known/{*splat}', (req, res, next) => {
 	next()
 })
 
-async function getRequestHandler(): Promise<RequestHandler> {
+async function getRequestHandler() {
 	function getLoadContext(req: any, res: any) {
 		return { cspNonce: res.locals.cspNonce }
 	}

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -22,7 +22,6 @@ import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
 import { getEnv } from '../app/utils/env.server.ts'
 import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
-import { createRequestHandlerWithMarkdown } from './react-router-express-with-markdown'
 
 sourceMapSupport.install()
 
@@ -33,6 +32,10 @@ const localServerModuleExtension = import.meta.url.includes('/server-build/')
 async function importLocalServerModule<T>(specifier: string): Promise<T> {
 	return (await import(`${specifier}${localServerModuleExtension}`)) as T
 }
+
+const { createRequestHandlerWithMarkdown } = await importLocalServerModule<
+	typeof import('./react-router-express-with-markdown.ts')
+>('./react-router-express-with-markdown')
 
 const { scheduleExpiredDataCleanup } = await importLocalServerModule<
 	typeof import('./expired-sessions-cleanup.ts')

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -22,7 +22,7 @@ import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
 import { getEnv } from '../app/utils/env.server.ts'
 import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
-import { createRequestHandlerWithMarkdown } from './react-router-express-with-markdown.ts'
+import { createRequestHandlerWithMarkdown } from './react-router-express-with-markdown'
 
 sourceMapSupport.install()
 

--- a/services/site/server/markdown-negotiation.ts
+++ b/services/site/server/markdown-negotiation.ts
@@ -29,7 +29,7 @@ function extractHtmlTitle(html: string) {
 		if (node.tagName !== 'title') return
 		const text = toString(node).replace(/\s+/g, ' ').trim()
 		title = text || null
-		return visit.EXIT
+		return false
 	})
 
 	return title

--- a/services/site/server/markdown-negotiation.ts
+++ b/services/site/server/markdown-negotiation.ts
@@ -1,0 +1,114 @@
+import { visit } from 'unist-util-visit'
+import rehypeParse from 'rehype-parse'
+import rehype2remark from 'rehype-remark'
+import remarkStringify from 'remark-stringify'
+import { unified } from 'unified'
+
+const markdownMediaType = 'text/markdown'
+const markdownContentType = `${markdownMediaType}; charset=utf-8`
+
+function requestPrefersMarkdown(accepts: (types: Array<string>) => string | false) {
+	return accepts(['text/html', markdownMediaType]) === markdownMediaType
+}
+
+function responseCanBecomeMarkdown(response: Response) {
+	return (
+		response.ok &&
+		Boolean(response.headers.get('content-type')?.match(/\btext\/html\b/i))
+	)
+}
+
+function extractHtmlTitle(html: string) {
+	const match = html.match(/<title>([\s\S]*?)<\/title>/i)
+	if (!match) return null
+
+	const title = match[1]?.replace(/\s+/g, ' ').trim()
+	return title ? title : null
+}
+
+function removeNonContentElements() {
+	return function transformer(tree: any) {
+		visit(tree, 'element', (node: any, index, parent) => {
+			if (!parent || typeof index !== 'number') return
+
+			if (
+				['head', 'script', 'style', 'noscript', 'template'].includes(
+					node.tagName,
+				)
+			) {
+				parent.children.splice(index, 1)
+				return [visit.SKIP, index]
+			}
+		})
+	}
+}
+
+async function convertHtmlToMarkdown(html: string) {
+	const title = extractHtmlTitle(html)
+	const result = await unified()
+		.use(rehypeParse)
+		.use(removeNonContentElements)
+		.use(rehype2remark)
+		.use(remarkStringify, {
+			bullet: '-',
+			emphasis: '*',
+			fences: true,
+			listItemIndent: 'one',
+			rule: '-',
+			ruleRepetition: 3,
+			strong: '*',
+		})
+		.process(html)
+
+	const bodyMarkdown = result.value.toString().trim()
+	const markdown =
+		title && !bodyMarkdown.startsWith(`# ${title}`)
+			? `# ${title}\n\n${bodyMarkdown}`
+			: bodyMarkdown
+
+	return `${markdown.replace(/\n{3,}/g, '\n\n').trim()}\n`
+}
+
+function estimateMarkdownTokens(markdown: string) {
+	return Math.max(1, Math.ceil(markdown.length / 4))
+}
+
+function appendVaryValue(headers: Headers, value: string) {
+	const vary = headers.get('vary')
+	if (!vary) {
+		headers.set('vary', value)
+		return
+	}
+
+	const values = new Set(
+		vary
+			.split(',')
+			.map((entry) => entry.trim())
+			.filter(Boolean),
+	)
+	values.add(value)
+	headers.set('vary', Array.from(values).join(', '))
+}
+
+async function maybeConvertHtmlResponseToMarkdown(response: Response) {
+	if (!responseCanBecomeMarkdown(response)) return response
+
+	const html = await response.text()
+	const markdown = await convertHtmlToMarkdown(html)
+	const headers = new Headers(response.headers)
+	headers.set('content-type', markdownContentType)
+	headers.set('x-markdown-tokens', String(estimateMarkdownTokens(markdown)))
+	appendVaryValue(headers, 'Accept')
+
+	return new Response(markdown, {
+		headers,
+		status: response.status,
+		statusText: response.statusText,
+	})
+}
+
+export {
+	markdownContentType,
+	maybeConvertHtmlResponseToMarkdown,
+	requestPrefersMarkdown,
+}

--- a/services/site/server/markdown-negotiation.ts
+++ b/services/site/server/markdown-negotiation.ts
@@ -37,7 +37,7 @@ function removeNonContentElements() {
 				)
 			) {
 				parent.children.splice(index, 1)
-				return [visit.SKIP, index]
+				return index
 			}
 		})
 	}

--- a/services/site/server/markdown-negotiation.ts
+++ b/services/site/server/markdown-negotiation.ts
@@ -1,3 +1,4 @@
+import { toString } from 'hast-util-to-string'
 import { visit } from 'unist-util-visit'
 import rehypeParse from 'rehype-parse'
 import rehype2remark from 'rehype-remark'
@@ -7,7 +8,9 @@ import { unified } from 'unified'
 const markdownMediaType = 'text/markdown'
 const markdownContentType = `${markdownMediaType}; charset=utf-8`
 
-function requestPrefersMarkdown(accepts: (types: Array<string>) => string | false) {
+function requestPrefersMarkdown(
+	accepts: (types: Array<string>) => string | false,
+) {
 	return accepts(['text/html', markdownMediaType]) === markdownMediaType
 }
 
@@ -19,11 +22,17 @@ function responseCanBecomeMarkdown(response: Response) {
 }
 
 function extractHtmlTitle(html: string) {
-	const match = html.match(/<title>([\s\S]*?)<\/title>/i)
-	if (!match) return null
+	const tree = unified().use(rehypeParse).parse(html)
+	let title: string | null = null
 
-	const title = match[1]?.replace(/\s+/g, ' ').trim()
-	return title ? title : null
+	visit(tree, 'element', (node: any) => {
+		if (node.tagName !== 'title') return
+		const text = toString(node).replace(/\s+/g, ' ').trim()
+		title = text || null
+		return visit.EXIT
+	})
+
+	return title
 }
 
 function removeNonContentElements() {

--- a/services/site/server/markdown-negotiation.ts
+++ b/services/site/server/markdown-negotiation.ts
@@ -96,6 +96,7 @@ async function maybeConvertHtmlResponseToMarkdown(response: Response) {
 	const html = await response.text()
 	const markdown = await convertHtmlToMarkdown(html)
 	const headers = new Headers(response.headers)
+	headers.delete('content-length')
 	headers.set('content-type', markdownContentType)
 	headers.set('x-markdown-tokens', String(estimateMarkdownTokens(markdown)))
 	appendVaryValue(headers, 'Accept')

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -17,7 +17,7 @@ import {
 import {
 	maybeConvertHtmlResponseToMarkdown,
 	requestPrefersMarkdown,
-} from './markdown-negotiation'
+} from './markdown-negotiation.js'
 
 type MaybePromise<T> = T | Promise<T>
 

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -90,7 +90,11 @@ async function sendResponse(res: ExpressResponse, response: globalThis.Response)
 	res.status(response.status)
 
 	for (const [key, value] of response.headers.entries()) {
+		if (key.toLowerCase() === 'set-cookie') continue
 		res.append(key, value)
+	}
+	for (const cookie of getSetCookieHeaders(response.headers)) {
+		res.append('Set-Cookie', cookie)
 	}
 
 	if (response.headers.get('content-type')?.match(/text\/event-stream/i)) {
@@ -103,6 +107,12 @@ async function sendResponse(res: ExpressResponse, response: globalThis.Response)
 	}
 
 	res.end()
+}
+
+function getSetCookieHeaders(headers: Headers) {
+	return typeof headers.getSetCookie === 'function'
+		? headers.getSetCookie()
+		: []
 }
 
 function createRequestHandlerWithMarkdown({
@@ -133,4 +143,4 @@ function createRequestHandlerWithMarkdown({
 	}
 }
 
-export { createRequestHandlerWithMarkdown }
+export { createRequestHandlerWithMarkdown, getSetCookieHeaders }

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -1,0 +1,137 @@
+import {
+	createReadableStreamFromReadable,
+	writeReadableStreamToWritable,
+} from '@react-router/node'
+import type { NextFunction, Request, Response } from 'express'
+import {
+	createRequestHandler as createReactRouterRequestHandler,
+	type AppLoadContext,
+	type RouterContextProvider,
+	type ServerBuild,
+	type UNSAFE_MiddlewareEnabled,
+} from 'react-router'
+import {
+	maybeConvertHtmlResponseToMarkdown,
+	requestPrefersMarkdown,
+} from './markdown-negotiation.ts'
+
+type MaybePromise<T> = T | Promise<T>
+
+type GetLoadContextFunction = (
+	req: Request,
+	res: Response,
+) => UNSAFE_MiddlewareEnabled extends true
+	? MaybePromise<RouterContextProvider>
+	: MaybePromise<AppLoadContext>
+
+type ExpressRequestHandler = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => Promise<void>
+
+function createRemixHeaders(requestHeaders: Request['headers']) {
+	const headers = new Headers()
+	for (const [key, values] of Object.entries(requestHeaders)) {
+		if (!values) continue
+
+		if (Array.isArray(values)) {
+			for (const value of values) {
+				headers.append(key, value)
+			}
+			continue
+		}
+
+		headers.set(key, values)
+	}
+	return headers
+}
+
+function createRemixRequest(req: Request, res: Response) {
+	const [, forwardedPortString] = req.get('X-Forwarded-Host')?.split(':') ?? []
+	const [, hostPortString] = req.get('host')?.split(':') ?? []
+	const forwardedPort = Number.parseInt(forwardedPortString ?? '', 10)
+	const hostPort = Number.parseInt(hostPortString ?? '', 10)
+	const port = Number.isSafeInteger(forwardedPort)
+		? forwardedPort
+		: Number.isSafeInteger(hostPort)
+			? hostPort
+			: ''
+	const resolvedHost = `${req.hostname}${port ? `:${port}` : ''}`
+	const url = new URL(`${req.protocol}://${resolvedHost}${req.originalUrl}`)
+	let controller: AbortController | null = new AbortController()
+	const init: RequestInit & { duplex?: 'half' } = {
+		method: req.method,
+		headers: createRemixHeaders(req.headers),
+		signal: controller.signal,
+	}
+
+	res.on('finish', () => {
+		controller = null
+	})
+	res.on('close', () => {
+		controller?.abort()
+	})
+
+	if (req.method !== 'GET' && req.method !== 'HEAD') {
+		init.body = createReadableStreamFromReadable(req)
+		init.duplex = 'half'
+	}
+
+	return new Request(url.href, init)
+}
+
+async function sendResponse(res: Response, response: Response) {
+	res.statusMessage = response.statusText
+	res.status(response.status)
+
+	for (const [key, value] of response.headers.entries()) {
+		res.append(key, value)
+	}
+
+	if (response.headers.get('content-type')?.match(/text\/event-stream/i)) {
+		res.flushHeaders()
+	}
+
+	if (response.body) {
+		await writeReadableStreamToWritable(response.body, res)
+		return
+	}
+
+	res.end()
+}
+
+function createRequestHandlerWithMarkdown({
+	build,
+	getLoadContext,
+	mode = process.env.NODE_ENV,
+}: {
+	build: ServerBuild | (() => Promise<ServerBuild>)
+	getLoadContext?: GetLoadContextFunction
+	mode?: string
+}): ExpressRequestHandler {
+	const handleRequest = createReactRouterRequestHandler(build, mode)
+
+	return async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const request = createRemixRequest(req, res)
+			const loadContext = await getLoadContext?.(req, res)
+			let response = await handleRequest(request, loadContext)
+
+			if (requestPrefersMarkdown(req.accepts.bind(req))) {
+				response = await maybeConvertHtmlResponseToMarkdown(response)
+			}
+
+			await sendResponse(res, response)
+		} catch (error) {
+			next(error)
+		}
+	}
+}
+
+async function getResponseText(response: Response) {
+	if (!response.body) return ''
+	return readableStreamToString(response.body, 'utf8')
+}
+
+export { createRequestHandlerWithMarkdown }

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -2,7 +2,11 @@ import {
 	createReadableStreamFromReadable,
 	writeReadableStreamToWritable,
 } from '@react-router/node'
-import type { NextFunction, Request, Response } from 'express'
+import type {
+	NextFunction,
+	Request as ExpressRequest,
+	Response as ExpressResponse,
+} from 'express'
 import {
 	createRequestHandler as createReactRouterRequestHandler,
 	type AppLoadContext,
@@ -18,19 +22,19 @@ import {
 type MaybePromise<T> = T | Promise<T>
 
 type GetLoadContextFunction = (
-	req: Request,
-	res: Response,
+	req: ExpressRequest,
+	res: ExpressResponse,
 ) => UNSAFE_MiddlewareEnabled extends true
 	? MaybePromise<RouterContextProvider>
 	: MaybePromise<AppLoadContext>
 
 type ExpressRequestHandler = (
-	req: Request,
-	res: Response,
+	req: ExpressRequest,
+	res: ExpressResponse,
 	next: NextFunction,
 ) => Promise<void>
 
-function createRemixHeaders(requestHeaders: Request['headers']) {
+function createRemixHeaders(requestHeaders: ExpressRequest['headers']) {
 	const headers = new Headers()
 	for (const [key, values] of Object.entries(requestHeaders)) {
 		if (!values) continue
@@ -47,7 +51,7 @@ function createRemixHeaders(requestHeaders: Request['headers']) {
 	return headers
 }
 
-function createRemixRequest(req: Request, res: Response) {
+function createRemixRequest(req: ExpressRequest, res: ExpressResponse) {
 	const [, forwardedPortString] = req.get('X-Forwarded-Host')?.split(':') ?? []
 	const [, hostPortString] = req.get('host')?.split(':') ?? []
 	const forwardedPort = Number.parseInt(forwardedPortString ?? '', 10)
@@ -81,7 +85,7 @@ function createRemixRequest(req: Request, res: Response) {
 	return new Request(url.href, init)
 }
 
-async function sendResponse(res: Response, response: Response) {
+async function sendResponse(res: ExpressResponse, response: globalThis.Response) {
 	res.statusMessage = response.statusText
 	res.status(response.status)
 
@@ -106,13 +110,13 @@ function createRequestHandlerWithMarkdown({
 	getLoadContext,
 	mode = process.env.NODE_ENV,
 }: {
-	build: ServerBuild | (() => Promise<ServerBuild>)
+	build: ServerBuild | (() => ServerBuild | Promise<ServerBuild>)
 	getLoadContext?: GetLoadContextFunction
 	mode?: string
 }): ExpressRequestHandler {
 	const handleRequest = createReactRouterRequestHandler(build, mode)
 
-	return async (req: Request, res: Response, next: NextFunction) => {
+	return async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
 		try {
 			const request = createRemixRequest(req, res)
 			const loadContext = await getLoadContext?.(req, res)
@@ -127,11 +131,6 @@ function createRequestHandlerWithMarkdown({
 			next(error)
 		}
 	}
-}
-
-async function getResponseText(response: Response) {
-	if (!response.body) return ''
-	return readableStreamToString(response.body, 'utf8')
 }
 
 export { createRequestHandlerWithMarkdown }

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -97,6 +97,13 @@ async function sendResponse(res: ExpressResponse, response: globalThis.Response)
 		res.append('Set-Cookie', cookie)
 	}
 
+	const contentType = response.headers.get('content-type')
+	const shouldVaryOnAccept =
+		response.ok && Boolean(contentType?.match(/\btext\/(html|markdown)\b/i))
+	if (shouldVaryOnAccept) {
+		res.vary('Accept')
+	}
+
 	if (response.headers.get('content-type')?.match(/text\/event-stream/i)) {
 		res.flushHeaders()
 	}

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -17,7 +17,7 @@ import {
 import {
 	maybeConvertHtmlResponseToMarkdown,
 	requestPrefersMarkdown,
-} from './markdown-negotiation.ts'
+} from './markdown-negotiation'
 
 type MaybePromise<T> = T | Promise<T>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a server-side fallback that returns markdown when requests prefer `text/markdown`
- keep HTML as the default browser response
- add focused backend coverage for markdown negotiation behavior
- fix the runtime/server-build import path chain so the production app artifact can boot under Playwright CI
- preserve multiple `Set-Cookie` headers when forwarding Fetch responses into Express
- fix markdown title traversal typing to match the installed `unist-util-visit` API used in CI

## Cloudflare note
- checked the Cloudflare-native path first via the connected production Kody MCP server
- the zone currently reports a `Free Website` plan, and the available token is valid but does not have zone-settings edit access for `content_converter`
- because of that, the CDN-native toggle was not usable from this environment, so this PR implements the app-level fallback instead

## Testing
- `npm run test:backend --workspace kentcdodds.com -- server/__tests__/markdown-negotiation.test.ts`
- `npm run lint --workspace kentcdodds.com`
- `npm run typecheck --workspace kentcdodds.com`
- `npm run build --workspace kentcdodds.com`
- `npm run build:server --workspace kentcdodds.com`
- `npm run prime-cache:mocks --workspace kentcdodds.com`
- reproduced the latest CI site-gate failure (`TS2339: Property 'EXIT' does not exist on type ...`) on the current PR head and fixed it by switching to the supported `unist-util-visit` early-exit return value
- reproduced the Playwright CI startup failure from logs (`ERR_MODULE_NOT_FOUND` for the markdown handler import chain) and fixed it by routing the new helper imports through the same runtime extension strategy the rest of the server already uses
- verified locally with `curl` that `/` still returns `text/html`, while `Accept: text/markdown` returns `Content-Type: text/markdown; charset=utf-8` plus `x-markdown-tokens`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b2ab0b1-179e-4336-9b91-f5f538ba4337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b2ab0b1-179e-4336-9b91-f5f538ba4337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site will negotiate content and serve HTML as Markdown when clients prefer Markdown, preserving response semantics, cookies, and updating headers (including Vary).

* **Tests**
  * Added tests for Markdown preference detection, HTML→Markdown conversion results, and multi‑cookie header handling.

* **Chores**
  * Added a Markdown serialization dependency to the site tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->