### PR TITLE
Fix search worker lexical sync duplicate ids

### DIFF
--- a/services/search-worker/src/search-db.test.ts
+++ b/services/search-worker/src/search-db.test.ts
@@ -191,6 +191,35 @@ test('queryLexicalSearch quotes hyphenated date tokens for FTS', async () => {
 	])
 })
 
+test('queryLexicalSearch returns original chunk ids from storage ids', async () => {
+	const { db } = createDb({
+		onAll: async () => ({
+			results: [
+				{
+					id: JSON.stringify([
+						'chunk',
+						'lexical-search/repo-content.json',
+						'blog:doc-without-slug:chunk:0',
+						0,
+					]),
+					type: 'blog',
+					title: 'Doc Without Slug',
+					url: '/blog/doc-without-slug',
+					snippet: 'A lexical result with a storage ID.',
+				},
+			],
+		}),
+	})
+
+	const results = await queryLexicalSearch({
+		db,
+		query: 'doc',
+		topK: 5,
+	})
+
+	expect(results[0]?.id).toBe('blog:doc-without-slug:chunk:0')
+})
+
 test('queryLexicalSearch retries when D1 reports no such column', async () => {
 	const { db, boundQueries } = createDb({
 		onAll: async () => {

--- a/services/search-worker/src/search-db.test.ts
+++ b/services/search-worker/src/search-db.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
-import { queryLexicalSearch } from './search-db'
+import { type LexicalSearchArtifact } from '@kcd-internal/search-shared'
+import { queryLexicalSearch, replaceSearchSource } from './search-db'
 
 function createDb({
 	onAll,
@@ -24,6 +25,112 @@ function createDb({
 
 	return { db, boundQueries }
 }
+
+type BoundStatement = {
+	sql: string
+	values: Array<unknown>
+}
+
+function createBatchDb() {
+	const boundStatements: Array<BoundStatement> = []
+	const db = {
+		prepare: vi.fn((sql: string) => ({
+			bind: vi.fn((...values: Array<unknown>) => ({ sql, values })),
+		})),
+		batch: vi.fn(async (statements: Array<D1PreparedStatement>) => {
+			boundStatements.push(...(statements as unknown as Array<BoundStatement>))
+			return []
+		}),
+	} as unknown as D1Database
+
+	return { db, boundStatements }
+}
+
+test('replaceSearchSource scopes duplicate chunk storage ids by source', async () => {
+	const { db, boundStatements } = createBatchDb()
+	const artifact: LexicalSearchArtifact = {
+		version: 1,
+		generatedAt: '2026-05-27T00:00:00.000Z',
+		chunks: [
+			{
+				id: 'youtube:abc123def45:chunk:0',
+				type: 'youtube',
+				slug: 'abc123def45',
+				url: '/youtube?video=abc123def45',
+				title: 'Duplicate Test Video',
+				snippet: 'First duplicate chunk.',
+				text: 'first chunk text',
+				chunkIndex: 0,
+				chunkCount: 2,
+			},
+			{
+				id: 'youtube:abc123def45:chunk:0',
+				type: 'youtube',
+				slug: 'abc123def45',
+				url: '/youtube?video=abc123def45',
+				title: 'Duplicate Test Video',
+				snippet: 'Second duplicate chunk.',
+				text: 'second chunk text',
+				chunkIndex: 1,
+				chunkCount: 2,
+			},
+		],
+	}
+
+	await replaceSearchSource({
+		db,
+		sourceKey: 'lexical-search/repo-content.json',
+		artifact,
+		syncedAt: '2026-05-27T01:00:00.000Z',
+	})
+	await replaceSearchSource({
+		db,
+		sourceKey: 'lexical-search/youtube.json',
+		artifact,
+		syncedAt: '2026-05-27T01:00:00.000Z',
+	})
+
+	const chunkInsertStatements = boundStatements.filter((statement) =>
+		statement.sql.includes('INSERT INTO lexical_chunks'),
+	)
+	const chunkStorageIds = chunkInsertStatements.map((statement) =>
+		String(statement.values[0]),
+	)
+	expect(chunkStorageIds).toEqual([
+		JSON.stringify([
+			'chunk',
+			'lexical-search/repo-content.json',
+			'youtube:abc123def45:chunk:0',
+			0,
+		]),
+		JSON.stringify([
+			'chunk',
+			'lexical-search/repo-content.json',
+			'youtube:abc123def45:chunk:0',
+			1,
+		]),
+		JSON.stringify([
+			'chunk',
+			'lexical-search/youtube.json',
+			'youtube:abc123def45:chunk:0',
+			0,
+		]),
+		JSON.stringify([
+			'chunk',
+			'lexical-search/youtube.json',
+			'youtube:abc123def45:chunk:0',
+			1,
+		]),
+	])
+	expect(new Set(chunkStorageIds).size).toBe(chunkStorageIds.length)
+
+	const docInsertStatements = boundStatements.filter((statement) =>
+		statement.sql.includes('INSERT INTO lexical_docs'),
+	)
+	expect(docInsertStatements.map((statement) => statement.values[7])).toEqual([
+		2, 2,
+	])
+})
 
 test('queryLexicalSearch quotes hyphenated date tokens for FTS', async () => {
 	const { db, boundQueries } = createDb({

--- a/services/search-worker/src/search-db.test.ts
+++ b/services/search-worker/src/search-db.test.ts
@@ -127,6 +127,18 @@ test('replaceSearchSource scopes duplicate chunk storage ids by source', async (
 	const docInsertStatements = boundStatements.filter((statement) =>
 		statement.sql.includes('INSERT INTO lexical_docs'),
 	)
+	expect(docInsertStatements.map((statement) => statement.values[0])).toEqual([
+		JSON.stringify([
+			'doc',
+			'lexical-search/repo-content.json',
+			'youtube:abc123def45',
+		]),
+		JSON.stringify([
+			'doc',
+			'lexical-search/youtube.json',
+			'youtube:abc123def45',
+		]),
+	])
 	expect(docInsertStatements.map((statement) => statement.values[7])).toEqual([
 		2, 2,
 	])

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -126,6 +126,28 @@ function getStorageId(parts: ReadonlyArray<string | number>) {
 	return JSON.stringify(parts)
 }
 
+function getStorageDocId({
+	sourceKey,
+	docId,
+}: {
+	sourceKey: string
+	docId: string
+}) {
+	return getStorageId(['doc', sourceKey, docId])
+}
+
+function getStorageChunkId({
+	sourceKey,
+	chunkId,
+	duplicateIndex,
+}: {
+	sourceKey: string
+	chunkId: string
+	duplicateIndex: number
+}) {
+	return getStorageId(['chunk', sourceKey, chunkId, duplicateIndex])
+}
+
 function asString(value: unknown): string | undefined {
 	return typeof value === 'string' ? value : undefined
 }
@@ -189,7 +211,7 @@ function buildDocRecords({
 			url: chunk.url,
 			title: chunk.title,
 		})
-		const storageDocId = getStorageId(['doc', sourceKey, docId])
+		const storageDocId = getStorageDocId({ sourceKey, docId })
 		const existing = docs.get(storageDocId)
 		if (existing) {
 			existing.chunkCount += 1
@@ -353,13 +375,12 @@ export async function replaceSearchSource({
 		})
 		const duplicateIndex = chunkIdCounts.get(chunk.id) ?? 0
 		chunkIdCounts.set(chunk.id, duplicateIndex + 1)
-		const storageChunkId = getStorageId([
-			'chunk',
+		const storageChunkId = getStorageChunkId({
 			sourceKey,
-			chunk.id,
+			chunkId: chunk.id,
 			duplicateIndex,
-		])
-		const storageDocId = getStorageId(['doc', sourceKey, docId])
+		})
+		const storageDocId = getStorageDocId({ sourceKey, docId })
 		statements.push(
 			db
 				.prepare(

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -148,6 +148,22 @@ function getStorageChunkId({
 	return getStorageId(['chunk', sourceKey, chunkId, duplicateIndex])
 }
 
+function getResultChunkId(storageChunkId: string) {
+	try {
+		const parts: unknown = JSON.parse(storageChunkId)
+		if (
+			Array.isArray(parts) &&
+			parts[0] === 'chunk' &&
+			typeof parts[2] === 'string'
+		) {
+			return parts[2]
+		}
+	} catch {
+		// Existing rows may use raw chunk IDs instead of JSON storage IDs.
+	}
+	return storageChunkId
+}
+
 function asString(value: unknown): string | undefined {
 	return typeof value === 'string' ? value : undefined
 }
@@ -491,7 +507,7 @@ export async function queryLexicalSearch({
 			.all<SqlRow>()
 
 		return (result.results ?? []).map((row) => ({
-			id: String(row.id),
+			id: getResultChunkId(String(row.id)),
 			type: asString(row.type),
 			slug: asString(row.slug),
 			title: asString(row.title),

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -122,6 +122,10 @@ type LexicalDocRecord = {
 	transcriptSource?: string
 }
 
+function getStorageId(parts: ReadonlyArray<string | number>) {
+	return JSON.stringify(parts)
+}
+
 function asString(value: unknown): string | undefined {
 	return typeof value === 'string' ? value : undefined
 }
@@ -185,14 +189,15 @@ function buildDocRecords({
 			url: chunk.url,
 			title: chunk.title,
 		})
-		const existing = docs.get(docId)
+		const storageDocId = getStorageId(['doc', sourceKey, docId])
+		const existing = docs.get(storageDocId)
 		if (existing) {
 			existing.chunkCount += 1
 			continue
 		}
 
-		docs.set(docId, {
-			docId,
+		docs.set(storageDocId, {
+			docId: storageDocId,
 			sourceKey,
 			type: chunk.type,
 			slug: chunk.slug,
@@ -246,13 +251,7 @@ async function setMetadataValue({
 		.run()
 }
 
-async function getMetadataValue({
-	db,
-	key,
-}: {
-	db: D1Database
-	key: string
-}) {
+async function getMetadataValue({ db, key }: { db: D1Database; key: string }) {
 	const row = await db
 		.prepare('SELECT value FROM service_metadata WHERE key = ?')
 		.bind(key)
@@ -295,10 +294,16 @@ export async function replaceSearchSource({
 }) {
 	const docs = buildDocRecords({ sourceKey, artifact })
 	const statements: Array<D1PreparedStatement> = [
-		db.prepare('DELETE FROM lexical_search_fts WHERE sourceKey = ?').bind(sourceKey),
-		db.prepare('DELETE FROM lexical_chunks WHERE sourceKey = ?').bind(sourceKey),
+		db
+			.prepare('DELETE FROM lexical_search_fts WHERE sourceKey = ?')
+			.bind(sourceKey),
+		db
+			.prepare('DELETE FROM lexical_chunks WHERE sourceKey = ?')
+			.bind(sourceKey),
 		db.prepare('DELETE FROM lexical_docs WHERE sourceKey = ?').bind(sourceKey),
-		db.prepare('DELETE FROM lexical_sources WHERE sourceKey = ?').bind(sourceKey),
+		db
+			.prepare('DELETE FROM lexical_sources WHERE sourceKey = ?')
+			.bind(sourceKey),
 		db
 			.prepare(
 				`
@@ -337,6 +342,7 @@ export async function replaceSearchSource({
 		)
 	}
 
+	const chunkIdCounts = new Map<string, number>()
 	for (const chunk of artifact.chunks) {
 		const docId = getLexicalDocId({
 			chunkId: chunk.id,
@@ -345,6 +351,15 @@ export async function replaceSearchSource({
 			url: chunk.url,
 			title: chunk.title,
 		})
+		const duplicateIndex = chunkIdCounts.get(chunk.id) ?? 0
+		chunkIdCounts.set(chunk.id, duplicateIndex + 1)
+		const storageChunkId = getStorageId([
+			'chunk',
+			sourceKey,
+			chunk.id,
+			duplicateIndex,
+		])
+		const storageDocId = getStorageId(['doc', sourceKey, docId])
 		statements.push(
 			db
 				.prepare(
@@ -357,8 +372,8 @@ export async function replaceSearchSource({
 					`,
 				)
 				.bind(
-					chunk.id,
-					docId,
+					storageChunkId,
+					storageDocId,
 					sourceKey,
 					chunk.type,
 					chunk.slug ?? null,
@@ -382,7 +397,7 @@ export async function replaceSearchSource({
 						VALUES (?, ?, ?, ?, ?)
 					`,
 				)
-				.bind(chunk.id, docId, sourceKey, chunk.title, chunk.text),
+				.bind(storageChunkId, storageDocId, sourceKey, chunk.title, chunk.text),
 		)
 	}
 
@@ -399,10 +414,18 @@ export async function clearSearchSource({
 	await runStatementsInTransaction({
 		db,
 		statements: [
-			db.prepare('DELETE FROM lexical_search_fts WHERE sourceKey = ?').bind(sourceKey),
-			db.prepare('DELETE FROM lexical_chunks WHERE sourceKey = ?').bind(sourceKey),
-			db.prepare('DELETE FROM lexical_docs WHERE sourceKey = ?').bind(sourceKey),
-			db.prepare('DELETE FROM lexical_sources WHERE sourceKey = ?').bind(sourceKey),
+			db
+				.prepare('DELETE FROM lexical_search_fts WHERE sourceKey = ?')
+				.bind(sourceKey),
+			db
+				.prepare('DELETE FROM lexical_chunks WHERE sourceKey = ?')
+				.bind(sourceKey),
+			db
+				.prepare('DELETE FROM lexical_docs WHERE sourceKey = ?')
+				.bind(sourceKey),
+			db
+				.prepare('DELETE FROM lexical_sources WHERE sourceKey = ?')
+				.bind(sourceKey),
 		],
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Scope lexical D1 storage IDs by artifact source and duplicate occurrence so `/internal/sync` can ingest duplicate raw chunk IDs without primary-key collisions.
- Preserve original raw chunk IDs in lexical query results so semantic/lexical fusion still canonicalizes slugless chunks correctly.
- Add regression tests for duplicate chunk storage and storage-ID-to-raw-ID query results.
- Address CodeRabbit review feedback by centralizing storage ID builders and asserting doc primary keys.

## Testing
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run test --workspace search-worker`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run typecheck --workspace search-worker`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run lint --workspace search-worker`
- Commit hook: `npm run precommit:verify` and `npm run test:all`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9604ee38-75fb-41d5-b786-83b3f31684c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9604ee38-75fb-41d5-b786-83b3f31684c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search indexing now scopes and de-duplicates items per data source to prevent collisions and ensure results are attributed to the correct source.
  * Replacing or clearing a source reliably updates indexed items so results reflect the current source state.
  * Search results now return original item identifiers even when stored with scoped IDs.

* **Tests**
  * Added tests validating duplicate handling across sources and correct indexing/lookup during source replacement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kentcdodds.com/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->