### PR TITLE
Tune Fly health check grace period

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -69,7 +69,8 @@ swap_size_mb = 512
   [[services.http_checks]]
     interval = "10s"
     timeout = "5s"
-    grace_period = "1m0s"
+    # 1m0s was for LiteFS proxy startup plus cold boot; direct npm start can route sooner.
+    grace_period = "30s"
     restart_limit = 0
     method = "get"
     path = "/healthcheck"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reduce the Fly HTTP health check grace period from `1m0s` to `30s` for the direct `npm start` production path.
- Leave `internal_port`, `/healthcheck`, and the existing `kill_timeout = "5s"` unchanged.
- Add a short config comment noting that the previous minute-long grace period was for LiteFS proxy startup plus cold boot.

## Tradeoff
This should reduce perceived deploy downtime by allowing Fly to route to the new machine sooner once `/healthcheck` passes. The tradeoff is less grace time for an unusually slow boot; if production boot time regresses beyond ~30 seconds, health checks may start evaluating earlier and could delay or fail rollout until the app becomes healthy.

## Validation
- `python3` TOML parse/assertion verified `internal_port=8080`, `path=/healthcheck`, and `grace_period=30s`.
- `git diff --check` passed.

No Fly deploy was run, and no production secrets were changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe5cf0ac-8aa5-48c0-b17b-4c342ab18706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe5cf0ac-8aa5-48c0-b17b-4c342ab18706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment startup configuration to reduce application grace period from 1 minute to 30 seconds, enabling faster deployment startup times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->