### PR TITLE
Handle catch-all POST scanner noise as 404

### DIFF
--- a/services/site/app/routes/$.tsx
+++ b/services/site/app/routes/$.tsx
@@ -45,6 +45,10 @@ export async function loader({ request }: { request: Request }) {
 	})
 }
 
+export function action() {
+	return new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/services/site/app/routes/$slug.tsx
+++ b/services/site/app/routes/$slug.tsx
@@ -87,6 +87,27 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 	)
 }
 
+export async function action({ params, request }: Route.ActionArgs) {
+	requireValidSlug(params.slug)
+
+	if (pathedRoutes[new URL(request.url).pathname]) {
+		return new Response('Not found', { status: 404 })
+	}
+
+	const page = await getMdxPage(
+		{ contentDir: 'pages', slug: params.slug },
+		{ request },
+	)
+	if (!page) {
+		return new Response('Not found', { status: 404 })
+	}
+
+	return new Response('Method Not Allowed', {
+		status: 405,
+		headers: { Allow: 'GET, HEAD' },
+	})
+}
+
 export const headers: HeadersFunction = reuseUsefulLoaderHeaders
 
 export const meta = mdxPageMeta

--- a/services/site/app/routes/__tests__/slug-route-action.test.ts
+++ b/services/site/app/routes/__tests__/slug-route-action.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest'
+
+const mdxServerMocks = vi.hoisted(() => ({
+	getMdxPage: vi.fn(),
+}))
+
+vi.mock('#app/utils/mdx.server', () => mdxServerMocks)
+vi.mock('#app/utils/blog.server.ts', () => ({
+	getBlogRecommendations: vi.fn(),
+}))
+vi.mock('#app/utils/not-found-suggestions.server.ts', () => ({
+	getNotFoundSuggestions: vi.fn(),
+}))
+vi.mock('vite-env-only/macros', () => ({
+	serverOnly$: (fn: unknown) => fn,
+}))
+
+import { action } from '../$slug.tsx'
+
+test('slug action returns 404 for scanner POSTs to unknown page slugs', async () => {
+	mdxServerMocks.getMdxPage.mockResolvedValueOnce(null)
+
+	const response = await action({
+		request: new Request('http://localhost/session', { method: 'POST' }),
+		params: { slug: 'session' },
+	} as never)
+
+	expect(response.status).toBe(404)
+	expect(await response.text()).toBe('Not found')
+	expect(mdxServerMocks.getMdxPage).toHaveBeenCalledWith(
+		{ contentDir: 'pages', slug: 'session' },
+		{ request: expect.any(Request) },
+	)
+})
+
+test('slug action returns a normal 405 for unsupported methods to existing pages', async () => {
+	mdxServerMocks.getMdxPage.mockResolvedValueOnce({
+		code: '',
+		frontmatter: {},
+	})
+
+	const response = await action({
+		request: new Request('http://localhost/about', { method: 'POST' }),
+		params: { slug: 'about' },
+	} as never)
+
+	expect(response.status).toBe(405)
+	expect(response.headers.get('Allow')).toBe('GET, HEAD')
+	expect(await response.text()).toBe('Method Not Allowed')
+})

--- a/services/site/app/routes/__tests__/splat-route.test.ts
+++ b/services/site/app/routes/__tests__/splat-route.test.ts
@@ -1,7 +1,11 @@
 import { createStaticHandler } from 'react-router'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
 import { action, loader } from '../$.tsx'
+
+vi.mock('vite-env-only/macros', () => ({
+	serverOnly$: (fn: unknown) => fn,
+}))
 
 type StaticHandlerContext = Awaited<
 	ReturnType<ReturnType<typeof createStaticHandler>['query']>

--- a/services/site/app/routes/__tests__/splat-route.test.ts
+++ b/services/site/app/routes/__tests__/splat-route.test.ts
@@ -18,7 +18,7 @@ type RouteErrorResponse = {
 	error?: unknown
 }
 
-test.each(['/RSC/example.txt', '/session/root/shell', '/session'])(
+test.each(['/RSC/example.txt', '/session/root/shell'])(
 	'catch-all POST to %s returns a normal 404 route response',
 	async (pathname) => {
 		const handler = createStaticHandler([

--- a/services/site/app/routes/__tests__/splat-route.test.ts
+++ b/services/site/app/routes/__tests__/splat-route.test.ts
@@ -1,0 +1,48 @@
+import { createStaticHandler } from 'react-router'
+import { expect, test } from 'vitest'
+
+import { action, loader } from '../$.tsx'
+
+type StaticHandlerContext = Awaited<
+	ReturnType<ReturnType<typeof createStaticHandler>['query']>
+>
+
+type RouteErrorResponse = {
+	status: number
+	internal?: boolean
+	data?: unknown
+	error?: unknown
+}
+
+test.each(['/RSC/example.txt', '/session/root/shell', '/session'])(
+	'catch-all POST to %s returns a normal 404 route response',
+	async (pathname) => {
+		const handler = createStaticHandler([
+			{
+				id: 'routes/$',
+				path: '*',
+				loader,
+				action,
+			},
+		])
+
+		const result = await handler.query(
+			new Request(`http://localhost${pathname}`, { method: 'POST' }),
+		)
+
+		expect(result).not.toBeInstanceOf(Response)
+
+		const context = result as Exclude<StaticHandlerContext, Response>
+		const routeError = context.errors?.['routes/$'] as
+			| RouteErrorResponse
+			| undefined
+
+		expect(context.statusCode).toBe(404)
+		expect(routeError).toMatchObject({
+			status: 404,
+			internal: false,
+			data: 'Not found',
+		})
+		expect(routeError?.error).toBeUndefined()
+	},
+)

--- a/services/site/server/__tests__/splat-post-handling.test.ts
+++ b/services/site/server/__tests__/splat-post-handling.test.ts
@@ -18,7 +18,7 @@ vi.mock('#app/components/arrow-button.tsx', () => ({
 vi.mock('#app/components/blurrable-image.tsx', () => ({
 	BlurrableImage: () => null,
 }))
-vi.mock('#app/components/error-boundary.tsx', () => ({
+vi.mock('#app/components/error-boundary', () => ({
 	GeneralErrorBoundary: () => null,
 }))
 vi.mock('#app/components/errors.tsx', () => ({

--- a/services/site/server/__tests__/splat-post-handling.test.ts
+++ b/services/site/server/__tests__/splat-post-handling.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+import { createRequestHandler, type ServerBuild } from 'react-router'
+import { expect, test, vi } from 'vitest'
+import * as catchAllRoute from '../../app/routes/$.tsx'
+
+vi.mock('#app/components/arrow-button.tsx', () => ({
+	ArrowLink: () => null,
+}))
+vi.mock('#app/components/error-boundary.tsx', () => ({
+	GeneralErrorBoundary: () => null,
+}))
+vi.mock('#app/components/errors.tsx', () => ({
+	ErrorPage: () => null,
+	FourOhFour: () => null,
+}))
+vi.mock('#app/components/kifs.tsx', () => ({
+	Facepalm: () => null,
+}))
+vi.mock('#app/utils/not-found-suggestions.server.ts', () => ({
+	getNotFoundSuggestions: async () => null,
+}))
+
+function createSplatBuild({
+	handleError,
+}: {
+	handleError: NonNullable<ServerBuild['entry']['module']['handleError']>
+}): ServerBuild {
+	return {
+		assets: {
+			entry: { imports: [], module: '/entry.js' },
+			routes: {
+				root: {
+					id: 'root',
+					path: '',
+					module: '/root.js',
+					hasAction: false,
+					hasLoader: false,
+					hasClientAction: false,
+					hasClientLoader: false,
+					hasClientMiddleware: false,
+					hasErrorBoundary: true,
+					clientActionModule: undefined,
+					clientLoaderModule: undefined,
+					clientMiddlewareModule: undefined,
+					hydrateFallbackModule: undefined,
+				},
+				'routes/$': {
+					id: 'routes/$',
+					parentId: 'root',
+					path: '*',
+					module: '/routes/$.js',
+					hasAction: true,
+					hasLoader: true,
+					hasClientAction: false,
+					hasClientLoader: false,
+					hasClientMiddleware: false,
+					hasErrorBoundary: true,
+					clientActionModule: undefined,
+					clientLoaderModule: undefined,
+					clientMiddlewareModule: undefined,
+					hydrateFallbackModule: undefined,
+				},
+			},
+			url: '/build/manifest.js',
+			version: 'test',
+		},
+		entry: {
+			module: {
+				default(_request, responseStatusCode) {
+					return new Response(null, { status: responseStatusCode })
+				},
+				handleError,
+			},
+		},
+		routes: {
+			root: {
+				id: 'root',
+				path: '',
+				module: {
+					default: function RootRoute() {
+						return null
+					},
+					ErrorBoundary: function RootErrorBoundary() {
+						return null
+					},
+				},
+			},
+			'routes/$': {
+				id: 'routes/$',
+				parentId: 'root',
+				path: '*',
+				module: catchAllRoute,
+			},
+		},
+		publicPath: '/build/',
+		assetsBuildDirectory: 'build',
+		future: {
+			unstable_subResourceIntegrity: false,
+			unstable_trailingSlashAwareDataRequests: false,
+			v8_middleware: false,
+		},
+		ssr: true,
+		isSpaMode: false,
+		prerender: [],
+		routeDiscovery: { mode: 'lazy', manifestPath: '/__manifest' },
+	}
+}
+
+test('catch-all route handles scanner POSTs as normal not found responses', async () => {
+	const reportedErrors: Array<unknown> = []
+	const handleRequest = createRequestHandler(
+		createSplatBuild({
+			handleError(error) {
+				reportedErrors.push(error)
+			},
+		}),
+		'production',
+	)
+
+	for (const pathname of ['/RSC/abc.txt', '/session/root/shell', '/session']) {
+		const response = await handleRequest(
+			new Request(`http://localhost${pathname}`, {
+				method: 'POST',
+				headers: { accept: 'text/html' },
+			}),
+		)
+
+		expect(response.status).toBe(404)
+	}
+
+	expect(reportedErrors).toEqual([])
+})

--- a/services/site/server/__tests__/splat-post-handling.test.ts
+++ b/services/site/server/__tests__/splat-post-handling.test.ts
@@ -2,9 +2,21 @@
 import { createRequestHandler, type ServerBuild } from 'react-router'
 import { expect, test, vi } from 'vitest'
 import * as catchAllRoute from '../../app/routes/$.tsx'
+import * as slugRoute from '../../app/routes/$slug.tsx'
+
+const mdxServerMocks = vi.hoisted(() => ({
+	getMdxPage: vi.fn(),
+	getMdxPagesInDirectory: vi.fn(),
+}))
+
+type TestRouteModule = NonNullable<ServerBuild['routes'][string]>['module']
 
 vi.mock('#app/components/arrow-button.tsx', () => ({
 	ArrowLink: () => null,
+	BackLink: () => null,
+}))
+vi.mock('#app/components/blurrable-image.tsx', () => ({
+	BlurrableImage: () => null,
 }))
 vi.mock('#app/components/error-boundary.tsx', () => ({
 	GeneralErrorBoundary: () => null,
@@ -12,12 +24,40 @@ vi.mock('#app/components/error-boundary.tsx', () => ({
 vi.mock('#app/components/errors.tsx', () => ({
 	ErrorPage: () => null,
 	FourOhFour: () => null,
+	FourHundred: () => null,
+}))
+vi.mock('#app/components/grid.tsx', () => ({
+	Grid: () => null,
+}))
+vi.mock('#app/components/typography.tsx', () => ({
+	H2: () => null,
+	H6: () => null,
+}))
+vi.mock('#app/images.tsx', () => ({
+	getImageBuilder: vi.fn(),
+	getImgProps: vi.fn(),
 }))
 vi.mock('#app/components/kifs.tsx', () => ({
 	Facepalm: () => null,
 }))
+vi.mock('#app/other-routes.server.ts', () => ({
+	pathedRoutes: {},
+}))
+vi.mock('#app/utils/blog.server.ts', () => ({
+	getBlogRecommendations: vi.fn(),
+}))
+vi.mock('#app/utils/mdx.server', () => mdxServerMocks)
+vi.mock('#app/utils/mdx.tsx', () => ({
+	getBannerAltProp: vi.fn(),
+	getBannerTitleProp: vi.fn(),
+	mdxPageMeta: vi.fn(),
+	useMdxComponent: () => () => null,
+}))
 vi.mock('#app/utils/not-found-suggestions.server.ts', () => ({
 	getNotFoundSuggestions: async () => null,
+}))
+vi.mock('vite-env-only/macros', () => ({
+	serverOnly$: (fn: unknown) => fn,
 }))
 
 function createSplatBuild({
@@ -35,6 +75,22 @@ function createSplatBuild({
 					module: '/root.js',
 					hasAction: false,
 					hasLoader: false,
+					hasClientAction: false,
+					hasClientLoader: false,
+					hasClientMiddleware: false,
+					hasErrorBoundary: true,
+					clientActionModule: undefined,
+					clientLoaderModule: undefined,
+					clientMiddlewareModule: undefined,
+					hydrateFallbackModule: undefined,
+				},
+				'routes/$slug': {
+					id: 'routes/$slug',
+					parentId: 'root',
+					path: ':slug',
+					module: '/routes/$slug.js',
+					hasAction: true,
+					hasLoader: true,
 					hasClientAction: false,
 					hasClientLoader: false,
 					hasClientMiddleware: false,
@@ -85,6 +141,12 @@ function createSplatBuild({
 					},
 				},
 			},
+			'routes/$slug': {
+				id: 'routes/$slug',
+				parentId: 'root',
+				path: ':slug',
+				module: slugRoute as unknown as TestRouteModule,
+			},
 			'routes/$': {
 				id: 'routes/$',
 				parentId: 'root',
@@ -107,6 +169,7 @@ function createSplatBuild({
 }
 
 test('catch-all route handles scanner POSTs as normal not found responses', async () => {
+	mdxServerMocks.getMdxPage.mockResolvedValue(null)
 	const reportedErrors: Array<unknown> = []
 	const handleRequest = createRequestHandler(
 		createSplatBuild({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add actions to the root splat route and one-segment MDX catch-all route so scanner/bot POSTs return normal 404/405 responses instead of React Router internal no-action errors.
- Preserve normal behavior by returning 404 for unknown scanner paths and 405 with `Allow: GET, HEAD` for real one-segment MDX pages receiving unsupported mutation methods.
- Add focused regressions for the Sentry examples and for the request-handler path to verify `handleError` is not called.

## Sentry

- Project: `kcd-node`
- Issue: `KCD-NODE-YE` / `7422387736`
- Noise pattern: `getInternalRouterError` for scanner `POST` requests such as `/RSC/...txt`, `/session/root/shell`, and `/session`.

## Verification

- `npm run test:backend --workspace kentcdodds.com -- app/routes/__tests__/splat-route.test.ts app/routes/__tests__/slug-route-action.test.ts server/__tests__/splat-post-handling.test.ts`
- Live dev-server POST check: `/RSC/abc.txt`, `/session/root/shell`, and `/session` all returned 404.
- `npm run validate`

## Artifact

<a href="/opt/cursor/artifacts/sentry-post-check.txt">Live POST check output</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a81a38b4-abd0-4e78-ad4b-409d1c5e37e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a81a38b4-abd0-4e78-ad4b-409d1c5e37e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routes now return 404 Not Found for non-existent pages and catch-all paths, and 405 Method Not Allowed (with Allow: GET, HEAD) for unsupported request methods.

* **Tests**
  * Added tests covering POST/method handling for dynamic, catch-all, and server route scenarios to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kentcdodds.com/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->