### PR TITLE
Handle OPTIONS preflight before React Router

### DIFF
--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -47,7 +47,6 @@ function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (!req.header('Access-Control-Request-Method')) return false
 
 	const existingVary = res.getHeader('Vary')
-	res.setHeader('X-Preflight-Vary-Before', String(existingVary ?? ''))
 	const varyBase = Array.isArray(existingVary)
 		? existingVary
 		: typeof existingVary === 'string'

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -46,8 +46,24 @@ function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (req.method !== 'OPTIONS') return false
 	if (!req.header('Access-Control-Request-Method')) return false
 
-	res.vary('Access-Control-Request-Method')
-	res.vary('Access-Control-Request-Headers')
+	const existingVary = res.getHeader('Vary')
+	const varyBase = Array.isArray(existingVary)
+		? existingVary
+		: typeof existingVary === 'string'
+			? [existingVary]
+			: typeof existingVary === 'number'
+				? [String(existingVary)]
+				: []
+	const varyValues = new Set(
+		varyBase
+			.flatMap((value) => value.split(','))
+			.map((value) => value.trim())
+			.filter(Boolean),
+	)
+	varyValues.add('Origin')
+	varyValues.add('Access-Control-Request-Method')
+	varyValues.add('Access-Control-Request-Headers')
+	res.setHeader('Vary', Array.from(varyValues).join(', '))
 	res.header('Access-Control-Allow-Methods', preflightAllowedMethods)
 	res.header(
 		'Access-Control-Allow-Headers',

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -40,6 +40,20 @@ type ExpressRequestHandler = (
 	next: NextFunction,
 ) => Promise<void>
 
+const preflightAllowedMethods = 'GET,HEAD,PUT,PATCH,POST,DELETE'
+
+function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
+	if (req.method !== 'OPTIONS') return false
+
+	res.header('Access-Control-Allow-Methods', preflightAllowedMethods)
+	res.header(
+		'Access-Control-Allow-Headers',
+		req.header('Access-Control-Request-Headers') || '*',
+	)
+	res.sendStatus(204)
+	return true
+}
+
 function createRemixHeaders(requestHeaders: ExpressRequest['headers']) {
 	const headers = new Headers()
 	for (const [key, values] of Object.entries(requestHeaders)) {
@@ -148,6 +162,8 @@ function createRequestHandlerWithMarkdown({
 		next: NextFunction,
 	) => {
 		try {
+			if (handleOptionsPreflight(req, res)) return
+
 			const request = createRemixRequest(req, res)
 			const loadContext = await getLoadContext?.(req, res)
 			let response = await handleRequest(request, loadContext)

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -46,22 +46,8 @@ function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (req.method !== 'OPTIONS') return false
 	if (!req.header('Access-Control-Request-Method')) return false
 
-	const existingVary = res.getHeader('Vary')
-	const varyBase =
-		typeof existingVary === 'number'
-			? String(existingVary)
-			: Array.isArray(existingVary)
-				? existingVary.join(',')
-				: (existingVary ?? '')
-	const varyValues = new Set(
-		varyBase
-			.split(',')
-			.map((value) => value.trim())
-			.filter(Boolean),
-	)
-	varyValues.add('Access-Control-Request-Method')
-	varyValues.add('Access-Control-Request-Headers')
-	res.setHeader('Vary', Array.from(varyValues).join(', '))
+	res.vary('Access-Control-Request-Method')
+	res.vary('Access-Control-Request-Headers')
 	res.header('Access-Control-Allow-Methods', preflightAllowedMethods)
 	res.header(
 		'Access-Control-Allow-Headers',

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -46,6 +46,8 @@ function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (req.method !== 'OPTIONS') return false
 	if (!req.header('Access-Control-Request-Method')) return false
 
+	res.vary('Access-Control-Request-Method')
+	res.vary('Access-Control-Request-Headers')
 	res.header('Access-Control-Allow-Methods', preflightAllowedMethods)
 	res.header(
 		'Access-Control-Allow-Headers',

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -44,6 +44,7 @@ const preflightAllowedMethods = 'GET,HEAD,PUT,PATCH,POST,DELETE'
 
 function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (req.method !== 'OPTIONS') return false
+	if (!req.header('Access-Control-Request-Method')) return false
 
 	res.header('Access-Control-Allow-Methods', preflightAllowedMethods)
 	res.header(

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -46,8 +46,22 @@ function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (req.method !== 'OPTIONS') return false
 	if (!req.header('Access-Control-Request-Method')) return false
 
-	res.vary('Access-Control-Request-Method')
-	res.vary('Access-Control-Request-Headers')
+	const existingVary = res.getHeader('Vary')
+	const varyBase =
+		typeof existingVary === 'number'
+			? String(existingVary)
+			: Array.isArray(existingVary)
+				? existingVary.join(',')
+				: (existingVary ?? '')
+	const varyValues = new Set(
+		varyBase
+			.split(',')
+			.map((value) => value.trim())
+			.filter(Boolean),
+	)
+	varyValues.add('Access-Control-Request-Method')
+	varyValues.add('Access-Control-Request-Headers')
+	res.setHeader('Vary', Array.from(varyValues).join(', '))
 	res.header('Access-Control-Allow-Methods', preflightAllowedMethods)
 	res.header(
 		'Access-Control-Allow-Headers',

--- a/services/site/server/react-router-express-with-markdown.ts
+++ b/services/site/server/react-router-express-with-markdown.ts
@@ -47,6 +47,7 @@ function handleOptionsPreflight(req: ExpressRequest, res: ExpressResponse) {
 	if (!req.header('Access-Control-Request-Method')) return false
 
 	const existingVary = res.getHeader('Vary')
+	res.setHeader('X-Preflight-Vary-Before', String(existingVary ?? ''))
 	const varyBase = Array.isArray(existingVary)
 		? existingVary
 		: typeof existingVary === 'string'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- treat OPTIONS only as preflight when Access-Control-Request-Method is present
- append Vary for Access-Control-Request-Method and Access-Control-Request-Headers in the preflight handler

## Testing
- npm run test:all (pre-push)
- Raw OPTIONS request via node socket (see walkthrough artifact)

## Notes
- The live dev server response still only lists `Vary: Origin, Access-Control-Request-Headers`; I wasn’t able to get `Access-Control-Request-Method` to appear despite the append calls. Needs follow-up if required by cache policy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8edc876a-0511-4a74-906a-23fe9ef97eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8edc876a-0511-4a74-906a-23fe9ef97eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS preflight handling: OPTIONS preflight requests now return 204, include Allow-Methods and Allow-Headers (echoing requested headers when present), set Vary for method and headers, and short-circuit further request processing to avoid unnecessary downstream work and reduce latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->