### PR TITLE
Prepare Prisma D1 adapter selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1920,7 +1920,6 @@
       "version": "4.20260317.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
       "integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
-      "dev": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cnakazawa/watch": {
@@ -7003,6 +7002,17 @@
       "dependencies": {
         "@prisma/driver-adapter-utils": "7.8.0",
         "better-sqlite3": "^12.6.0"
+      }
+    },
+    "node_modules/@prisma/adapter-d1": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-d1/-/adapter-d1-7.8.0.tgz",
+      "integrity": "sha512-JLmmuDKnPltHicr8+W0xOt4ozbTlAiaPEDe8YGAJIEgHmflOF7sr4Dsd8d+saRBKOARnODz/yxx+y+QMRm/e/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudflare/workers-types": "^4.20251014.0",
+        "@prisma/driver-adapter-utils": "7.8.0",
+        "ky": "1.7.5"
       }
     },
     "node_modules/@prisma/client": {
@@ -17890,6 +17900,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/ky": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.7.5.tgz",
+      "integrity": "sha512-HzhziW6sc5m0pwi5M196+7cEBtbt0lCYi67wNsiwMUmz833wloE0gbzJPWKs1gliFKQb34huItDQX97LyOdPdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -27986,6 +28008,7 @@
         "@octokit/plugin-throttling": "^11.0.3",
         "@octokit/rest": "^22.0.1",
         "@prisma/adapter-better-sqlite3": "^7.8.0",
+        "@prisma/adapter-d1": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@reach/accordion": "^0.18.0",

--- a/services/site/.env.example
+++ b/services/site/.env.example
@@ -36,6 +36,8 @@ MAGIC_LINK_SECRET=whatever_stuff
 DATABASE_FILENAME="sqlite.db"
 DATABASE_PATH=./prisma/sqlite.db
 DATABASE_URL="file:./prisma/sqlite.db"
+# Worker/D1 only: APP_DB is a runtime binding, not a Node/Fly production env var.
+# APP_DB=
 CACHE_DATABASE_PATH="other/cache.db"
 LITEFS_DIR="./prisma"
 PORT=3000

--- a/services/site/app/utils/__tests__/prisma.server.test.ts
+++ b/services/site/app/utils/__tests__/prisma.server.test.ts
@@ -1,0 +1,34 @@
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { PrismaD1 } from '@prisma/adapter-d1'
+import { afterEach, expect, test, vi } from 'vitest'
+import { getPrismaAdapter } from '../prisma-adapter.server.ts'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+test('uses file SQLite when no D1 binding is present', () => {
+	const adapter = getPrismaAdapter({
+		appDbBinding: undefined,
+		databaseUrl: 'file:./prisma/sqlite.db',
+	})
+
+	expect(adapter).toBeInstanceOf(PrismaBetterSqlite3)
+})
+
+test('uses D1 when APP_DB has the D1 binding shape', () => {
+	const d1Binding = {
+		prepare: vi.fn(),
+		batch: vi.fn(),
+		exec: vi.fn(),
+		dump: vi.fn(),
+		withSession: vi.fn(),
+	}
+	vi.stubGlobal('__runtimeBindings', { APP_DB: d1Binding })
+
+	const adapter = getPrismaAdapter({
+		databaseUrl: 'file:./prisma/sqlite.db',
+	})
+
+	expect(adapter).toBeInstanceOf(PrismaD1)
+})

--- a/services/site/app/utils/prisma-adapter.server.ts
+++ b/services/site/app/utils/prisma-adapter.server.ts
@@ -1,0 +1,28 @@
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { PrismaD1 } from '@prisma/adapter-d1'
+import { getEnv } from '#app/utils/env.server.ts'
+import { getRuntimeBinding } from '#app/utils/runtime-bindings.server.ts'
+import { Prisma } from './prisma-generated.server/client.ts'
+
+function getPrismaAdapter({
+	appDbBinding = getRuntimeBinding('APP_DB'),
+	databaseUrl = getEnv().DATABASE_URL,
+}: {
+	appDbBinding?: unknown
+	databaseUrl?: string
+} = {}): NonNullable<Prisma.PrismaClientOptions['adapter']> {
+	if (isD1Database(appDbBinding)) {
+		return new PrismaD1(appDbBinding as ConstructorParameters<typeof PrismaD1>[0])
+	}
+	return new PrismaBetterSqlite3({ url: databaseUrl })
+}
+
+function isD1Database(value: unknown) {
+	if (!value || typeof value !== 'object') return false
+	const binding = value as Record<string, unknown>
+	return ['prepare', 'batch', 'exec', 'dump', 'withSession'].every(
+		(method) => typeof binding[method] === 'function',
+	)
+}
+
+export { getPrismaAdapter }

--- a/services/site/app/utils/prisma.server.ts
+++ b/services/site/app/utils/prisma.server.ts
@@ -1,11 +1,10 @@
 import { remember } from '@epic-web/remember'
-import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import chalk from 'chalk'
 import pProps from 'p-props'
 import { type Session } from '#app/types.ts'
-import { getEnv } from '#app/utils/env.server.ts'
 import { getEpisodeHomeworkContentId } from '#app/utils/favorites.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
+import { getPrismaAdapter } from './prisma-adapter.server.ts'
 import { Prisma, PrismaClient } from './prisma-generated.server/client.ts'
 import { time, type Timings } from './timing.server.ts'
 
@@ -17,9 +16,8 @@ function getClient(): PrismaClient {
 	// NOTE: during development if you change anything in this function, remember
 	// that this only runs once per server restart and won't automatically be
 	// re-run per request like everything else is.
-	const url = getEnv().DATABASE_URL
 	const client = new PrismaClient({
-		adapter: new PrismaBetterSqlite3({ url }),
+		adapter: getPrismaAdapter(),
 		log: [
 			{ level: 'query', emit: 'event' },
 			{ level: 'error', emit: 'stdout' },

--- a/services/site/app/utils/runtime-bindings.server.ts
+++ b/services/site/app/utils/runtime-bindings.server.ts
@@ -1,0 +1,11 @@
+type RuntimeBindings = Record<string, unknown>
+
+declare global {
+	var __runtimeBindings: RuntimeBindings | undefined
+}
+
+function getRuntimeBinding(name: string) {
+	return globalThis.__runtimeBindings?.[name]
+}
+
+export { getRuntimeBinding }

--- a/services/site/package.json
+++ b/services/site/package.json
@@ -69,6 +69,7 @@
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
     "@prisma/adapter-better-sqlite3": "^7.8.0",
+    "@prisma/adapter-d1": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@reach/accordion": "^0.18.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `@prisma/adapter-d1` to the site workspace at the existing Prisma version range.
- Route Prisma adapter creation through a small helper that uses Better SQLite by default and Prisma D1 only when `APP_DB` is a D1-shaped runtime binding.
- Document `APP_DB` as Worker/D1-only and add focused unit coverage for SQLite fallback and D1 binding selection.

## Validation
- `node v26.3.0 npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/prisma.server.test.ts`
- `node v26.3.0 npm run lint --workspace kentcdodds.com`
- `node v26.3.0 npm run typecheck --workspace kentcdodds.com`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e511914c-f6c6-44e0-9225-6bd09aae40d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e511914c-f6c6-44e0-9225-6bd09aae40d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for D1 database adapter alongside existing SQLite configuration options.

* **Tests**
  * Added test suite for database adapter selection logic.

* **Chores**
  * Updated environment configuration with new variable placeholder.
  * Added `@prisma/adapter-d1` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->