### PR TITLE
Add homepage agent discovery link headers

### DIFF
--- a/services/site/app/entry.server.tsx
+++ b/services/site/app/entry.server.tsx
@@ -11,6 +11,10 @@ import {
 	type LoaderFunctionArgs,
 	type HandleDocumentRequestFunction,
 } from 'react-router'
+import {
+	appendAgentDiscoveryHeaders,
+	shouldAppendAgentDiscoveryHeaders,
+} from '#app/utils/agent-discovery.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
 import { routes as otherRoutes } from './other-routes.server.ts'
 import { getEnv, getPublicEnv, init } from './utils/env.server.ts'
@@ -55,6 +59,9 @@ export default async function handleDocumentRequest(...args: DocRequestArgs) {
 		'Link',
 		'<https://res.cloudinary.com>; rel="preconnect"',
 	)
+	if (shouldAppendAgentDiscoveryHeaders(request)) {
+		appendAgentDiscoveryHeaders(responseHeaders)
+	}
 
 	// If the request is from a bot, we want to wait for the full
 	// response to render before sending it to the client. This

--- a/services/site/app/routes/[.]well-known/api-catalog.ts
+++ b/services/site/app/routes/[.]well-known/api-catalog.ts
@@ -1,4 +1,3 @@
-import { data as json } from 'react-router'
 import {
 	appendApiCatalogHeaders,
 	getAgentApiCatalog,
@@ -13,5 +12,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 	})
 	appendApiCatalogHeaders(headers)
 
-	return json(getAgentApiCatalog(request), { headers })
+	const string = JSON.stringify(getAgentApiCatalog(request))
+	headers.set('Content-Length', String(Buffer.byteLength(string)))
+	return new Response(string, { headers })
 }

--- a/services/site/app/routes/[.]well-known/api-catalog.ts
+++ b/services/site/app/routes/[.]well-known/api-catalog.ts
@@ -1,0 +1,17 @@
+import { data as json } from 'react-router'
+import {
+	appendApiCatalogHeaders,
+	getAgentApiCatalog,
+} from '#app/utils/agent-discovery.ts'
+import { type Route } from './+types/api-catalog'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const headers = new Headers({
+		'Cache-Control': 'public, max-age=3600',
+		'Content-Type':
+			'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+	})
+	appendApiCatalogHeaders(headers)
+
+	return json(getAgentApiCatalog(request), { headers })
+}

--- a/services/site/app/utils/__tests__/agent-discovery.test.ts
+++ b/services/site/app/utils/__tests__/agent-discovery.test.ts
@@ -29,7 +29,11 @@ test('only the homepage gets agent discovery headers', () => {
 })
 
 test('api catalog includes machine-readable agent resources', () => {
-	const catalog = getAgentApiCatalog(new Request('https://kentcdodds.com/'))
+	const catalog = getAgentApiCatalog(
+		new Request('https://kentcdodds.com/', {
+			headers: { host: 'kentcdodds.com' },
+		}),
+	)
 
 	expect(catalog.linkset[0]?.anchor).toBe(
 		'https://kentcdodds.com/.well-known/api-catalog',

--- a/services/site/app/utils/__tests__/agent-discovery.test.ts
+++ b/services/site/app/utils/__tests__/agent-discovery.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest'
+import {
+	appendAgentDiscoveryHeaders,
+	appendApiCatalogHeaders,
+	getAgentApiCatalog,
+	shouldAppendAgentDiscoveryHeaders,
+} from '../agent-discovery.ts'
+
+test('appends homepage discovery links for useful agent resources', () => {
+	const headers = new Headers()
+
+	appendAgentDiscoveryHeaders(headers)
+
+	const linkHeader = headers.get('Link')
+
+	expect(linkHeader).toContain('</.well-known/api-catalog>; rel="api-catalog"')
+	expect(linkHeader).toContain('</about-mcp>; rel="service-doc"')
+})
+
+test('only the homepage gets agent discovery headers', () => {
+	expect(
+		shouldAppendAgentDiscoveryHeaders(new Request('https://kentcdodds.com/')),
+	).toBe(true)
+	expect(
+		shouldAppendAgentDiscoveryHeaders(
+			new Request('https://kentcdodds.com/about'),
+		),
+	).toBe(false)
+})
+
+test('api catalog includes machine-readable agent resources', () => {
+	const catalog = getAgentApiCatalog(new Request('https://kentcdodds.com/'))
+
+	expect(catalog.linkset[0]?.anchor).toBe(
+		'https://kentcdodds.com/.well-known/api-catalog',
+	)
+	expect(catalog.linkset[0]?.item).toEqual([
+		expect.objectContaining({ href: 'https://kentcdodds.com/mcp' }),
+	])
+	expect(catalog.linkset[1]).toEqual(
+		expect.objectContaining({
+			anchor: 'https://kentcdodds.com/mcp',
+			describedby: expect.arrayContaining([
+				expect.objectContaining({
+					href: 'https://kentcdodds.com/.well-known/oauth-protected-resource',
+				}),
+				expect.objectContaining({
+					href: 'https://kentcdodds.com/.well-known/oauth-authorization-server',
+				}),
+			]),
+			'service-doc': expect.arrayContaining([
+				expect.objectContaining({ href: 'https://kentcdodds.com/about-mcp' }),
+			]),
+		}),
+	)
+})
+
+test('api catalog responses advertise themselves with api-catalog relation', () => {
+	const headers = new Headers()
+
+	appendApiCatalogHeaders(headers)
+
+	expect(headers.get('Link')).toContain(
+		'</.well-known/api-catalog>; rel="api-catalog"',
+	)
+})

--- a/services/site/app/utils/agent-discovery.ts
+++ b/services/site/app/utils/agent-discovery.ts
@@ -19,12 +19,18 @@ const homepageAgentDiscoveryLinks = [
 	},
 ] as const
 
+type HomepageAgentDiscoveryLink = (typeof homepageAgentDiscoveryLinks)[number]
+
+function formatAgentDiscoveryLinkHeader(link: HomepageAgentDiscoveryLink) {
+	const params = [`rel="${link.rel}"`, `type="${link.type}"`]
+	if ('profile' in link) params.push(`profile="${link.profile}"`)
+	if (link.title) params.push(`title="${link.title}"`)
+	return `<${link.href}>; ${params.join('; ')}`
+}
+
 export function appendAgentDiscoveryHeaders(headers: Headers) {
 	for (const link of homepageAgentDiscoveryLinks) {
-		const params = [`rel="${link.rel}"`, `type="${link.type}"`]
-		if ('profile' in link) params.push(`profile="${link.profile}"`)
-		if (link.title) params.push(`title="${link.title}"`)
-		headers.append('Link', `<${link.href}>; ${params.join('; ')}`)
+		headers.append('Link', formatAgentDiscoveryLinkHeader(link))
 	}
 }
 
@@ -33,10 +39,11 @@ export function shouldAppendAgentDiscoveryHeaders(request: Request) {
 }
 
 export function appendApiCatalogHeaders(headers: Headers) {
-	headers.append(
-		'Link',
-		`</.well-known/api-catalog>; rel="api-catalog"; type="${apiCatalogMediaType}"; profile="${apiCatalogProfileUri}"; title="kentcdodds.com API catalog"`,
+	const apiCatalogLink = homepageAgentDiscoveryLinks.find(
+		(link) => link.rel === 'api-catalog',
 	)
+	if (!apiCatalogLink) return
+	headers.append('Link', formatAgentDiscoveryLinkHeader(apiCatalogLink))
 }
 
 export function getAgentApiCatalog(request: Request) {

--- a/services/site/app/utils/agent-discovery.ts
+++ b/services/site/app/utils/agent-discovery.ts
@@ -1,13 +1,14 @@
 import { getDomainUrl } from './misc.ts'
 
-const apiCatalogMediaType =
-	'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"'
+const apiCatalogMediaType = 'application/linkset+json'
+const apiCatalogProfileUri = 'https://www.rfc-editor.org/info/rfc9727'
 
 const homepageAgentDiscoveryLinks = [
 	{
 		href: '/.well-known/api-catalog',
 		rel: 'api-catalog',
 		type: apiCatalogMediaType,
+		profile: apiCatalogProfileUri,
 		title: 'kentcdodds.com API catalog',
 	},
 	{
@@ -21,6 +22,7 @@ const homepageAgentDiscoveryLinks = [
 export function appendAgentDiscoveryHeaders(headers: Headers) {
 	for (const link of homepageAgentDiscoveryLinks) {
 		const params = [`rel="${link.rel}"`, `type="${link.type}"`]
+		if ('profile' in link) params.push(`profile="${link.profile}"`)
 		if (link.title) params.push(`title="${link.title}"`)
 		headers.append('Link', `<${link.href}>; ${params.join('; ')}`)
 	}
@@ -33,7 +35,7 @@ export function shouldAppendAgentDiscoveryHeaders(request: Request) {
 export function appendApiCatalogHeaders(headers: Headers) {
 	headers.append(
 		'Link',
-		`</.well-known/api-catalog>; rel="api-catalog"; type="${apiCatalogMediaType}"; title="kentcdodds.com API catalog"`,
+		`</.well-known/api-catalog>; rel="api-catalog"; type="${apiCatalogMediaType}"; profile="${apiCatalogProfileUri}"; title="kentcdodds.com API catalog"`,
 	)
 }
 

--- a/services/site/app/utils/agent-discovery.ts
+++ b/services/site/app/utils/agent-discovery.ts
@@ -1,0 +1,69 @@
+import { getDomainUrl } from './misc.ts'
+
+const apiCatalogMediaType =
+	'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"'
+
+const homepageAgentDiscoveryLinks = [
+	{
+		href: '/.well-known/api-catalog',
+		rel: 'api-catalog',
+		type: apiCatalogMediaType,
+		title: 'kentcdodds.com API catalog',
+	},
+	{
+		href: '/about-mcp',
+		rel: 'service-doc',
+		type: 'text/html; charset=UTF-8',
+		title: 'MCP usage documentation',
+	},
+] as const
+
+export function appendAgentDiscoveryHeaders(headers: Headers) {
+	for (const link of homepageAgentDiscoveryLinks) {
+		const params = [`rel="${link.rel}"`, `type="${link.type}"`]
+		if (link.title) params.push(`title="${link.title}"`)
+		headers.append('Link', `<${link.href}>; ${params.join('; ')}`)
+	}
+}
+
+export function shouldAppendAgentDiscoveryHeaders(request: Request) {
+	return new URL(request.url).pathname === '/'
+}
+
+export function appendApiCatalogHeaders(headers: Headers) {
+	headers.append(
+		'Link',
+		`</.well-known/api-catalog>; rel="api-catalog"; type="${apiCatalogMediaType}"; title="kentcdodds.com API catalog"`,
+	)
+}
+
+export function getAgentApiCatalog(request: Request) {
+	const origin = getDomainUrl(request)
+	return {
+		linkset: [
+			{
+				anchor: `${origin}/.well-known/api-catalog`,
+				item: [{ href: `${origin}/mcp` }],
+			},
+			{
+				anchor: `${origin}/mcp`,
+				'service-doc': [
+					{
+						href: `${origin}/about-mcp`,
+						type: 'text/html',
+					},
+				],
+				describedby: [
+					{
+						href: `${origin}/.well-known/oauth-protected-resource`,
+						type: 'application/json',
+					},
+					{
+						href: `${origin}/.well-known/oauth-authorization-server`,
+						type: 'application/json',
+					},
+				],
+			},
+		],
+	} as const
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add homepage `Link` headers for agent discovery using registered `api-catalog` and `service-doc` relations
- add a new `/.well-known/api-catalog` endpoint that returns an RFC 9727-style `application/linkset+json` catalog for the site MCP surface
- cover the discovery helper with focused regression tests and fix the link header syntax after live validation

## Testing
- `npm run lint --workspace kentcdodds.com`
- `npm run test --workspace kentcdodds.com`
- started the site locally with mock search worker env and verified live response headers from `/` and `/.well-known/api-catalog`

## Notes
- the live validation confirmed the homepage now returns `Link` headers for `/.well-known/api-catalog` and `/about-mcp`, and the catalog endpoint self-advertises with `rel="api-catalog"`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ded53bc4-b976-434e-8cdb-4b62d078f85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ded53bc4-b976-434e-8cdb-4b62d078f85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a machine-readable /.well-known/api-catalog endpoint (RFC 9727) with caching.
  * Homepage now emits discovery Link headers so clients can locate API specs, auth endpoints, and service documents.
* **Tests**
  * Added tests validating discovery headers, api-catalog contents, and when homepage discovery is advertised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->