### PR TITLE
feat(site): add Better with Kent landing page at /better

### DIFF
--- a/services/site/app/components/footer.tsx
+++ b/services/site/app/components/footer.tsx
@@ -70,6 +70,7 @@ function SitemapSection() {
 				<FooterLink name="Home" href="/" />
 				<FooterLink name="Blog" href="/blog" />
 				<FooterLink name="Courses" href="/courses" />
+				<FooterLink name="Better" href="/better" />
 				<FooterLink name="Discord" href="/discord" />
 				<FooterLink name="Chats Podcast" href="/chats" />
 				<FooterLink name="Talks" href="/talks" />

--- a/services/site/app/components/navbar.css
+++ b/services/site/app/components/navbar.css
@@ -65,7 +65,4 @@ body:has(#mobile-menu:popover-open) [popovertarget='mobile-menu'] {
 	.navbar-links [data-nav-item='discord'] {
 		display: none;
 	}
-	.navbar-links [data-nav-item='chats'] {
-		display: none;
-	}
 }

--- a/services/site/app/components/navbar.tsx
+++ b/services/site/app/components/navbar.tsx
@@ -49,6 +49,7 @@ function useNavbarLinks(): {
 			{ id: 'blog', name: 'Blog', to: '/blog' },
 			{ id: 'talks', name: 'Talks', to: '/talks' },
 			{ id: 'courses', name: 'Courses', to: '/courses' },
+			{ id: 'better', name: 'Better', to: '/better' },
 			{ id: 'discord', name: 'Discord', to: '/discord' },
 			{ id: 'chats', name: 'Chats', to: chatsTo, activeTo: '/chats' },
 			{ id: 'calls', name: 'Calls', to: callsTo, activeTo: '/calls' },

--- a/services/site/app/components/navbar.tsx
+++ b/services/site/app/components/navbar.tsx
@@ -41,7 +41,6 @@ function useNavbarLinks(): {
 } {
 	const { latestPodcastSeasonLinks } = useRootData()
 
-	const chatsTo = latestPodcastSeasonLinks?.chats.latestSeasonPath ?? '/chats'
 	const callsTo = latestPodcastSeasonLinks?.calls.latestSeasonPath ?? '/calls'
 
 	const links = React.useMemo<Array<NavbarLinkItem>>(
@@ -51,11 +50,10 @@ function useNavbarLinks(): {
 			{ id: 'courses', name: 'Courses', to: '/courses' },
 			{ id: 'better', name: 'Better', to: '/better' },
 			{ id: 'discord', name: 'Discord', to: '/discord' },
-			{ id: 'chats', name: 'Chats', to: chatsTo, activeTo: '/chats' },
 			{ id: 'calls', name: 'Calls', to: callsTo, activeTo: '/calls' },
 			{ id: 'about', name: 'About', to: '/about' },
 		],
-		[chatsTo, callsTo],
+		[callsTo],
 	)
 
 	const mobileLinks = React.useMemo(

--- a/services/site/app/routes/better.tsx
+++ b/services/site/app/routes/better.tsx
@@ -1,0 +1,417 @@
+import { type ReactNode } from 'react'
+import { type HeadersFunction, type MetaFunction } from 'react-router'
+import { ArrowLink } from '#app/components/arrow-button.tsx'
+import { ButtonLink } from '#app/components/button.tsx'
+import { FeatureCard } from '#app/components/feature-card.tsx'
+import { Grid } from '#app/components/grid.tsx'
+import {
+	CheckCircledIcon,
+	HeartIcon,
+	MicrophoneIcon,
+	RssIcon,
+	TrophyIcon,
+	UsersIcon,
+	YoutubeIcon,
+} from '#app/components/icons.tsx'
+import { HeaderSection } from '#app/components/sections/header-section.tsx'
+import { HeroSection } from '#app/components/sections/hero-section.tsx'
+import { H2, H3, H6, Paragraph } from '#app/components/typography.tsx'
+import { getGenericSocialImage, getImgProps, images } from '#app/images.tsx'
+import { type RootLoaderType } from '#app/root.tsx'
+import { getDisplayUrl, getUrl } from '#app/utils/misc.ts'
+import { getSocialMetas } from '#app/utils/seo.ts'
+
+const betterYouTubeUrl = 'https://www.youtube.com/c/kentcdodds-vids'
+const betterRssUrl = 'https://feeds.transistor.fm/better-with-kent'
+const lastSoftwareEngineerUrl =
+	'https://www.epicproduct.engineer/the-last-software-engineer'
+
+export const headers: HeadersFunction = () => ({
+	'Cache-Control': 'public, max-age=3600',
+})
+
+export const meta: MetaFunction<{}, { root: RootLoaderType }> = ({
+	matches,
+}) => {
+	const requestInfo = matches.find((m) => m.id === 'root')?.data.requestInfo
+	return getSocialMetas({
+		title: 'Better with Kent',
+		description:
+			'Durable skills for people who ship software. Watch Better with Kent from Kent C. Dodds on YouTube.',
+		url: getUrl(requestInfo),
+		image: getGenericSocialImage({
+			url: getDisplayUrl(requestInfo),
+			featuredImage: images.microphone.id,
+			words: `Better with Kent: Durable skills for people who ship software`,
+		}),
+	})
+}
+
+function ExternalTextLink({
+	href,
+	children,
+}: {
+	href: string
+	children: ReactNode
+}) {
+	return (
+		<a
+			className="underlined focus:outline-none"
+			href={href}
+			target="_blank"
+			rel="noreferrer noopener"
+		>
+			{children}
+		</a>
+	)
+}
+
+function ListenCard({
+	title,
+	description,
+	icon,
+	action,
+}: {
+	title: string
+	description: string
+	icon: ReactNode
+	action: ReactNode
+}) {
+	return (
+		<div className="bg-secondary flex h-full flex-col rounded-lg px-8 py-10 lg:px-12">
+			<div className="text-primary mb-6">{icon}</div>
+			<H3 className="mb-4">{title}</H3>
+			<Paragraph className="mb-8 flex-auto">{description}</Paragraph>
+			<div>{action}</div>
+		</div>
+	)
+}
+
+function PlaceholderBadge({ children }: { children: ReactNode }) {
+	return (
+		<span className="text-secondary inline-flex rounded-full border border-gray-300 px-5 py-2 text-base font-medium dark:border-gray-700">
+			{children}
+		</span>
+	)
+}
+
+export default function BetterRoute() {
+	return (
+		<>
+			<HeroSection
+				title="Better with Kent"
+				subtitle="Durable skills for people who ship software"
+				imageBuilder={images.microphone}
+				arrowUrl="#what-is-the-show"
+				arrowLabel="What is Better with Kent?"
+				action={
+					<ButtonLink
+						variant="primary"
+						href={betterYouTubeUrl}
+						target="_blank"
+						rel="noreferrer noopener"
+					>
+						<YoutubeIcon /> Watch on YouTube
+					</ButtonLink>
+				}
+			/>
+
+			<main>
+				<Grid className="mb-24 lg:mb-64">
+					<div className="col-span-full lg:col-span-6 lg:col-start-1">
+						<div className="mb-12 aspect-[4/3] lg:mb-0">
+							<img
+								{...getImgProps(images.kentSmilingWithLaptop, {
+									className: 'rounded-lg object-cover',
+									widths: [410, 650, 820, 1230, 1640, 2460],
+									sizes: [
+										'(max-width: 1023px) 80vw',
+										'(min-width:1024px) and (max-width:1620px) 40vw',
+										'630px',
+									],
+									transformations: {
+										resize: {
+											type: 'fill',
+											aspectRatio: '4:3',
+										},
+									},
+								})}
+							/>
+						</div>
+					</div>
+
+					<div className="col-span-full lg:col-span-5 lg:col-start-8 lg:row-start-1">
+						<H2 id="what-is-the-show" className="mb-10">
+							A solo show about becoming the kind of person who ships better
+							software.
+						</H2>
+						<Paragraph className="mb-12">
+							Better with Kent is a talking-head video show from Kent C. Dodds
+							about the durable skills that keep mattering as tools, teams, and
+							careers change. Expect direct, thoughtful episodes about judgment,
+							product thinking, technical leadership, and the human side of
+							software work.
+						</Paragraph>
+						<Paragraph className="mb-12">
+							It complements the guest conversations in Chats with Kent and the
+							Become a Product Engineer season. This one is Kent solo: concise,
+							opinionated, and focused on helping you build instincts that last.
+						</Paragraph>
+						<ButtonLink
+							variant="primary"
+							href={betterYouTubeUrl}
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							<YoutubeIcon /> Subscribe on YouTube
+						</ButtonLink>
+					</div>
+				</Grid>
+
+				<Grid className="mb-24 lg:mb-64">
+					<div className="col-span-full mb-12 hidden lg:col-span-4 lg:mb-0 lg:block">
+						<H6 as="h2">Why now?</H6>
+					</div>
+					<div className="col-span-full mb-12 lg:col-span-8 lg:mb-20">
+						<H2 as="p" className="mb-3">
+							The work is changing quickly.
+						</H2>
+						<H2 as="p" variant="secondary">
+							The people who keep shipping well are the ones who get better at
+							choosing problems, understanding users, and making accountable
+							tradeoffs.
+						</H2>
+					</div>
+					<div className="col-span-full lg:col-span-4 lg:col-start-5 lg:pr-12">
+						<H6 as="h3" className="mb-4">
+							Tools are accelerating.
+						</H6>
+						<Paragraph className="mb-16">
+							AI can make code faster, but it does not decide what is worth
+							building, what risk to accept, or how to earn trust with the
+							people depending on your work.
+						</Paragraph>
+					</div>
+					<div className="col-span-full lg:col-span-4 lg:col-start-9 lg:pr-12">
+						<H6 as="h3" className="mb-4">
+							Craft still matters.
+						</H6>
+						<Paragraph className="mb-16">
+							Better with Kent is for developers, product engineers, and team
+							leads who want durable skills they can carry across frameworks,
+							companies, and product cycles.
+						</Paragraph>
+					</div>
+				</Grid>
+
+				<HeaderSection
+					title="What you will get better at."
+					subTitle="Four durable skills that outlast the latest toolchain."
+					className="mb-16"
+				/>
+				<Grid className="mb-24 lg:mb-64" rowGap>
+					<div className="col-span-full lg:col-span-6">
+						<FeatureCard
+							title="Judgment"
+							description="Practice making technical and product tradeoffs with the constraints in view, not just the code in front of you."
+							icon={<TrophyIcon size={48} />}
+						/>
+					</div>
+					<div className="col-span-full lg:col-span-6">
+						<FeatureCard
+							title="Accountability"
+							description="Own outcomes, communicate risk, and develop the reliability people trust when the work gets ambiguous."
+							icon={<CheckCircledIcon size={48} />}
+						/>
+					</div>
+					<div className="col-span-full lg:col-span-6">
+						<FeatureCard
+							title="Problem clarity"
+							description="Get sharper at naming the real problem so your implementation energy lands where it creates value."
+							icon={<MicrophoneIcon size={48} />}
+						/>
+					</div>
+					<div className="col-span-full lg:col-span-6">
+						<FeatureCard
+							title="Empathy"
+							description="Build the habit of seeing the humans around the software: users, teammates, stakeholders, and future maintainers."
+							icon={<HeartIcon size={48} />}
+						/>
+					</div>
+				</Grid>
+
+				<Grid className="mb-24 lg:mb-64" featured>
+					<div className="col-span-full lg:col-span-5">
+						<H6 as="h2" className="mb-6">
+							Episode 1 spotlight
+						</H6>
+						<H2 className="mb-8">The Last Software Engineer</H2>
+						<Paragraph className="mb-12">
+							The first episode is upcoming and starts with the question behind
+							Kent's essay: if AI changes the day-to-day mechanics of writing
+							code, what kind of engineer remains valuable?
+						</Paragraph>
+						<ArrowLink href={lastSoftwareEngineerUrl} direction="top-right">
+							Read the essay
+						</ArrowLink>
+					</div>
+					<div className="col-span-full mt-12 lg:col-span-6 lg:col-start-7 lg:mt-0">
+						<div className="bg-primary rounded-lg p-8 shadow-xl lg:p-12 dark:bg-gray-950">
+							<Paragraph
+								prose={false}
+								className="mb-6 text-base tracking-[0.25em] uppercase"
+								textColorClassName="text-secondary"
+							>
+								Coming soon
+							</Paragraph>
+							<H3 className="mb-6">Episode 1: The Last Software Engineer</H3>
+							<Paragraph className="mb-8">
+								Watch the first episode on YouTube when it lands. The feed is
+								ready for podcast apps too, but YouTube is the best place to
+								follow the show first.
+							</Paragraph>
+							<ButtonLink
+								variant="secondary"
+								href={betterYouTubeUrl}
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								<YoutubeIcon /> Watch on YouTube
+							</ButtonLink>
+						</div>
+					</div>
+				</Grid>
+
+				<Grid className="mb-24 lg:mb-64">
+					<div className="col-span-full lg:col-span-6 lg:col-start-7">
+						<div className="mb-12 lg:mb-0">
+							<img
+								{...getImgProps(images.microphoneWithHands, {
+									className: 'rounded-lg object-cover',
+									widths: [512, 650, 840, 1024, 1300, 1680, 2000, 2520],
+									sizes: [
+										'(max-width: 1023px) 80vw',
+										'(min-width: 1024px) and (max-width: 1620px) 40vw',
+										'650px',
+									],
+									transformations: {
+										resize: {
+											type: 'fill',
+											aspectRatio: '3:4',
+										},
+									},
+								})}
+							/>
+						</div>
+					</div>
+
+					<div className="col-span-full lg:col-span-5 lg:col-start-1 lg:row-start-1">
+						<H2 className="mb-10">Want guest conversations too?</H2>
+						<H2 variant="secondary" as="p" className="mb-12">
+							Better with Kent is Kent solo. For long-form guest conversations
+							about becoming a product engineer, listen to Chats with Kent.
+						</H2>
+						<ArrowLink to="/chats/07">Become a Product Engineer</ArrowLink>
+					</div>
+				</Grid>
+
+				<HeaderSection
+					title="Listen and watch."
+					subTitle="YouTube is the primary home. Podcast app links can grow here as they become available."
+					className="mb-16"
+				/>
+				<Grid className="mb-24 lg:mb-64" rowGap>
+					<div className="col-span-full lg:col-span-4">
+						<ListenCard
+							title="YouTube"
+							description="Subscribe on YouTube for the primary Better with Kent experience and future playlist updates."
+							icon={<YoutubeIcon size={48} />}
+							action={
+								<ButtonLink
+									variant="primary"
+									size="medium"
+									href={betterYouTubeUrl}
+									target="_blank"
+									rel="noreferrer noopener"
+								>
+									Watch on YouTube
+								</ButtonLink>
+							}
+						/>
+					</div>
+					<div className="col-span-full lg:col-span-4">
+						<ListenCard
+							title="RSS"
+							description="Prefer a podcast app? Add the RSS feed directly while Apple Podcasts and Spotify listings are pending."
+							icon={<RssIcon size={48} />}
+							action={
+								<ArrowLink href={betterRssUrl} direction="top-right">
+									Open RSS feed
+								</ArrowLink>
+							}
+						/>
+					</div>
+					<div className="col-span-full lg:col-span-4">
+						<ListenCard
+							title="Apple and Spotify"
+							description="Dedicated Apple Podcasts and Spotify links will go here once those listings are live."
+							icon={<UsersIcon size={48} />}
+							action={
+								<div className="flex flex-wrap gap-3">
+									<PlaceholderBadge>Apple coming soon</PlaceholderBadge>
+									<PlaceholderBadge>Spotify coming soon</PlaceholderBadge>
+								</div>
+							}
+						/>
+					</div>
+					<div className="col-span-full">
+						<div className="border-secondary rounded-lg border border-dashed p-8 lg:p-12">
+							<H3 className="mb-4">Future playlist embed</H3>
+							<Paragraph>
+								When the Better with Kent YouTube playlist is ready, this
+								section can host an inline playlist embed without changing the
+								page structure.
+							</Paragraph>
+						</div>
+					</div>
+				</Grid>
+
+				<Grid className="mb-24 lg:mb-64">
+					<div className="col-span-full lg:col-span-4 lg:col-start-2">
+						<img
+							loading="lazy"
+							{...getImgProps(images.microphone, {
+								className: 'object-contain',
+								widths: [420, 512, 840, 1260, 1024, 1680, 2520],
+								sizes: [
+									'(max-width: 1023px) 80vw',
+									'(min-width: 1024px) and (max-width: 1620px) 40vw',
+									'630px',
+								],
+							})}
+						/>
+					</div>
+
+					<div className="col-span-full mt-4 lg:col-span-6 lg:col-start-7 lg:mt-0">
+						<H2 className="mb-8">Get better at the work beyond the code.</H2>
+						<H2 variant="secondary" as="p" className="mb-16">
+							Subscribe on YouTube and follow along as Better with Kent starts
+							with The Last Software Engineer.
+						</H2>
+						<div className="flex flex-col gap-6 sm:flex-row sm:items-center">
+							<ButtonLink
+								variant="primary"
+								href={betterYouTubeUrl}
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								<YoutubeIcon /> Subscribe on YouTube
+							</ButtonLink>
+							<ExternalTextLink href={betterRssUrl}>RSS feed</ExternalTextLink>
+						</div>
+					</div>
+				</Grid>
+			</main>
+		</>
+	)
+}

--- a/services/site/app/routes/better.tsx
+++ b/services/site/app/routes/better.tsx
@@ -15,6 +15,7 @@ import {
 } from '#app/components/icons.tsx'
 import { HeaderSection } from '#app/components/sections/header-section.tsx'
 import { HeroSection } from '#app/components/sections/hero-section.tsx'
+import { Spacer } from '#app/components/spacer.tsx'
 import { H2, H3, H6, Paragraph } from '#app/components/typography.tsx'
 import { getGenericSocialImage, getImgProps, images } from '#app/images.tsx'
 import { type RootLoaderType } from '#app/root.tsx'
@@ -95,6 +96,15 @@ function PlaceholderBadge({ children }: { children: ReactNode }) {
 	)
 }
 
+function YouTubeButtonLabel({ children }: { children: ReactNode }) {
+	return (
+		<>
+			<YoutubeIcon size={28} />
+			<span className="pl-1">{children}</span>
+		</>
+	)
+}
+
 export default function BetterRoute() {
 	return (
 		<>
@@ -111,7 +121,7 @@ export default function BetterRoute() {
 						target="_blank"
 						rel="noreferrer noopener"
 					>
-						<YoutubeIcon /> Watch on YouTube
+						<YouTubeButtonLabel>Watch on YouTube</YouTubeButtonLabel>
 					</ButtonLink>
 				}
 			/>
@@ -163,7 +173,7 @@ export default function BetterRoute() {
 							target="_blank"
 							rel="noreferrer noopener"
 						>
-							<YoutubeIcon /> Subscribe on YouTube
+							<YouTubeButtonLabel>Subscribe on YouTube</YouTubeButtonLabel>
 						</ButtonLink>
 					</div>
 				</Grid>
@@ -240,47 +250,54 @@ export default function BetterRoute() {
 					</div>
 				</Grid>
 
-				<Grid className="mb-24 lg:mb-64" featured>
-					<div className="col-span-full lg:col-span-5">
-						<H6 as="h2" className="mb-6">
-							Episode 1 spotlight
-						</H6>
-						<H2 className="mb-8">The Last Software Engineer</H2>
-						<Paragraph className="mb-12">
-							The first episode is upcoming and starts with the question behind
-							Kent's essay: if AI changes the day-to-day mechanics of writing
-							code, what kind of engineer remains valuable?
-						</Paragraph>
-						<ArrowLink href={lastSoftwareEngineerUrl} direction="top-right">
-							Read the essay
-						</ArrowLink>
-					</div>
-					<div className="col-span-full mt-12 lg:col-span-6 lg:col-start-7 lg:mt-0">
-						<div className="bg-primary rounded-lg p-8 shadow-xl lg:p-12 dark:bg-gray-950">
-							<Paragraph
-								prose={false}
-								className="mb-6 text-base tracking-[0.25em] uppercase"
-								textColorClassName="text-secondary"
-							>
-								Coming soon
-							</Paragraph>
-							<H3 className="mb-6">Episode 1: The Last Software Engineer</H3>
-							<Paragraph className="mb-8">
-								Watch the first episode on YouTube when it lands. The feed is
-								ready for podcast apps too, but YouTube is the best place to
-								follow the show first.
-							</Paragraph>
-							<ButtonLink
-								variant="secondary"
-								href={betterYouTubeUrl}
-								target="_blank"
-								rel="noreferrer noopener"
-							>
-								<YoutubeIcon /> Watch on YouTube
-							</ButtonLink>
-						</div>
+				<Grid>
+					<div className="bg-secondary col-span-full rounded-lg px-8 py-12 md:px-14 md:py-16 lg:px-20 lg:py-20">
+						<Grid nested rowGap className="items-start">
+							<div className="col-span-full lg:col-span-5">
+								<H6 as="h2" className="mb-6">
+									Episode 1 spotlight
+								</H6>
+								<H2 className="mb-8">The Last Software Engineer</H2>
+								<Paragraph className="mb-12">
+									The first episode is upcoming and starts with the question
+									behind Kent's essay: if AI changes the day-to-day mechanics of
+									writing code, what kind of engineer remains valuable?
+								</Paragraph>
+								<ArrowLink href={lastSoftwareEngineerUrl} direction="top-right">
+									Read the essay
+								</ArrowLink>
+							</div>
+							<div className="col-span-full lg:col-span-6 lg:col-start-7">
+								<div className="bg-primary rounded-lg p-8 shadow-xl lg:p-12 dark:bg-gray-950">
+									<Paragraph
+										prose={false}
+										className="mb-6 text-base tracking-[0.25em] uppercase"
+										textColorClassName="text-secondary"
+									>
+										Coming soon
+									</Paragraph>
+									<H3 className="mb-6">
+										Episode 1: The Last Software Engineer
+									</H3>
+									<Paragraph className="mb-8">
+										Watch the first episode on YouTube when it lands. The feed
+										is ready for podcast apps too, but YouTube is the best place
+										to follow the show first.
+									</Paragraph>
+									<ButtonLink
+										variant="secondary"
+										href={betterYouTubeUrl}
+										target="_blank"
+										rel="noreferrer noopener"
+									>
+										<YouTubeButtonLabel>Watch on YouTube</YouTubeButtonLabel>
+									</ButtonLink>
+								</div>
+							</div>
+						</Grid>
 					</div>
 				</Grid>
+				<Spacer size="sm" />
 
 				<Grid className="mb-24 lg:mb-64">
 					<div className="col-span-full lg:col-span-6 lg:col-start-7">
@@ -334,7 +351,7 @@ export default function BetterRoute() {
 									target="_blank"
 									rel="noreferrer noopener"
 								>
-									Watch on YouTube
+									<YouTubeButtonLabel>Watch on YouTube</YouTubeButtonLabel>
 								</ButtonLink>
 							}
 						/>
@@ -405,7 +422,7 @@ export default function BetterRoute() {
 								target="_blank"
 								rel="noreferrer noopener"
 							>
-								<YoutubeIcon /> Subscribe on YouTube
+								<YouTubeButtonLabel>Subscribe on YouTube</YouTubeButtonLabel>
 							</ButtonLink>
 							<ExternalTextLink href={betterRssUrl}>RSS feed</ExternalTextLink>
 						</div>

--- a/services/site/e2e/smoke.spec.ts
+++ b/services/site/e2e/smoke.spec.ts
@@ -2,6 +2,13 @@ import { expect, test } from '@playwright/test'
 
 test('App loads and nav works', async ({ page }) => {
 	await page.setViewportSize({ width: 1400, height: 900 })
+	await page.context().addCookies([
+		{
+			name: 'chats-with-kent-season-7',
+			value: 'hidden',
+			url: `http://localhost:${process.env.PORT ?? '3000'}`,
+		},
+	])
 	await page.goto('/')
 
 	const nav = page.getByRole('navigation')
@@ -12,19 +19,16 @@ test('App loads and nav works', async ({ page }) => {
 		'Blog',
 		'Talks',
 		'Courses',
+		'Better',
 		'Discord',
-		'Chats',
 		'Calls',
 		'About',
 	])
 
-	// Narrower desktop viewport: Discord + Chats hide (same behavior as Chats had).
+	// Narrower desktop viewport: Discord hides to keep the centered links compact.
 	await page.setViewportSize({ width: 1100, height: 900 })
 	await expect(
 		page.locator('.navbar-links [data-nav-item="discord"]'),
-	).toBeHidden()
-	await expect(
-		page.locator('.navbar-links [data-nav-item="chats"]'),
 	).toBeHidden()
 
 	const blogLink = nav.getByRole('link', { name: 'Blog' })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a marketing landing page for Better with Kent at `/better`.
- Use existing site components (`HeroSection`, `Grid`, `FeatureCard`, `ButtonLink`, typography, images, social meta helpers).
- Add `Better` to the top nav and footer sitemap, and remove `Chats` from the top nav.
- Tune Episode 1-to-guest-section spacing and improve YouTube CTA icon sizing/spacing.
- Update the navbar smoke test expectations for the intentional Better/Chats nav change.

## Validation

- Pre-commit hook passed: `npm run format:staged && npm run lint:all && npm run typecheck:all && npm run build:all`.
- `npm run lint` passed.
- `npm run typecheck` passed.
- Focused local Playwright smoke test passed: `PORT=3001 npx playwright test e2e/smoke.spec.ts`.
- Full local Playwright suite passed in CI mode: `CI=1 PORT=8812 npx playwright test` (`13 passed`).
- Pre-push hook passed after installing Playwright Chromium: `npm run test:all`.
- Latest PR checks passed: Site Gate, Playwright, CodeRabbit, and Cursor Bugbot.
- Local route check passed: `curl -I http://localhost:3000/better` returned `200 OK`.
- Manual browser walkthrough verified the active Better nav item, YouTube-first hero CTA, required sections, listen placeholders, future playlist placeholder, and closing YouTube CTA.
- Manual browser follow-up verified reduced gray internal padding, clear section margin, and larger/spaced YouTube CTA icon.
- Browser automation verified top nav items are `Blog`, `Talks`, `Courses`, `Better`, `Discord`, `Calls`, `About` and footer includes `Better`.

## Walkthrough

<a href="https://cursor.com/agents/bc-c65bab86-adfa-48f1-adc7-904f51148401/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbetter-with-kent-page-walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-4b488bcb-d486-4ab4-af55-6722443421eb" alt="better-with-kent-page-walkthrough.mp4" /></a>

<a href="https://cursor.com/agents/bc-c65bab86-adfa-48f1-adc7-904f51148401/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbetter-spacing-and-youtube-cta-fix.mp4"><img src="https://cursor.com/artifacts/c/art-9a7e5495-97df-403a-bee6-1fd2ad637a70" alt="better-spacing-and-youtube-cta-fix.mp4" /></a>

![Top nav without Chats](https://cursor.com/artifacts/c/art-1154d7e4-f72c-49a0-bff5-853aa31ec057)

![Footer sitemap with Better](https://cursor.com/artifacts/c/art-7e5f6d2c-b333-4142-91ac-93efed9c71a6)

![Episode 1 spacing after refinement](https://cursor.com/artifacts/c/art-62ccf730-82be-4174-8d97-ad04baed8297)

![YouTube CTA spacing after refinement](https://cursor.com/artifacts/c/art-57d23a8b-381a-4e64-bccf-2326d965f048)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65bab86-adfa-48f1-adc7-904f51148401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65bab86-adfa-48f1-adc7-904f51148401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Better" content hub with hero CTAs, skill cards, episode spotlight, listen/watch options, playlist/embed placeholder, social metadata, and newsletter subscribe.

* **UI / Navigation**
  * Replaced the desktop "Chats" header link with "Better" and added "Better" to the footer sitemap.

* **Responsive**
  * Adjusted which nav item is hidden at narrower widths (now hides the Discord item).

* **Tests**
  * Updated smoke test expectations to match the new navigation and state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kentcdodds.com/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->