### PR TITLE
Handle JSON payloads in set-theme action

### DIFF
--- a/services/site/app/routes/action/set-theme.tsx
+++ b/services/site/app/routes/action/set-theme.tsx
@@ -9,7 +9,34 @@ export async function loader() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+	const contentType = request.headers.get('content-type')
+	const isJsonRequest = contentType?.includes('application/json') ?? false
+	const shouldTryJson = isJsonRequest || !contentType
+	if (shouldTryJson) {
+		let jsonPayload: unknown = null
+		try {
+			jsonPayload = await request.clone().json()
+		} catch (jsonError) {
+			if (isJsonRequest) {
+				return json({ error: 'Invalid JSON body.' }, { status: 400 })
+			}
+		}
+
+		if (jsonPayload) {
+			const parsed = ThemeFormSchema.safeParse(jsonPayload)
+			if (!parsed.success) {
+				return json({ result: parsed.error.format() }, { status: 400 })
+			}
+			const { theme } = parsed.data
+			const responseInit = {
+				headers: { 'set-cookie': setTheme(theme) },
+			}
+			return json({ success: true, submission: parsed.data }, responseInit)
+		}
+	}
+
 	const formData = await request.formData()
+
 	const submission = parseWithZod(formData, {
 		schema: ThemeFormSchema,
 	})

--- a/services/site/app/routes/action/set-theme.tsx
+++ b/services/site/app/routes/action/set-theme.tsx
@@ -9,33 +9,15 @@ export async function loader() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-	const contentType = request.headers.get('content-type')
-	const isJsonRequest = contentType?.includes('application/json') ?? false
-	const shouldTryJson = isJsonRequest || !contentType
-	if (shouldTryJson) {
-		let jsonPayload: unknown = null
-		try {
-			jsonPayload = await request.clone().json()
-		} catch (jsonError) {
-			if (isJsonRequest) {
-				return json({ error: 'Invalid JSON body.' }, { status: 400 })
-			}
+	let formData: FormData
+	try {
+		formData = await request.formData()
+	} catch (error) {
+		if (error instanceof TypeError) {
+			return json({ error: 'Invalid form body.' }, { status: 400 })
 		}
-
-		if (jsonPayload) {
-			const parsed = ThemeFormSchema.safeParse(jsonPayload)
-			if (!parsed.success) {
-				return json({ result: parsed.error.format() }, { status: 400 })
-			}
-			const { theme } = parsed.data
-			const responseInit = {
-				headers: { 'set-cookie': setTheme(theme) },
-			}
-			return json({ success: true, submission: parsed.data }, responseInit)
-		}
+		throw error
 	}
-
-	const formData = await request.formData()
 
 	const submission = parseWithZod(formData, {
 		schema: ThemeFormSchema,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- return a 400 response when `/action/set-theme` receives a non-form body
- keep the form submission flow (and validation) unchanged

## Testing
- `npm run test:all`
- `curl -i -X POST http://localhost:3000/action/set-theme -H "Content-Type: application/json" -d '{"theme":"dark"}'`
- Manual: theme toggle in browser

## Artifacts
[theme-toggle-form-success-trim.mp4](https://cursor.com/agents/bc-20890a45-da57-4fcb-879d-e065660e44b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme-toggle-form-success-trim.mp4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20890a45-da57-4fcb-879d-e065660e44b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20890a45-da57-4fcb-879d-e065660e44b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for theme settings. Invalid form submissions now return a clear error message instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->