### PR TITLE
fix: typing error in blog- useMemo & useCallBack

### DIFF
--- a/services/site/content/blog/usememo-and-usecallback/index.mdx
+++ b/services/site/content/blog/usememo-and-usecallback/index.mdx
@@ -466,7 +466,7 @@ function RenderPrimes({ iterations, multiplier }) {
 ```
 
 That could be pretty slow given the right `iterations` or `multiplier` and
-there's not too much you can do about that specifically. You can't automagically
+there's not too much you can do about that specifically. You can't automatically
 make your user's hardware faster. But you _can_ make it so you never have to
 calculate the same value twice in a row, which is what `useMemo` will do for
 you:


### PR DESCRIPTION
This pull request contains a minor change to the wording in the blog post for clarity and professionalism. The term "automagically" was replaced with "automatically" in the `services/site/content/blog/usememo-and-usecallback/index.mdx` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling error in blog post content to improve clarity and accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kentcdodds.com/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->