### PR TITLE
Add site runtime binding indirection

### DIFF
--- a/services/site/app/utils/__tests__/env.server.test.ts
+++ b/services/site/app/utils/__tests__/env.server.test.ts
@@ -82,3 +82,16 @@ test('clearRuntimeEnvSource restores process.env reads', () => {
 	expect(getEnv().PORT).toBe(3100)
 	expect(getEnv().DATABASE_PATH).toBe('/tmp/process-env.sqlite')
 })
+
+test('getEnv cache distinguishes unset values from empty strings', () => {
+	using _env = setEnv({
+		SENTRY_DSN: undefined,
+	})
+	expect(getEnv().SENTRY_DSN).toBeUndefined()
+
+	using _updatedEnv = setEnv({
+		SENTRY_DSN: '',
+	})
+
+	expect(getEnv().SENTRY_DSN).toBe('')
+})

--- a/services/site/app/utils/__tests__/env.server.test.ts
+++ b/services/site/app/utils/__tests__/env.server.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, test } from 'vitest'
+import { setEnv } from '#tests/env-disposable.ts'
+import {
+	clearRuntimeEnvSource,
+	getEnv,
+	setRuntimeEnvSource,
+	type RuntimeEnvSource,
+} from '../env.server.ts'
+
+afterEach(() => {
+	clearRuntimeEnvSource()
+})
+
+function createRuntimeEnvSource(
+	overrides: RuntimeEnvSource = {},
+): RuntimeEnvSource {
+	return {
+		...process.env,
+		...overrides,
+	}
+}
+
+test('getEnv reads from process.env by default', () => {
+	using _env = setEnv({
+		PORT: '3100',
+		DATABASE_URL: 'file:/tmp/process-env.sqlite',
+		DATABASE_PATH: undefined,
+		MOCKS: 'false',
+	})
+
+	const env = getEnv()
+
+	expect(env.PORT).toBe(3100)
+	expect(env.DATABASE_PATH).toBe('/tmp/process-env.sqlite')
+	expect(env.MOCKS).toBe(false)
+})
+
+test('getEnv reads from the configured runtime env source', () => {
+	using _env = setEnv({
+		PORT: '3100',
+		DATABASE_URL: 'file:/tmp/process-env.sqlite',
+		DATABASE_PATH: undefined,
+	})
+	setRuntimeEnvSource(
+		createRuntimeEnvSource({
+			PORT: '4200',
+			DATABASE_URL: 'file:/tmp/runtime-env-source.sqlite',
+			DATABASE_PATH: undefined,
+			MOCKS: 'true',
+			ALLOWED_ACTION_ORIGINS: 'https://a.example, https://b.example',
+		}),
+	)
+
+	const env = getEnv()
+
+	expect(env.PORT).toBe(4200)
+	expect(env.DATABASE_PATH).toBe('/tmp/runtime-env-source.sqlite')
+	expect(env.MOCKS).toBe(true)
+	expect(env.allowedActionOrigins).toEqual([
+		'https://a.example',
+		'https://b.example',
+	])
+})
+
+test('clearRuntimeEnvSource restores process.env reads', () => {
+	using _env = setEnv({
+		PORT: '3100',
+		DATABASE_URL: 'file:/tmp/process-env.sqlite',
+		DATABASE_PATH: undefined,
+	})
+	setRuntimeEnvSource(
+		createRuntimeEnvSource({
+			PORT: '4200',
+			DATABASE_URL: 'file:/tmp/runtime-env-source.sqlite',
+			DATABASE_PATH: undefined,
+		}),
+	)
+	expect(getEnv().PORT).toBe(4200)
+
+	clearRuntimeEnvSource()
+
+	expect(getEnv().PORT).toBe(3100)
+	expect(getEnv().DATABASE_PATH).toBe('/tmp/process-env.sqlite')
+})

--- a/services/site/app/utils/__tests__/runtime-bindings.server.test.ts
+++ b/services/site/app/utils/__tests__/runtime-bindings.server.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, test } from 'vitest'
+import {
+	clearRuntimeEnvSource,
+	setRuntimeEnvSource,
+	type RuntimeEnvSource,
+} from '../env.server.ts'
+import {
+	clearRuntimeBindingSource,
+	getRuntimeBinding,
+	setRuntimeBindingSource,
+} from '../runtime-bindings.server.ts'
+
+afterEach(() => {
+	clearRuntimeBindingSource()
+	clearRuntimeEnvSource()
+})
+
+function createRuntimeEnvSource(
+	overrides: RuntimeEnvSource = {},
+): RuntimeEnvSource {
+	return {
+		...process.env,
+		...overrides,
+	}
+}
+
+test('getRuntimeBinding reads from getEnv when no binding source is configured', () => {
+	setRuntimeEnvSource(
+		createRuntimeEnvSource({
+			DATABASE_URL: 'file:/tmp/runtime-binding.sqlite',
+			DATABASE_PATH: undefined,
+			PORT: '4500',
+			SEARCH_WORKER_TOKEN: 'env-search-token',
+		}),
+	)
+
+	expect(getRuntimeBinding('DATABASE_PATH')).toBe('/tmp/runtime-binding.sqlite')
+	expect(getRuntimeBinding('SEARCH_WORKER_TOKEN')).toBe('env-search-token')
+	expect(getRuntimeBinding('PORT')).toBe(4500)
+})
+
+test('getRuntimeBinding prefers the configured binding source', () => {
+	const d1Binding = {
+		prepare() {
+			return null
+		},
+	}
+	setRuntimeEnvSource(
+		createRuntimeEnvSource({
+			SEARCH_WORKER_TOKEN: 'env-search-token',
+		}),
+	)
+	setRuntimeBindingSource({
+		DB: d1Binding,
+		SEARCH_WORKER_TOKEN: 'binding-search-token',
+	})
+
+	expect(getRuntimeBinding('DB')).toBe(d1Binding)
+	expect(getRuntimeBinding('SEARCH_WORKER_TOKEN')).toBe('binding-search-token')
+})
+
+test('getRuntimeBinding falls back to getEnv after clearing the binding source', () => {
+	setRuntimeEnvSource(
+		createRuntimeEnvSource({
+			SEARCH_WORKER_TOKEN: 'env-search-token',
+		}),
+	)
+	setRuntimeBindingSource({
+		SEARCH_WORKER_TOKEN: 'binding-search-token',
+	})
+	expect(getRuntimeBinding('SEARCH_WORKER_TOKEN')).toBe('binding-search-token')
+
+	clearRuntimeBindingSource()
+
+	expect(getRuntimeBinding('SEARCH_WORKER_TOKEN')).toBe('env-search-token')
+})

--- a/services/site/app/utils/env.server.ts
+++ b/services/site/app/utils/env.server.ts
@@ -175,6 +175,7 @@ const schema = schemaBase.superRefine((values, ctx) => {
 
 type BaseEnv = z.infer<typeof schemaBase>
 type BaseEnvInput = z.input<typeof schemaBase>
+export type RuntimeEnvSource = Record<string, string | undefined>
 
 export type Env = Omit<
 	BaseEnv,
@@ -247,16 +248,28 @@ let _cache:
 			env: Env
 	  }
 	| undefined
+let runtimeEnvSource: RuntimeEnvSource | undefined
+
+export function setRuntimeEnvSource(source: RuntimeEnvSource) {
+	runtimeEnvSource = source
+	_cache = undefined
+}
+
+export function clearRuntimeEnvSource() {
+	runtimeEnvSource = undefined
+	_cache = undefined
+}
 
 export function getEnv(): Env {
 	const keys = Object.keys(schemaBase.shape) as Array<keyof BaseEnv>
+	const source = runtimeEnvSource ?? process.env
 	const fingerprint = keys
-		.map((k) => `${String(k)}=${process.env[String(k)] ?? ''}`)
+		.map((k) => `${String(k)}=${source[String(k)] ?? ''}`)
 		.join('\0')
 
 	if (_cache?.fingerprint === fingerprint) return _cache.env
 
-	const parsed = schema.safeParse(process.env)
+	const parsed = schema.safeParse(source)
 
 	if (parsed.success === false) {
 		// Prefer throwing the ZodError; `init()` prints a nicer message.

--- a/services/site/app/utils/env.server.ts
+++ b/services/site/app/utils/env.server.ts
@@ -264,7 +264,7 @@ export function getEnv(): Env {
 	const keys = Object.keys(schemaBase.shape) as Array<keyof BaseEnv>
 	const source = runtimeEnvSource ?? process.env
 	const fingerprint = keys
-		.map((k) => `${String(k)}=${source[String(k)] ?? ''}`)
+		.map((k) => `${String(k)}=${JSON.stringify(source[String(k)])}`)
 		.join('\0')
 
 	if (_cache?.fingerprint === fingerprint) return _cache.env

--- a/services/site/app/utils/runtime-bindings.server.ts
+++ b/services/site/app/utils/runtime-bindings.server.ts
@@ -1,0 +1,26 @@
+import { getEnv } from './env.server.ts'
+
+export type RuntimeBindingSource = Record<string, unknown>
+
+let runtimeBindingSource: RuntimeBindingSource | undefined
+
+function hasOwn(source: RuntimeBindingSource, name: string) {
+	return Object.prototype.hasOwnProperty.call(source, name)
+}
+
+export function setRuntimeBindingSource(source: RuntimeBindingSource) {
+	runtimeBindingSource = source
+}
+
+export function clearRuntimeBindingSource() {
+	runtimeBindingSource = undefined
+}
+
+export function getRuntimeBinding<T = unknown>(name: string): T | undefined {
+	if (runtimeBindingSource && hasOwn(runtimeBindingSource, name)) {
+		return runtimeBindingSource[name] as T | undefined
+	}
+
+	const env = getEnv() as RuntimeBindingSource
+	return env[name] as T | undefined
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an optional runtime env source override to `env.server.ts` while keeping `process.env` as the default Node/Fly source
- add `runtime-bindings.server.ts` with binding-source overrides and `getEnv()` fallback for existing env/path-backed values
- add focused unit tests for env source overrides, binding overrides, fallback, clearing behavior, and env cache fingerprinting
- address CodeRabbit feedback by distinguishing unset env values from empty strings in the cache fingerprint

## Notes
- Foundation-only change: no call-site migration, no D1 wiring, no Worker entrypoint, and no `wrangler.toml` added under `services/site`.

## Testing
- `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/env.server.test.ts app/utils/__tests__/runtime-bindings.server.test.ts` (7 tests passed after feedback fix)
- `npm run lint --workspace kentcdodds.com`
- `npm run typecheck --workspace kentcdodds.com`
- `npm run test:backend --workspace kentcdodds.com` (42 files / 143 tests passed after feedback fix)
- `npm run test:browser --workspace kentcdodds.com` (8 passed / 1 skipped files, 14 passed / 1 skipped tests)
- `npm exec --workspace kentcdodds.com prettier -- --check app/utils/env.server.ts app/utils/runtime-bindings.server.ts app/utils/__tests__/env.server.test.ts app/utils/__tests__/runtime-bindings.server.test.ts`
- pre-commit hook: `npm run precommit:verify` (format staged, lint:all, typecheck:all, build:all)
- pre-push hook: `npm run prepush:verify` / `npm run test:all`
- PR CI after latest push: all required checks passed; deploy jobs skipped as expected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-483fd025-46b3-4303-adc1-f91e936a3e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-483fd025-46b3-4303-adc1-f91e936a3e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to override runtime environment and provide runtime bindings for server code.

* **Tests**
  * Added comprehensive tests ensuring env overrides, binding precedence, cache behavior, and correct parsing/clearing.

* **Chores**
  * Improve environment/configuration handling to prevent stale cached values and increase robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->