### PR TITLE
Add site Cloudflare Worker scaffold

### DIFF
--- a/.github/workflows/validate-site-worker.yml
+++ b/.github/workflows/validate-site-worker.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/validate-site-worker.yml
+++ b/.github/workflows/validate-site-worker.yml
@@ -1,0 +1,43 @@
+name: Validate Site Worker
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate-site-worker.yml
+      - package-lock.json
+      - package.json
+      - services/site-worker/**
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate Site Worker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install site worker deps
+        run: npm ci --workspace=site-worker --include-workspace-root
+
+      - name: Lint site worker
+        run: npm run lint --workspace site-worker
+
+      - name: Typecheck site worker
+        run: npm run typecheck --workspace site-worker
+
+      - name: Test site worker
+        run: npm run test --workspace site-worker
+
+      - name: Wrangler deploy dry run
+        working-directory: services/site-worker
+        run: npm exec wrangler -- deploy --dry-run

--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -110,6 +110,8 @@ output). If it didn't, run `node prisma/seed.ts` from `services/site/`.
 
 - The Cursor Cloud VM snapshot ships with Node 24 via nvm, so run
   `nvm install 26 && nvm use 26` before installing dependencies or testing.
+  If the shell still resolves `/exec-daemon/node`, prepend nvm after switching:
+  `export PATH="$NVM_BIN:$PATH"`.
   Chrome is configured to
   open `localhost:3000` on startup and new tabs, and the browser pre-logged-in
   as the seed admin user (`me@kentcdodds.com` / `iliketwix`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -24807,6 +24807,10 @@
         "node": ">=18"
       }
     },
+    "node_modules/site-worker": {
+      "resolved": "services/site-worker",
+      "link": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -27954,6 +27958,33 @@
       }
     },
     "services/search-worker/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "services/site-worker": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260306.1",
+        "@epic-web/config": "^2.0.0",
+        "@types/node": "^25.5.0",
+        "oxlint": "^1.51.0",
+        "prettier": "^3.8.1",
+        "typescript": "^6.0.2",
+        "vitest": "^4.0.18",
+        "wrangler": "^4.80.0"
+      }
+    },
+    "services/site-worker/node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",

--- a/services/site-worker/package.json
+++ b/services/site-worker/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "site-worker",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "format": "prettier --write .",
+    "lint": "oxlint . --ignore-pattern .wrangler",
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --port 8788",
+    "start": "wrangler dev --port 8788",
+    "cf-typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260306.1",
+    "@epic-web/config": "^2.0.0",
+    "@types/node": "^25.5.0",
+    "oxlint": "^1.51.0",
+    "prettier": "^3.8.1",
+    "typescript": "^6.0.2",
+    "vitest": "^4.0.18",
+    "wrangler": "^4.80.0"
+  },
+  "prettier": "@epic-web/config/prettier"
+}

--- a/services/site-worker/readme.md
+++ b/services/site-worker/readme.md
@@ -1,0 +1,18 @@
+This Worker is a staging Cloudflare Worker shell for the main `kentcdodds.com`
+site.
+
+It intentionally does not route production traffic or replace the Fly deploy.
+For now it is only configured for the default `workers.dev` route and exposes a
+minimal health endpoint:
+
+- `GET /health` -> `{ "ok": true }`
+
+## Local development
+
+- Run `npm run dev --workspace site-worker`
+- Run checks with:
+  - `npm run lint --workspace site-worker`
+  - `npm run typecheck --workspace site-worker`
+  - `npm run test --workspace site-worker`
+- Validate the Worker bundle with:
+  - `cd services/site-worker && npm exec wrangler -- deploy --dry-run`

--- a/services/site-worker/src/index.test.ts
+++ b/services/site-worker/src/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import { handleRequest } from './index'
+
+describe('site worker', () => {
+	test('returns ok from GET /health', async () => {
+		const response = await handleRequest(
+			new Request('https://example.com/health'),
+		)
+
+		await expect(response.json()).resolves.toEqual({ ok: true })
+		expect(response.status).toBe(200)
+	})
+
+	test('rejects non-GET /health requests', async () => {
+		const response = await handleRequest(
+			new Request('https://example.com/health', { method: 'POST' }),
+		)
+
+		await expect(response.json()).resolves.toEqual({
+			ok: false,
+			error: 'Method not allowed',
+		})
+		expect(response.status).toBe(405)
+		expect(response.headers.get('Allow')).toBe('GET')
+	})
+
+	test('returns not found for other paths', async () => {
+		const response = await handleRequest(new Request('https://example.com/'))
+
+		await expect(response.json()).resolves.toEqual({
+			ok: false,
+			error: 'Not found',
+		})
+		expect(response.status).toBe(404)
+	})
+})

--- a/services/site-worker/src/index.ts
+++ b/services/site-worker/src/index.ts
@@ -1,0 +1,36 @@
+type ErrorResponse = {
+	ok: false
+	error: string
+}
+
+type HealthResponse = {
+	ok: true
+}
+
+function json(data: ErrorResponse | HealthResponse, init?: ResponseInit) {
+	return Response.json(data, init)
+}
+
+function methodNotAllowed() {
+	return json(
+		{ ok: false, error: 'Method not allowed' },
+		{ status: 405, headers: { Allow: 'GET' } },
+	)
+}
+
+export async function handleRequest(request: Request) {
+	const url = new URL(request.url)
+
+	if (url.pathname === '/health') {
+		if (request.method !== 'GET') return methodNotAllowed()
+		return json({ ok: true })
+	}
+
+	return json({ ok: false, error: 'Not found' }, { status: 404 })
+}
+
+export default {
+	async fetch(request: Request) {
+		return await handleRequest(request)
+	},
+} satisfies ExportedHandler

--- a/services/site-worker/tsconfig.json
+++ b/services/site-worker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["@cloudflare/workers-types", "node", "vitest/globals"]
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/services/site-worker/wrangler.jsonc
+++ b/services/site-worker/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "kentcdodds-com-staging",
+	"main": "src/index.ts",
+	"compatibility_date": "2026-03-17",
+	"compatibility_flags": ["nodejs_compat"],
+	"workers_dev": true
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a minimal `services/site-worker` workspace with a workers.dev-only Wrangler config
- implement `GET /health` returning `{ "ok": true }`
- add a validation workflow that installs the workspace, typechecks/tests it, and runs `npm exec wrangler -- deploy --dry-run`
- harden the workflow checkout with `persist-credentials: false`
- keep the existing Fly deploy workflow unchanged

## Verification
- `npm ci --workspace=site-worker --include-workspace-root`
- `npm exec prettier -- --check .github/workflows/validate-site-worker.yml`
- `npm run lint --workspace site-worker`
- `npm run typecheck --workspace site-worker`
- `npm run test --workspace site-worker`
- `cd services/site-worker && npm exec wrangler -- deploy --dry-run`
- PR checks green: Validate Site Worker, Deploy Planner/Site Gate/Playwright, Cursor Bugbot, CodeRabbit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f38ba60b-beec-4aab-a1b1-c707fd2a9aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f38ba60b-beec-4aab-a1b1-c707fd2a9aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staging Cloudflare Worker deployment with a health endpoint for the site.

* **Documentation**
  * Added setup and development documentation for the site worker.

* **Tests**
  * Added comprehensive test coverage for the worker.

* **Chores**
  * Added GitHub Actions validation workflow for site worker deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->