### PR TITLE
Add RFC 9727 API catalog endpoints

### DIFF
--- a/services/site/app/other-routes.server.ts
+++ b/services/site/app/other-routes.server.ts
@@ -1,12 +1,28 @@
 import { type EntryContext } from 'react-router'
+import {
+	apiCatalogPath,
+	apiDocsPath,
+	getApiCatalogResponse,
+	getApiDocsResponse,
+	getOpenApiResponse,
+} from './utils/api-catalog.server.ts'
 import { getSitemapXml } from './utils/sitemap.server.ts'
 
 type Handler = (
 	request: Request,
 	remixContext: EntryContext,
-) => Promise<Response | null> | null
+) => Response | Promise<Response | null> | null
 
 const pathedRoutes: Record<string, Handler> = {
+	[apiCatalogPath]: (request) => {
+		return getApiCatalogResponse(request)
+	},
+	[apiDocsPath]: (request) => {
+		return getApiDocsResponse(request)
+	},
+	'/openapi.json': (request) => {
+		return getOpenApiResponse(request)
+	},
 	'/sitemap.xml': async (request, remixContext) => {
 		const sitemap = await getSitemapXml(request, remixContext)
 		return new Response(sitemap, {

--- a/services/site/app/other-routes.server.ts
+++ b/services/site/app/other-routes.server.ts
@@ -5,6 +5,7 @@ import {
 	getApiCatalogResponse,
 	getApiDocsResponse,
 	getOpenApiResponse,
+	openApiPath,
 } from './utils/api-catalog.server.ts'
 import { getSitemapXml } from './utils/sitemap.server.ts'
 
@@ -20,7 +21,7 @@ const pathedRoutes: Record<string, Handler> = {
 	[apiDocsPath]: (request) => {
 		return getApiDocsResponse(request)
 	},
-	'/openapi.json': (request) => {
+	[openApiPath]: (request) => {
 		return getOpenApiResponse(request)
 	},
 	'/sitemap.xml': async (request, remixContext) => {

--- a/services/site/app/utils/__tests__/api-catalog.server.test.ts
+++ b/services/site/app/utils/__tests__/api-catalog.server.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from 'vitest'
+import {
+	apiCatalogPath,
+	apiDocsPath,
+	getApiCatalogDocument,
+	getApiCatalogResponse,
+	getApiDocsResponse,
+	getOpenApiDocument,
+	getOpenApiResponse,
+	linksetContentType,
+	openApiContentType,
+} from '../api-catalog.server.ts'
+
+function createRequest(pathname: string) {
+	return new Request(`https://kentcdodds.com${pathname}`, {
+		headers: { host: 'kentcdodds.com' },
+	})
+}
+
+test('getApiCatalogDocument returns an RFC 9727 linkset entry', () => {
+	const request = createRequest(apiCatalogPath)
+
+	const document = getApiCatalogDocument(request)
+
+	expect(document).toEqual({
+		linkset: [
+			{
+				anchor: 'https://kentcdodds.com',
+				'service-desc': [
+					{
+						href: 'https://kentcdodds.com/openapi.json',
+						type: openApiContentType,
+					},
+				],
+				'service-doc': [
+					{
+						href: 'https://kentcdodds.com/.well-known/api-docs',
+						type: 'text/html',
+					},
+				],
+				status: [
+					{
+						href: 'https://kentcdodds.com/healthcheck',
+						type: 'text/plain',
+					},
+				],
+			},
+		],
+	})
+})
+
+test('getApiCatalogResponse returns linkset+json with the RFC profile', async () => {
+	const response = getApiCatalogResponse(createRequest(apiCatalogPath))
+
+	expect(response.headers.get('Content-Type')).toBe(linksetContentType)
+	expect(response.headers.get('Link')).toBe(
+		'<https://kentcdodds.com/.well-known/api-catalog>; rel="api-catalog"',
+	)
+	await expect(response.json()).resolves.toEqual({
+		linkset: [
+			expect.objectContaining({
+				anchor: 'https://kentcdodds.com',
+			}),
+		],
+	})
+})
+
+test('getOpenApiDocument points discovery metadata at the current origin', () => {
+	const request = createRequest('/openapi.json')
+
+	const document = getOpenApiDocument(request)
+
+	expect(document.openapi).toBe('3.1.0')
+	expect(document.servers).toEqual([
+		{
+			url: 'https://kentcdodds.com',
+			description: 'Current site origin',
+		},
+	])
+	expect(document.externalDocs).toEqual({
+		description: 'Human-readable API documentation',
+		url: 'https://kentcdodds.com/.well-known/api-docs',
+	})
+	expect(
+		document.paths[apiCatalogPath]?.get?.responses?.['200']?.content,
+	).toEqual({
+		'application/linkset+json': {
+			schema: { type: 'object' },
+		},
+	})
+})
+
+test('getOpenApiResponse returns the configured OpenAPI media type', () => {
+	const response = getOpenApiResponse(createRequest('/openapi.json'))
+
+	expect(response.headers.get('Content-Type')).toBe(openApiContentType)
+})
+
+test('getApiDocsResponse returns HTML docs with discovery links', async () => {
+	const response = getApiDocsResponse(createRequest(apiDocsPath))
+	const body = await response.text()
+
+	expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8')
+	expect(body).toContain('Kent C. Dodds Site API')
+	expect(body).toContain('https://kentcdodds.com/.well-known/api-catalog')
+	expect(body).toContain('https://kentcdodds.com/openapi.json')
+	expect(body).toContain('https://kentcdodds.com/healthcheck')
+})

--- a/services/site/app/utils/api-catalog.server.ts
+++ b/services/site/app/utils/api-catalog.server.ts
@@ -1,0 +1,411 @@
+import { getDomainUrl } from './misc.ts'
+
+const apiCatalogPath = '/.well-known/api-catalog'
+const openApiPath = '/openapi.json'
+const apiDocsPath = '/.well-known/api-docs'
+const healthcheckPath = '/healthcheck'
+
+const apiCatalogProfileUrl = 'https://www.rfc-editor.org/info/rfc9727'
+const linksetContentType = `application/linkset+json; profile="${apiCatalogProfileUrl}"`
+const htmlContentType = 'text/html; charset=utf-8'
+const openApiContentType = 'application/vnd.oai.openapi+json'
+
+type LinkTarget = {
+	href: string
+	type?: string
+}
+
+type ApiCatalogDocument = {
+	linkset: Array<{
+		anchor: string
+		'service-desc': Array<LinkTarget>
+		'service-doc': Array<LinkTarget>
+		status: Array<LinkTarget>
+	}>
+}
+
+function getAbsoluteUrl(origin: string, pathname: string) {
+	return pathname === '/' ? origin : `${origin}${pathname}`
+}
+
+function createJsonResponse(
+	body: unknown,
+	{
+		contentType,
+		headers = {},
+	}: {
+		contentType: string
+		headers?: Record<string, string>
+	},
+) {
+	const stringifiedBody = JSON.stringify(body)
+
+	return new Response(stringifiedBody, {
+		headers: {
+			'Cache-Control': 'public, max-age=3600',
+			'Content-Length': String(Buffer.byteLength(stringifiedBody)),
+			'Content-Type': contentType,
+			...headers,
+		},
+	})
+}
+
+function createTextResponse(
+	body: string,
+	{
+		contentType,
+		headers = {},
+	}: {
+		contentType: string
+		headers?: Record<string, string>
+	},
+) {
+	return new Response(body, {
+		headers: {
+			'Cache-Control': 'public, max-age=3600',
+			'Content-Length': String(Buffer.byteLength(body)),
+			'Content-Type': contentType,
+			...headers,
+		},
+	})
+}
+
+function getApiCatalogDocument(request: Request): ApiCatalogDocument {
+	const origin = getDomainUrl(request)
+
+	return {
+		linkset: [
+			{
+				anchor: origin,
+				'service-desc': [
+					{
+						href: getAbsoluteUrl(origin, openApiPath),
+						type: openApiContentType,
+					},
+				],
+				'service-doc': [
+					{
+						href: getAbsoluteUrl(origin, apiDocsPath),
+						type: 'text/html',
+					},
+				],
+				status: [
+					{
+						href: getAbsoluteUrl(origin, healthcheckPath),
+						type: 'text/plain',
+					},
+				],
+			},
+		],
+	}
+}
+
+function getApiCatalogResponse(request: Request) {
+	const origin = getDomainUrl(request)
+
+	return createJsonResponse(getApiCatalogDocument(request), {
+		contentType: linksetContentType,
+		headers: {
+			Link: `<${getAbsoluteUrl(origin, apiCatalogPath)}>; rel="api-catalog"`,
+		},
+	})
+}
+
+function getOpenApiDocument(request: Request) {
+	const origin = getDomainUrl(request)
+
+	return {
+		openapi: '3.1.0',
+		info: {
+			title: 'Kent C. Dodds Site API',
+			version: '1.0.0',
+			summary: 'Public discovery endpoints for kentcdodds.com.',
+			description:
+				'OpenAPI description for the public machine-consumable endpoints published by kentcdodds.com.',
+		},
+		jsonSchemaDialect: 'https://json-schema.org/draft/2020-12/schema',
+		servers: [
+			{
+				url: origin,
+				description: 'Current site origin',
+			},
+		],
+		externalDocs: {
+			description: 'Human-readable API documentation',
+			url: getAbsoluteUrl(origin, apiDocsPath),
+		},
+		tags: [
+			{
+				name: 'discovery',
+				description: 'Catalog, spec, and health endpoints',
+			},
+			{
+				name: 'content',
+				description: 'Published site content feeds',
+			},
+			{
+				name: 'search',
+				description: 'Public content search endpoints',
+			},
+		],
+		paths: {
+			[apiCatalogPath]: {
+				get: {
+					tags: ['discovery'],
+					summary: 'Get the API catalog',
+					operationId: 'getApiCatalog',
+					responses: {
+						'200': {
+							description: 'API catalog in RFC 9727 Linkset format',
+							content: {
+								'application/linkset+json': {
+									schema: { type: 'object' },
+								},
+							},
+						},
+					},
+				},
+			},
+			[openApiPath]: {
+				get: {
+					tags: ['discovery'],
+					summary: 'Get the OpenAPI description',
+					operationId: 'getOpenApiDocument',
+					responses: {
+						'200': {
+							description: 'OpenAPI 3.1 JSON document',
+							content: {
+								[openApiContentType]: {
+									schema: { type: 'object' },
+								},
+							},
+						},
+					},
+				},
+			},
+			[healthcheckPath]: {
+				get: {
+					tags: ['discovery'],
+					summary: 'Health check',
+					operationId: 'getHealthcheck',
+					responses: {
+						'200': {
+							description: 'The app instance is healthy',
+							content: {
+								'text/plain': {
+									schema: { type: 'string' },
+									example: 'OK',
+								},
+							},
+						},
+						'500': {
+							description: 'The app instance encountered an error',
+							content: {
+								'text/plain': {
+									schema: { type: 'string' },
+									example: 'ERROR',
+								},
+							},
+						},
+					},
+				},
+			},
+			'/blog.json': {
+				get: {
+					tags: ['content'],
+					summary: 'Get published blog metadata',
+					operationId: 'getBlogJson',
+					responses: {
+						'200': {
+							description: 'Published blog content as JSON',
+							content: {
+								'application/json': {
+									schema: { type: 'object' },
+								},
+							},
+						},
+					},
+				},
+			},
+			'/resources/search': {
+				get: {
+					tags: ['search'],
+					summary: 'Search public site content',
+					operationId: 'searchSiteContent',
+					parameters: [
+						{
+							name: 'query',
+							in: 'query',
+							required: true,
+							description: 'Search query string',
+							schema: {
+								type: 'string',
+								minLength: 1,
+							},
+						},
+					],
+					responses: {
+						'200': {
+							description: 'Search results',
+							content: {
+								'application/json': {
+									schema: {
+										type: 'object',
+										properties: {
+											noCloseMatches: { type: 'boolean' },
+											results: {
+												type: 'array',
+												items: {
+													type: 'object',
+													properties: {
+														url: { type: 'string', format: 'uri' },
+														segment: { type: 'string' },
+														title: { type: 'string' },
+														summary: { type: 'string' },
+														imageUrl: {
+															type: ['string', 'null'],
+															format: 'uri',
+														},
+														imageAlt: { type: ['string', 'null'] },
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						'400': {
+							description: 'Missing or invalid query',
+							content: {
+								'application/json': {
+									schema: {
+										type: 'object',
+										properties: {
+											error: { type: 'string' },
+										},
+										required: ['error'],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+function getOpenApiResponse(request: Request) {
+	return createJsonResponse(getOpenApiDocument(request), {
+		contentType: openApiContentType,
+	})
+}
+
+function getApiDocsHtml(request: Request) {
+	const origin = getDomainUrl(request)
+	const catalogUrl = getAbsoluteUrl(origin, apiCatalogPath)
+	const openApiUrl = getAbsoluteUrl(origin, openApiPath)
+	const healthcheckUrl = getAbsoluteUrl(origin, healthcheckPath)
+	const searchUrl = `${getAbsoluteUrl(origin, '/resources/search')}?query=react`
+	const blogUrl = getAbsoluteUrl(origin, '/blog.json')
+
+	return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kent C. Dodds Site API</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      main {
+        max-width: 48rem;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+      a {
+        color: #7dd3fc;
+      }
+      code, pre {
+        font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, monospace;
+      }
+      pre {
+        padding: 1rem;
+        border-radius: 0.75rem;
+        overflow-x: auto;
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+      }
+      .card {
+        margin-top: 1.5rem;
+        padding: 1rem 1.25rem;
+        border-radius: 0.75rem;
+        background: rgba(30, 41, 59, 0.9);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      ul {
+        padding-left: 1.25rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Kent C. Dodds Site API</h1>
+      <p>Public discovery endpoints for automated API clients.</p>
+
+      <div class="card">
+        <h2>Discovery</h2>
+        <ul>
+          <li><a href="${catalogUrl}"><code>${catalogUrl}</code></a> - RFC 9727 API catalog</li>
+          <li><a href="${openApiUrl}"><code>${openApiUrl}</code></a> - OpenAPI 3.1 description</li>
+          <li><a href="${healthcheckUrl}"><code>${healthcheckUrl}</code></a> - Health endpoint</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h2>Documented endpoints</h2>
+        <ul>
+          <li><code>GET /resources/search?query=...</code> returns JSON search results.</li>
+          <li><code>GET /blog.json</code> returns published blog metadata as JSON.</li>
+          <li><code>GET /healthcheck</code> returns plain-text health status.</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h2>Quick examples</h2>
+        <pre>curl -H 'Accept: application/linkset+json' ${catalogUrl}
+curl ${openApiUrl}
+curl ${searchUrl}
+curl ${blogUrl}</pre>
+      </div>
+    </main>
+  </body>
+</html>`
+}
+
+function getApiDocsResponse(request: Request) {
+	return createTextResponse(getApiDocsHtml(request), {
+		contentType: htmlContentType,
+	})
+}
+
+export {
+	apiCatalogProfileUrl,
+	apiCatalogPath,
+	apiDocsPath,
+	getApiCatalogDocument,
+	getApiCatalogResponse,
+	getApiDocsResponse,
+	getOpenApiDocument,
+	getOpenApiResponse,
+	linksetContentType,
+	openApiContentType,
+}

--- a/services/site/app/utils/api-catalog.server.ts
+++ b/services/site/app/utils/api-catalog.server.ts
@@ -1,4 +1,4 @@
-import { getDomainUrl } from './misc.ts'
+import { escapeHtml, getDomainUrl } from './misc.ts'
 
 const apiCatalogPath = '/.well-known/api-catalog'
 const openApiPath = '/openapi.json'
@@ -26,15 +26,6 @@ type ApiCatalogDocument = {
 
 function getAbsoluteUrl(origin: string, pathname: string) {
 	return pathname === '/' ? origin : `${origin}${pathname}`
-}
-
-function escapeHtml(value: string) {
-	return value
-		.replaceAll('&', '&amp;')
-		.replaceAll('<', '&lt;')
-		.replaceAll('>', '&gt;')
-		.replaceAll('"', '&quot;')
-		.replaceAll("'", '&#39;')
 }
 
 function createJsonResponse(
@@ -412,7 +403,6 @@ function getApiDocsResponse(request: Request) {
 }
 
 export {
-	apiCatalogProfileUrl,
 	apiCatalogPath,
 	apiDocsPath,
 	getApiCatalogDocument,

--- a/services/site/app/utils/api-catalog.server.ts
+++ b/services/site/app/utils/api-catalog.server.ts
@@ -28,6 +28,15 @@ function getAbsoluteUrl(origin: string, pathname: string) {
 	return pathname === '/' ? origin : `${origin}${pathname}`
 }
 
+function escapeHtml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;')
+}
+
 function createJsonResponse(
 	body: unknown,
 	{
@@ -309,6 +318,11 @@ function getApiDocsHtml(request: Request) {
 	const healthcheckUrl = getAbsoluteUrl(origin, healthcheckPath)
 	const searchUrl = `${getAbsoluteUrl(origin, '/resources/search')}?query=react`
 	const blogUrl = getAbsoluteUrl(origin, '/blog.json')
+	const safeCatalogUrl = escapeHtml(catalogUrl)
+	const safeOpenApiUrl = escapeHtml(openApiUrl)
+	const safeHealthcheckUrl = escapeHtml(healthcheckUrl)
+	const safeSearchUrl = escapeHtml(searchUrl)
+	const safeBlogUrl = escapeHtml(blogUrl)
 
 	return `<!doctype html>
 <html lang="en">
@@ -364,9 +378,9 @@ function getApiDocsHtml(request: Request) {
       <div class="card">
         <h2>Discovery</h2>
         <ul>
-          <li><a href="${catalogUrl}"><code>${catalogUrl}</code></a> - RFC 9727 API catalog</li>
-          <li><a href="${openApiUrl}"><code>${openApiUrl}</code></a> - OpenAPI 3.1 description</li>
-          <li><a href="${healthcheckUrl}"><code>${healthcheckUrl}</code></a> - Health endpoint</li>
+          <li><a href="${safeCatalogUrl}"><code>${safeCatalogUrl}</code></a> - RFC 9727 API catalog</li>
+          <li><a href="${safeOpenApiUrl}"><code>${safeOpenApiUrl}</code></a> - OpenAPI 3.1 description</li>
+          <li><a href="${safeHealthcheckUrl}"><code>${safeHealthcheckUrl}</code></a> - Health endpoint</li>
         </ul>
       </div>
 
@@ -381,10 +395,10 @@ function getApiDocsHtml(request: Request) {
 
       <div class="card">
         <h2>Quick examples</h2>
-        <pre>curl -H 'Accept: application/linkset+json' ${catalogUrl}
-curl ${openApiUrl}
-curl ${searchUrl}
-curl ${blogUrl}</pre>
+        <pre>curl -H 'Accept: application/linkset+json' ${safeCatalogUrl}
+curl ${safeOpenApiUrl}
+curl ${safeSearchUrl}
+curl ${safeBlogUrl}</pre>
       </div>
     </main>
   </body>
@@ -407,5 +421,6 @@ export {
 	getOpenApiDocument,
 	getOpenApiResponse,
 	linksetContentType,
+	openApiPath,
 	openApiContentType,
 }

--- a/services/site/app/utils/call-kent-published-email.ts
+++ b/services/site/app/utils/call-kent-published-email.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from './misc.ts'
+
 const callKentEpisodeArtworkSize = 200
 
 type GetPublishedCallKentEpisodeEmailParams = {
@@ -5,15 +7,6 @@ type GetPublishedCallKentEpisodeEmailParams = {
 	episodeTitle: string
 	episodeUrl: string
 	imageUrl?: string | null
-}
-
-function escapeHtml(value: string) {
-	return value
-		.replaceAll('&', '&amp;')
-		.replaceAll('<', '&lt;')
-		.replaceAll('>', '&gt;')
-		.replaceAll('"', '&quot;')
-		.replaceAll("'", '&#39;')
 }
 
 function getPublishedCallKentEpisodeEmail({

--- a/services/site/app/utils/misc.ts
+++ b/services/site/app/utils/misc.ts
@@ -102,6 +102,15 @@ export function getErrorStack(
 	return fallback
 }
 
+export function escapeHtml(value: string) {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;')
+}
+
 export function assertNonNull<PossibleNullType>(
 	possibleNull: PossibleNullType,
 	errorMessage: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- publish `/.well-known/api-catalog` as `application/linkset+json` with RFC 9727 profile metadata
- add linked `/openapi.json` and `/.well-known/api-docs` discovery endpoints backed by shared server-side builders
- add focused backend coverage for the catalog, OpenAPI, and docs responses

## Testing
- `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/api-catalog.server.test.ts`
- `npm run typecheck --workspace kentcdodds.com`
- live `curl` checks against `http://localhost:3000/.well-known/api-catalog`, `http://localhost:3000/openapi.json`, `http://localhost:3000/.well-known/api-docs`, and `http://localhost:3000/healthcheck`
- repo pre-push gate via `git push -u origin cursor/api-catalog-b7f9` (ran `npm run test:all` successfully after installing Playwright browsers)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ed89d0-f952-4b91-a536-ea303fedb7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ed89d0-f952-4b91-a536-ea303fedb7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced RFC 9727 API catalog at /.well-known/api-catalog
  * Added OpenAPI 3.1 JSON at /openapi.json documenting public endpoints
  * Created an API docs page at /.well-known/api-docs with discovery links and examples

* **Tests**
  * Added tests validating API catalog, OpenAPI output, and docs responses

* **Chores**
  * Added shared HTML-escape utility and switched email generation to use it
<!-- end of auto-generated comment: release notes by coderabbit.ai -->