### PR TITLE
docs: note Fly replica recreation stall during recovery

### DIFF
--- a/docs/fly-scale-down-recovery-plan.md
+++ b/docs/fly-scale-down-recovery-plan.md
@@ -118,13 +118,17 @@ fly checks list -a kcd
 ```
 
 Only continue to the next region after the new machine is healthy (`3/3`).
+Use `fly machine clone` for replica recreation; do not hand-create replicas with
+the Machines API during normal recovery.
 
-If recreating a replica through the Machines API instead of `fly machine clone`,
-verify the process list before continuing. During the 2026-06-02 recovery,
-REST-created `gru`/`ams` replicas started `litefs mount` but never opened the
-service proxy on `:8080`, so the app process never started. In that state,
-destroy the new replica and keep the fleet at the last healthy footprint rather
-than adding more regions.
+If `flyctl` is unavailable and you must use the Machines API, clone the full
+machine config from the kept primary, swap in the target region's volume, and
+verify the process list before continuing. A healthy replica must show
+`litefs mount` listening on `:8080` and the app process listening on `:8081`.
+During the 2026-06-02 recovery, REST-created `gru`/`ams` replicas started
+`litefs mount` but never opened the service proxy on `:8080`, so the app process
+never started. In that state, destroy the new replica and keep the fleet at the
+last healthy footprint rather than adding more regions.
 
 If a machine fails to start or is left in a non-started state, destroy it before
 continuing:

--- a/docs/fly-scale-down-recovery-plan.md
+++ b/docs/fly-scale-down-recovery-plan.md
@@ -119,6 +119,13 @@ fly checks list -a kcd
 
 Only continue to the next region after the new machine is healthy (`3/3`).
 
+If recreating a replica through the Machines API instead of `fly machine clone`,
+verify the process list before continuing. During the 2026-06-02 recovery,
+REST-created `gru`/`ams` replicas started `litefs mount` but never opened the
+service proxy on `:8080`, so the app process never started. In that state,
+destroy the new replica and keep the fleet at the last healthy footprint rather
+than adding more regions.
+
 If a machine fails to start or is left in a non-started state, destroy it before
 continuing:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Prescribe `fly machine clone` as the normal replica recreation path during scale-back-up.
- Mark raw Machines API recreation as an emergency fallback only when `flyctl` is unavailable.
- Document the process-list checks and the 2026-06-02 LiteFS stall failure mode.

### Testing
- Documentation-only change; reviewed the diff locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34c3133e-fefc-449c-a8f7-8265aac770b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34c3133e-fefc-449c-a8f7-8265aac770b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced recovery plan: added an operational warning for scaling back up and guidance to avoid ad-hoc replica creation during normal recovery.
  * When recreation is necessary, document cloning the kept-primary configuration, swapping the target region volume, and verifying the process list.
  * Added instructions to destroy faulty replicas and maintain the last healthy footprint if services fail to start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->