### PR TITLE
Add Pragmatic AI with Matt Stauffer podcast appearance

### DIFF
--- a/services/site/content/pages/appearances.mdx
+++ b/services/site/content/pages/appearances.mdx
@@ -22,6 +22,7 @@ bannerAlt: Kent talking with Cory House with recording equipment
 
 ### Others:
 
+- [Pragmatic AI with Matt Stauffer](https://pragmaticai.fm/): [Kent C. Dodds on MCP and How Product Engineering Might Outlast Coding](https://pragmaticai.fm/episodes/kent-c-dodds-on-mcp-and-how-product-engineering-might-outlast-coding)
 - [Syntax](https://syntax.fm): [The Web's Next Form: MCP UI with Kent C. Dodds](https://syntax.fm/show/973/the-web-s-next-form-mcp-ui-with-kent-c-dodds)
 - [The Programming Podcast](https://www.youtube.com/@TheProgrammingPodcast): [How GREAT Senior Software Engineers Think! (Steal these 9 TIPS!) Kent C. Dodds](https://www.youtube.com/watch?v=kEIG3n5W8_Q&list=PLhSJZbh9flb2wOaiiprOplVF6PQLLL5kP)
 - [Software Huddle](https://www.youtube.com/@SoftwareHuddle): [It's time to build Jarvis with Kent C. Dodds](https://www.youtube.com/watch?v=a5eo0OIJlXo)


### PR DESCRIPTION
Adds the appearance on Pragmatic AI (E12, April 22 2026): "Kent C. Dodds on MCP and How Product Engineering Might Outlast Coding"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change; updates a single MDX page by adding one external link with no code or runtime behavior changes.
> 
> **Overview**
> Adds a new entry to `services/site/content/pages/appearances.mdx` under **Podcasts → Others** for the "Pragmatic AI with Matt Stauffer" episode, including links to the show and the specific episode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3748df98db34790b0cbe09b8835337fe4be59ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new podcast appearance listing for the Pragmatic AI episode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->