### PR TITLE
Add Pragmatic AI appearance to appearances page

### DIFF
--- a/services/site/content/pages/appearances.mdx
+++ b/services/site/content/pages/appearances.mdx
@@ -22,6 +22,7 @@ bannerAlt: Kent talking with Cory House with recording equipment
 
 ### Others:
 
+- [Pragmatic AI with Matt Stauffer](https://pragmaticai.fm): [Kent C. Dodds on MCP and How Product Engineering Might Outlast Coding](https://pragmaticai.fm/episodes/kent-c-dodds-on-mcp-and-how-product-engineering-might-outlast-coding)
 - [Syntax](https://syntax.fm): [The Web's Next Form: MCP UI with Kent C. Dodds](https://syntax.fm/show/973/the-web-s-next-form-mcp-ui-with-kent-c-dodds)
 - [The Programming Podcast](https://www.youtube.com/@TheProgrammingPodcast): [How GREAT Senior Software Engineers Think! (Steal these 9 TIPS!) Kent C. Dodds](https://www.youtube.com/watch?v=kEIG3n5W8_Q&list=PLhSJZbh9flb2wOaiiprOplVF6PQLLL5kP)
 - [Software Huddle](https://www.youtube.com/@SoftwareHuddle): [It's time to build Jarvis with Kent C. Dodds](https://www.youtube.com/watch?v=a5eo0OIJlXo)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Kent's Pragmatic AI with Matt Stauffer podcast appearance to the appearances page
- keep the podcast appearances list in newest-first order by inserting the new entry at the top of the "Others" section

## Testing
- verified the rendered `/appearances` page locally after refresh and confirmed the new entry appears above the existing Syntax entry
- screenshot: ![Appearances page showing Pragmatic AI entry](https://cursor.com/artifacts/c/art-de581d32-81aa-4f5b-a83a-713d2f8febe8)
- video: <a href="https://cursor.com/agents/bc-dead864d-ca4c-4bca-86d5-d6cd9eb2fdcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fappearances-page-pragmatic-ai-entry-clean.mp4"><img src="https://cursor.com/artifacts/c/art-785cd243-d5f9-468c-8862-fd938b018899" alt="appearances-page-pragmatic-ai-entry-clean.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dead864d-ca4c-4bca-86d5-d6cd9eb2fdcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dead864d-ca4c-4bca-86d5-d6cd9eb2fdcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

