### PR TITLE
Fix agent readiness discovery endpoints

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -148,8 +148,10 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-node${{ env.NODE_VERSION }}-
 
-      - name: 🎬 Setup ffmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+      - name: 🎬 Install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
 
       - name: 🌐 Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
+++ b/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
@@ -1,15 +1,48 @@
 // @vitest-environment node
 import { expect, test } from 'vitest'
+import {
+	getContentSearchSkillDigest,
+	getContentSearchSkillMarkdown,
+} from '#app/utils/agent-skills.ts'
+import { loader as skillIndexLoader } from '../agent-skills.index[.]json.ts'
+import { loader as skillMarkdownLoader } from '../agent-skills.content-search.SKILL[.]md.ts'
 
-import { loader } from '../agent-skills.index[.]json.ts'
-
-test('loader returns the placeholder agent skills discovery index', async () => {
-	const response = await loader()
+test('loader returns a populated agent skills discovery index', async () => {
+	const request = new Request(
+		'https://kentcdodds.com/.well-known/agent-skills/index.json',
+		{
+			headers: { host: 'kentcdodds.com' },
+		},
+	)
+	const response = await skillIndexLoader({ request } as { request: Request })
 	const payload = await response.json()
 
 	expect(response.headers.get('Content-Type')).toContain('application/json')
+	expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600')
 	expect(payload).toEqual({
 		$schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
-		skills: [],
+		skills: [
+			{
+				name: 'content-search',
+				type: 'skill-md',
+				description:
+					'Find relevant kentcdodds.com content and retrieve it from canonical, agent-friendly endpoints.',
+				url: 'https://kentcdodds.com/.well-known/agent-skills/content-search/SKILL.md',
+				digest: getContentSearchSkillDigest(),
+			},
+		],
 	})
+})
+
+test('skill markdown route serves the same artifact referenced by the index', async () => {
+	const response = await skillMarkdownLoader()
+	const body = await response.text()
+
+	expect(response.headers.get('Content-Type')).toContain('text/markdown')
+	expect(response.headers.get('Content-Digest')).toBe(
+		getContentSearchSkillDigest(),
+	)
+	expect(body).toBe(getContentSearchSkillMarkdown())
+	expect(body).toContain('https://kentcdodds.com/blog.json')
+	expect(body).toContain('Accept: text/markdown')
 })

--- a/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
+++ b/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { expect, test } from 'vitest'
 import {
+	getContentSearchSkillContentDigest,
 	getContentSearchSkillDigest,
 	getContentSearchSkillMarkdown,
 } from '#app/utils/agent-skills.ts'
@@ -40,7 +41,7 @@ test('skill markdown route serves the same artifact referenced by the index', as
 
 	expect(response.headers.get('Content-Type')).toContain('text/markdown')
 	expect(response.headers.get('Content-Digest')).toBe(
-		getContentSearchSkillDigest(),
+		getContentSearchSkillContentDigest(),
 	)
 	expect(body).toBe(getContentSearchSkillMarkdown())
 	expect(body).toContain('https://kentcdodds.com/search?query=<terms>')

--- a/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
+++ b/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
@@ -43,6 +43,6 @@ test('skill markdown route serves the same artifact referenced by the index', as
 		getContentSearchSkillDigest(),
 	)
 	expect(body).toBe(getContentSearchSkillMarkdown())
-	expect(body).toContain('https://kentcdodds.com/blog.json')
+	expect(body).toContain('https://kentcdodds.com/search?query=<terms>')
 	expect(body).toContain('Accept: text/markdown')
 })

--- a/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
+++ b/services/site/app/routes/[.]well-known/__tests__/agent-skills-index.test.ts
@@ -1,12 +1,22 @@
 // @vitest-environment node
+import { createHash } from 'node:crypto'
 import { expect, test } from 'vitest'
 import {
-	getContentSearchSkillContentDigest,
 	getContentSearchSkillDigest,
 	getContentSearchSkillMarkdown,
 } from '#app/utils/agent-skills.ts'
 import { loader as skillIndexLoader } from '../agent-skills.index[.]json.ts'
 import { loader as skillMarkdownLoader } from '../agent-skills.content-search.SKILL[.]md.ts'
+import { type Route as IndexRoute } from '../+types/agent-skills.index[.]json'
+
+function createIndexLoaderArgs(request: Request): IndexRoute.LoaderArgs {
+	return {
+		context: {},
+		params: {},
+		request,
+		unstable_pattern: '/.well-known/agent-skills/index.json',
+	}
+}
 
 test('loader returns a populated agent skills discovery index', async () => {
 	const request = new Request(
@@ -15,7 +25,7 @@ test('loader returns a populated agent skills discovery index', async () => {
 			headers: { host: 'kentcdodds.com' },
 		},
 	)
-	const response = await skillIndexLoader({ request } as { request: Request })
+	const response = await skillIndexLoader(createIndexLoaderArgs(request))
 	const payload = await response.json()
 
 	expect(response.headers.get('Content-Type')).toContain('application/json')
@@ -38,11 +48,12 @@ test('loader returns a populated agent skills discovery index', async () => {
 test('skill markdown route serves the same artifact referenced by the index', async () => {
 	const response = await skillMarkdownLoader()
 	const body = await response.text()
+	const expectedContentDigest = `sha-256=:${createHash('sha256')
+		.update(getContentSearchSkillMarkdown(), 'utf8')
+		.digest('base64')}:`
 
 	expect(response.headers.get('Content-Type')).toContain('text/markdown')
-	expect(response.headers.get('Content-Digest')).toBe(
-		getContentSearchSkillContentDigest(),
-	)
+	expect(response.headers.get('Content-Digest')).toBe(expectedContentDigest)
 	expect(body).toBe(getContentSearchSkillMarkdown())
 	expect(body).toContain('https://kentcdodds.com/search?query=<terms>')
 	expect(body).toContain('Accept: text/markdown')

--- a/services/site/app/routes/[.]well-known/agent-skills.content-search.SKILL[.]md.ts
+++ b/services/site/app/routes/[.]well-known/agent-skills.content-search.SKILL[.]md.ts
@@ -1,5 +1,5 @@
 import {
-	getContentSearchSkillDigest,
+	getContentSearchSkillContentDigest,
 	getContentSearchSkillMarkdown,
 } from '#app/utils/agent-skills.ts'
 
@@ -9,7 +9,7 @@ export function loader() {
 	return new Response(markdown, {
 		headers: {
 			'Cache-Control': 'public, max-age=3600',
-			'Content-Digest': getContentSearchSkillDigest(),
+			'Content-Digest': getContentSearchSkillContentDigest(),
 			'Content-Length': String(Buffer.byteLength(markdown)),
 			'Content-Type': 'text/markdown; charset=utf-8',
 		},

--- a/services/site/app/routes/[.]well-known/agent-skills.content-search.SKILL[.]md.ts
+++ b/services/site/app/routes/[.]well-known/agent-skills.content-search.SKILL[.]md.ts
@@ -1,0 +1,17 @@
+import {
+	getContentSearchSkillDigest,
+	getContentSearchSkillMarkdown,
+} from '#app/utils/agent-skills.ts'
+
+export function loader() {
+	const markdown = getContentSearchSkillMarkdown()
+
+	return new Response(markdown, {
+		headers: {
+			'Cache-Control': 'public, max-age=3600',
+			'Content-Digest': getContentSearchSkillDigest(),
+			'Content-Length': String(Buffer.byteLength(markdown)),
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
+	})
+}

--- a/services/site/app/routes/[.]well-known/agent-skills.index[.]json.ts
+++ b/services/site/app/routes/[.]well-known/agent-skills.index[.]json.ts
@@ -1,6 +1,7 @@
 import { getAgentSkillsDiscoveryDocument } from '#app/utils/agent-skills.ts'
+import { type Route } from './+types/agent-skills.index[.]json'
 
-export function loader({ request }: { request: Request }) {
+export function loader({ request }: Route.LoaderArgs) {
 	const body = JSON.stringify(getAgentSkillsDiscoveryDocument(request))
 
 	return new Response(body, {

--- a/services/site/app/routes/[.]well-known/agent-skills.index[.]json.ts
+++ b/services/site/app/routes/[.]well-known/agent-skills.index[.]json.ts
@@ -1,13 +1,11 @@
-const agentSkillsDiscoveryDocument = {
-	$schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
-	skills: [],
-} as const
+import { getAgentSkillsDiscoveryDocument } from '#app/utils/agent-skills.ts'
 
-export function loader() {
-	const body = JSON.stringify(agentSkillsDiscoveryDocument)
+export function loader({ request }: { request: Request }) {
+	const body = JSON.stringify(getAgentSkillsDiscoveryDocument(request))
 
 	return new Response(body, {
 		headers: {
+			'Cache-Control': 'public, max-age=3600',
 			'Content-Length': String(Buffer.byteLength(body)),
 			'Content-Type': 'application/json',
 		},

--- a/services/site/app/utils/agent-skills.ts
+++ b/services/site/app/utils/agent-skills.ts
@@ -41,6 +41,11 @@ function createSha256Digest(contents: string) {
 	return `sha256:${createHash('sha256').update(contents, 'utf8').digest('hex')}`
 }
 
+function createSha256ContentDigest(contents: string) {
+	const digest = createHash('sha256').update(contents, 'utf8').digest('base64')
+	return `sha-256=:${digest}:`
+}
+
 export function getAgentSkillsDiscoveryDocument(request: Request) {
 	const origin = getDomainUrl(request)
 
@@ -62,4 +67,8 @@ export function getContentSearchSkillMarkdown() {
 
 export function getContentSearchSkillDigest() {
 	return createSha256Digest(contentSearchSkill.markdown)
+}
+
+export function getContentSearchSkillContentDigest() {
+	return createSha256ContentDigest(contentSearchSkill.markdown)
 }

--- a/services/site/app/utils/agent-skills.ts
+++ b/services/site/app/utils/agent-skills.ts
@@ -4,13 +4,15 @@ import { getDomainUrl } from './misc.ts'
 const agentSkillsDiscoverySchemaUrl =
 	'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
 
-const contentSearchSkill = {
-	name: 'content-search',
-	type: 'skill-md',
-	description:
-		'Find relevant kentcdodds.com content and retrieve it from canonical, agent-friendly endpoints.',
-	path: '/.well-known/agent-skills/content-search/SKILL.md',
-	markdown: `---
+function createSha256Digest(contents: string) {
+	return `sha256:${createHash('sha256').update(contents, 'utf8').digest('hex')}`
+}
+
+function createContentDigestHeader(contents: string) {
+	return `sha-256=:${createHash('sha256').update(contents, 'utf8').digest('base64')}:`
+}
+
+const contentSearchSkillMarkdown = `---
 name: content-search
 description: Search kentcdodds.com content quickly and prefer canonical, agent-friendly sources.
 ---
@@ -32,23 +34,20 @@ Use this skill when you need articles, podcast episodes, or other published cont
 - Prefer \`/blog/\` articles when the user wants detailed written guidance.
 - Use the search results page to shortlist candidates before opening full pages.
 - If several results match, prefer the newest relevant post unless the user asks for historical context.
-`,
+`
+
+const contentSearchSkill = {
+	name: 'content-search',
+	type: 'skill-md',
+	description:
+		'Find relevant kentcdodds.com content and retrieve it from canonical, agent-friendly endpoints.',
+	path: '/.well-known/agent-skills/content-search/SKILL.md',
+	markdown: contentSearchSkillMarkdown,
+	digest: createSha256Digest(contentSearchSkillMarkdown),
+	contentDigest: createContentDigestHeader(contentSearchSkillMarkdown),
 } as const
 
 const agentSkillDefinitions = [contentSearchSkill] as const
-
-function createSha256Digest(contents: string) {
-	return `sha256:${createHash('sha256').update(contents, 'utf8').digest('hex')}`
-}
-
-function createContentDigestHeader(contents: string) {
-	return `sha-256=:${createHash('sha256').update(contents, 'utf8').digest('base64')}:`
-}
-
-const contentSearchSkillDigest = createSha256Digest(contentSearchSkill.markdown)
-const contentSearchSkillContentDigest = createContentDigestHeader(
-	contentSearchSkill.markdown,
-)
 export function getAgentSkillsDiscoveryDocument(request: Request) {
 	const origin = getDomainUrl(request)
 
@@ -59,10 +58,7 @@ export function getAgentSkillsDiscoveryDocument(request: Request) {
 			type: skill.type,
 			description: skill.description,
 			url: `${origin}${skill.path}`,
-			digest:
-				skill.name === contentSearchSkill.name
-					? contentSearchSkillDigest
-					: createSha256Digest(skill.markdown),
+			digest: skill.digest,
 		})),
 	} as const
 }
@@ -72,9 +68,9 @@ export function getContentSearchSkillMarkdown() {
 }
 
 export function getContentSearchSkillDigest() {
-	return contentSearchSkillDigest
+	return contentSearchSkill.digest
 }
 
 export function getContentSearchSkillContentDigest() {
-	return contentSearchSkillContentDigest
+	return contentSearchSkill.contentDigest
 }

--- a/services/site/app/utils/agent-skills.ts
+++ b/services/site/app/utils/agent-skills.ts
@@ -21,18 +21,17 @@ Use this skill when you need articles, podcast episodes, or other published cont
 
 ## Preferred workflow
 
-1. Fetch \`https://kentcdodds.com/blog.json\` first to enumerate blog posts with titles, descriptions, categories, dates, and canonical URLs.
-2. If the request might involve non-blog pages, fetch \`https://kentcdodds.com/sitemap.xml\` to discover canonical URLs across the site.
-3. If you need topical matching, query \`https://kentcdodds.com/search?query=<terms>\` and review the highest-signal results.
-4. Fetch the canonical page that best matches the request.
-5. When reading a page, prefer \`Accept: text/markdown\` so the site can return markdown instead of HTML when available.
+1. Query \`https://kentcdodds.com/search?query=<terms>\` first and review the highest-signal results.
+2. Fetch the canonical page that best matches the request.
+3. If the request might involve broader site discovery or you need alternate candidates, fetch \`https://kentcdodds.com/sitemap.xml\`.
+4. When reading a page, prefer \`Accept: text/markdown\` so the site can return markdown instead of HTML when available.
 
 ## Selection heuristics
 
 - Prefer canonical \`https://kentcdodds.com\` URLs over mirrors, embeds, or syndicated copies.
 - Prefer \`/blog/\` articles when the user wants detailed written guidance.
-- Use titles, descriptions, and categories from \`blog.json\` to narrow candidates before opening full pages.
-- If several posts match, prefer the newest relevant post unless the user asks for historical context.
+- Use the search results page to shortlist candidates before opening full pages.
+- If several results match, prefer the newest relevant post unless the user asks for historical context.
 `,
 } as const
 

--- a/services/site/app/utils/agent-skills.ts
+++ b/services/site/app/utils/agent-skills.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto'
+import { getDomainUrl } from './misc.ts'
+
+const agentSkillsDiscoverySchemaUrl =
+	'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
+
+const contentSearchSkill = {
+	name: 'content-search',
+	type: 'skill-md',
+	description:
+		'Find relevant kentcdodds.com content and retrieve it from canonical, agent-friendly endpoints.',
+	path: '/.well-known/agent-skills/content-search/SKILL.md',
+	markdown: `---
+name: content-search
+description: Search kentcdodds.com content quickly and prefer canonical, agent-friendly sources.
+---
+
+# Search kentcdodds.com content
+
+Use this skill when you need articles, podcast episodes, or other published content from kentcdodds.com.
+
+## Preferred workflow
+
+1. Fetch \`https://kentcdodds.com/blog.json\` first to enumerate blog posts with titles, descriptions, categories, dates, and canonical URLs.
+2. If the request might involve non-blog pages, fetch \`https://kentcdodds.com/sitemap.xml\` to discover canonical URLs across the site.
+3. If you need topical matching, query \`https://kentcdodds.com/search?query=<terms>\` and review the highest-signal results.
+4. Fetch the canonical page that best matches the request.
+5. When reading a page, prefer \`Accept: text/markdown\` so the site can return markdown instead of HTML when available.
+
+## Selection heuristics
+
+- Prefer canonical \`https://kentcdodds.com\` URLs over mirrors, embeds, or syndicated copies.
+- Prefer \`/blog/\` articles when the user wants detailed written guidance.
+- Use titles, descriptions, and categories from \`blog.json\` to narrow candidates before opening full pages.
+- If several posts match, prefer the newest relevant post unless the user asks for historical context.
+`,
+} as const
+
+const agentSkillDefinitions = [contentSearchSkill] as const
+
+function createSha256Digest(contents: string) {
+	return `sha256:${createHash('sha256').update(contents, 'utf8').digest('hex')}`
+}
+
+export function getAgentSkillsDiscoveryDocument(request: Request) {
+	const origin = getDomainUrl(request)
+
+	return {
+		$schema: agentSkillsDiscoverySchemaUrl,
+		skills: agentSkillDefinitions.map((skill) => ({
+			name: skill.name,
+			type: skill.type,
+			description: skill.description,
+			url: `${origin}${skill.path}`,
+			digest: createSha256Digest(skill.markdown),
+		})),
+	} as const
+}
+
+export function getContentSearchSkillMarkdown() {
+	return contentSearchSkill.markdown
+}
+
+export function getContentSearchSkillDigest() {
+	return createSha256Digest(contentSearchSkill.markdown)
+}

--- a/services/site/app/utils/agent-skills.ts
+++ b/services/site/app/utils/agent-skills.ts
@@ -41,11 +41,14 @@ function createSha256Digest(contents: string) {
 	return `sha256:${createHash('sha256').update(contents, 'utf8').digest('hex')}`
 }
 
-function createSha256ContentDigest(contents: string) {
-	const digest = createHash('sha256').update(contents, 'utf8').digest('base64')
-	return `sha-256=:${digest}:`
+function createContentDigestHeader(contents: string) {
+	return `sha-256=:${createHash('sha256').update(contents, 'utf8').digest('base64')}:`
 }
 
+const contentSearchSkillDigest = createSha256Digest(contentSearchSkill.markdown)
+const contentSearchSkillContentDigest = createContentDigestHeader(
+	contentSearchSkill.markdown,
+)
 export function getAgentSkillsDiscoveryDocument(request: Request) {
 	const origin = getDomainUrl(request)
 
@@ -56,7 +59,10 @@ export function getAgentSkillsDiscoveryDocument(request: Request) {
 			type: skill.type,
 			description: skill.description,
 			url: `${origin}${skill.path}`,
-			digest: createSha256Digest(skill.markdown),
+			digest:
+				skill.name === contentSearchSkill.name
+					? contentSearchSkillDigest
+					: createSha256Digest(skill.markdown),
 		})),
 	} as const
 }
@@ -66,9 +72,9 @@ export function getContentSearchSkillMarkdown() {
 }
 
 export function getContentSearchSkillDigest() {
-	return createSha256Digest(contentSearchSkill.markdown)
+	return contentSearchSkillDigest
 }
 
 export function getContentSearchSkillContentDigest() {
-	return createSha256ContentDigest(contentSearchSkill.markdown)
+	return contentSearchSkillContentDigest
 }

--- a/services/site/public/robots.txt
+++ b/services/site/public/robots.txt
@@ -1,5 +1,10 @@
+# Signals:
+# search - build a search index and show results
+# ai-input - use content as live input for AI answers
+# ai-train - train or fine-tune AI models
+
 User-agent: *
-Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Content-Signal: ai-train=no, search=yes, ai-input=no
 Allow: /
 
 Sitemap: https://kentcdodds.com/sitemap.xml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `robots.txt` to publish the intended search-only `Content-Signal` policy
- publish a generated `content-search` skill at `/.well-known/agent-skills/content-search/SKILL.md`
- populate `/.well-known/agent-skills/index.json` with schema, metadata, and SHA-256 digest for that skill
- direct the generated skill to use the site search endpoint first, then fetch canonical content pages
- add regression tests covering the discovery index and markdown artifact

## Testing
- `npm run lint --workspace kentcdodds.com`
- `npm run test:backend --workspace kentcdodds.com -- app/routes/[.]well-known/__tests__/agent-skills-index.test.ts`
- `npm run typecheck --workspace kentcdodds.com`
- `npm run build --workspace kentcdodds.com`
- `npm run test:browser --workspace kentcdodds.com`
- production-style local verification of `robots.txt`, `/.well-known/agent-skills/index.json`, and `/.well-known/agent-skills/content-search/SKILL.md`

[agent_readiness_checks.log](https://cursor.com/artifacts/c/art-06b1e47e-afe7-4e2f-a7a2-cd16a04a16dd)</TextReference>
[browser_tests.log](https://cursor.com/artifacts/c/art-ef63ebeb-4f94-426d-8009-f1204aef8617)</TextReference>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c84d3697-31cc-4469-9c27-8f0c87eb995e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c84d3697-31cc-4469-9c27-8f0c87eb995e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints that publish an agent skills discovery JSON (now derived from the request origin) and a skill Markdown file, both including Content-Type, Cache-Control, Content-Digest and Content-Length headers with computed digests.

* **Configuration**
  * Updated robots.txt Content-Signal: set ai-train=no, ai-input=no while keeping search=yes.

* **Tests**
  * Added/updated tests to validate discovery JSON, markdown response, headers, and digests.

* **Chores**
  * Adjusted CI step for ffmpeg installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->