### PR TITLE
Use readable stream SSR in site entry

### DIFF
--- a/services/site/app/entry.server.tsx
+++ b/services/site/app/entry.server.tsx
@@ -91,20 +91,27 @@ async function serveTheBots(...args: DocRequestArgs) {
 		loadContext,
 	] = args
 	const nonce = loadContext.cspNonce ? String(loadContext.cspNonce) : ''
-	const controller = new AbortController()
-	setTimeout(() => controller.abort(), ABORT_DELAY)
-	const stream = await renderToReadableStream(
-		<NonceProvider value={nonce}>
-			<ServerRouter
-				context={reactRouterContext}
-				url={request.url}
-				nonce={nonce}
-			/>
-		</NonceProvider>,
-		{ nonce, signal: controller.signal },
-	)
-	// Use allReady to wait for the entire document to be ready.
-	await stream.allReady
+	const { controller, clearAbortTimeout } = createAbortTimeout()
+	let stream: Awaited<ReturnType<typeof renderToReadableStream>>
+	try {
+		stream = await renderToReadableStream(
+			<NonceProvider value={nonce}>
+				<ServerRouter
+					context={reactRouterContext}
+					url={request.url}
+					nonce={nonce}
+				/>
+			</NonceProvider>,
+			{ nonce, signal: controller.signal },
+		)
+		// Use allReady to wait for the entire document to be ready.
+		await stream.allReady
+	} catch (error) {
+		Sentry.captureException(error)
+		throw error
+	} finally {
+		clearAbortTimeout()
+	}
 	responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
 	return new Response(transformDataEvtAttributes(stream, nonce), {
 		status: responseStatusCode,
@@ -122,33 +129,57 @@ async function serveBrowsers(...args: DocRequestArgs) {
 	] = args
 	const nonce = loadContext.cspNonce ? String(loadContext.cspNonce) : ''
 	let didError = false
-	const controller = new AbortController()
-	setTimeout(() => controller.abort(), ABORT_DELAY)
-	const stream = await renderToReadableStream(
-		<NonceProvider value={nonce}>
-			<ServerRouter
-				context={reactRouterContext}
-				url={request.url}
-				nonce={nonce}
-			/>
-		</NonceProvider>,
-		{
-			nonce,
-			signal: controller.signal,
-			onError(err: unknown) {
-				didError = true
-				console.error(err)
+	const { controller, clearAbortTimeout } = createAbortTimeout()
+	let stream: Awaited<ReturnType<typeof renderToReadableStream>>
+	try {
+		stream = await renderToReadableStream(
+			<NonceProvider value={nonce}>
+				<ServerRouter
+					context={reactRouterContext}
+					url={request.url}
+					nonce={nonce}
+				/>
+			</NonceProvider>,
+			{
+				nonce,
+				signal: controller.signal,
+				onError(err: unknown) {
+					didError = true
+					console.error(err)
+					Sentry.captureException(err)
+				},
 			},
+		)
+	} catch (error) {
+		Sentry.captureException(error)
+		throw error
+	}
+	responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
+	return new Response(
+		transformDataEvtAttributes(stream, nonce, clearAbortTimeout),
+		{
+			status: didError ? 500 : responseStatusCode,
+			headers: responseHeaders,
 		},
 	)
-	responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
-	return new Response(transformDataEvtAttributes(stream, nonce), {
-		status: didError ? 500 : responseStatusCode,
-		headers: responseHeaders,
-	})
 }
 
-function transformDataEvtAttributes(stream: ReadableStream, nonce: string) {
+function createAbortTimeout() {
+	const controller = new AbortController()
+	const timeoutId = setTimeout(() => controller.abort(), ABORT_DELAY)
+	return {
+		controller,
+		clearAbortTimeout() {
+			clearTimeout(timeoutId)
+		},
+	}
+}
+
+function transformDataEvtAttributes(
+	stream: ReadableStream,
+	nonce: string,
+	onDone?: () => void,
+) {
 	// React won't render the onload prop, which blurrable image marks as data-evt-*.
 	return stream
 		.pipeThrough(new TextDecoderStream())
@@ -156,6 +187,9 @@ function transformDataEvtAttributes(stream: ReadableStream, nonce: string) {
 			new TransformStream({
 				transform(chunk: string, controller) {
 					controller.enqueue(chunk.replace(/data-evt-/g, `nonce="${nonce}" `))
+				},
+				flush() {
+					onDone?.()
 				},
 			}),
 		)

--- a/services/site/app/entry.server.tsx
+++ b/services/site/app/entry.server.tsx
@@ -1,10 +1,7 @@
-import { PassThrough, Transform } from 'stream'
-
-import { createReadableStreamFromReadable } from '@react-router/node'
 import * as Sentry from '@sentry/react-router'
 import chalk from 'chalk'
 import { isbot } from 'isbot'
-import { renderToPipeableStream } from 'react-dom/server'
+import { renderToReadableStream } from 'react-dom/server'
 import {
 	ServerRouter,
 	type ActionFunctionArgs,
@@ -85,7 +82,7 @@ export default async function handleDocumentRequest(...args: DocRequestArgs) {
 	)
 }
 
-function serveTheBots(...args: DocRequestArgs) {
+async function serveTheBots(...args: DocRequestArgs) {
 	const [
 		request,
 		responseStatusCode,
@@ -94,51 +91,28 @@ function serveTheBots(...args: DocRequestArgs) {
 		loadContext,
 	] = args
 	const nonce = loadContext.cspNonce ? String(loadContext.cspNonce) : ''
-	return new Promise((resolve, reject) => {
-		const stream = renderToPipeableStream(
-			<NonceProvider value={nonce}>
-				<ServerRouter
-					context={reactRouterContext}
-					url={request.url}
-					nonce={nonce}
-				/>
-			</NonceProvider>,
-			{
-				nonce,
-				// Use onAllReady to wait for the entire document to be ready
-				onAllReady() {
-					responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
-					const body = new PassThrough()
-
-					// find/replace all instances of the string "data-evt-" with ""
-					// this is a bit of a hack because React won't render the "onload"
-					// prop, which we use for blurrable image
-					const dataEvtTransform = new Transform({
-						transform(chunk, encoding, callback) {
-							const string = chunk.toString()
-							const replaced = string.replace(/data-evt-/g, `nonce="${nonce}" `)
-							callback(null, replaced)
-						},
-					})
-
-					stream.pipe(dataEvtTransform).pipe(body)
-					resolve(
-						new Response(createReadableStreamFromReadable(body), {
-							status: responseStatusCode,
-							headers: responseHeaders,
-						}),
-					)
-				},
-				onShellError(err: unknown) {
-					reject(err)
-				},
-			},
-		)
-		setTimeout(() => stream.abort(), ABORT_DELAY)
+	const controller = new AbortController()
+	setTimeout(() => controller.abort(), ABORT_DELAY)
+	const stream = await renderToReadableStream(
+		<NonceProvider value={nonce}>
+			<ServerRouter
+				context={reactRouterContext}
+				url={request.url}
+				nonce={nonce}
+			/>
+		</NonceProvider>,
+		{ nonce, signal: controller.signal },
+	)
+	// Use allReady to wait for the entire document to be ready.
+	await stream.allReady
+	responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
+	return new Response(transformDataEvtAttributes(stream, nonce), {
+		status: responseStatusCode,
+		headers: responseHeaders,
 	})
 }
 
-function serveBrowsers(...args: DocRequestArgs) {
+async function serveBrowsers(...args: DocRequestArgs) {
 	const [
 		request,
 		responseStatusCode,
@@ -147,53 +121,45 @@ function serveBrowsers(...args: DocRequestArgs) {
 		loadContext,
 	] = args
 	const nonce = loadContext.cspNonce ? String(loadContext.cspNonce) : ''
-	return new Promise((resolve, reject) => {
-		let didError = false
-		const stream = renderToPipeableStream(
-			<NonceProvider value={nonce}>
-				<ServerRouter
-					context={reactRouterContext}
-					url={request.url}
-					nonce={nonce}
-				/>
-			</NonceProvider>,
-			{
-				nonce,
-				// use onShellReady to wait until a suspense boundary is triggered
-				onShellReady() {
-					responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
-					const body = new PassThrough()
-
-					// find/replace all instances of the string "data-evt-" with ""
-					// this is a bit of a hack because React won't render the "onload"
-					// prop, which we use for blurrable image
-					const dataEvtTransform = new Transform({
-						transform(chunk, encoding, callback) {
-							const string = chunk.toString()
-							const replaced = string.replace(/data-evt-/g, `nonce="${nonce}" `)
-							callback(null, replaced)
-						},
-					})
-
-					stream.pipe(dataEvtTransform).pipe(body)
-					resolve(
-						new Response(createReadableStreamFromReadable(body), {
-							status: didError ? 500 : responseStatusCode,
-							headers: responseHeaders,
-						}),
-					)
-				},
-				onShellError(err: unknown) {
-					reject(err)
-				},
-				onError(err: unknown) {
-					didError = true
-					console.error(err)
-				},
+	let didError = false
+	const controller = new AbortController()
+	setTimeout(() => controller.abort(), ABORT_DELAY)
+	const stream = await renderToReadableStream(
+		<NonceProvider value={nonce}>
+			<ServerRouter
+				context={reactRouterContext}
+				url={request.url}
+				nonce={nonce}
+			/>
+		</NonceProvider>,
+		{
+			nonce,
+			signal: controller.signal,
+			onError(err: unknown) {
+				didError = true
+				console.error(err)
 			},
-		)
-		setTimeout(() => stream.abort(), ABORT_DELAY)
+		},
+	)
+	responseHeaders.set('Content-Type', 'text/html; charset=UTF-8')
+	return new Response(transformDataEvtAttributes(stream, nonce), {
+		status: didError ? 500 : responseStatusCode,
+		headers: responseHeaders,
 	})
+}
+
+function transformDataEvtAttributes(stream: ReadableStream, nonce: string) {
+	// React won't render the onload prop, which blurrable image marks as data-evt-*.
+	return stream
+		.pipeThrough(new TextDecoderStream())
+		.pipeThrough(
+			new TransformStream({
+				transform(chunk: string, controller) {
+					controller.enqueue(chunk.replace(/data-evt-/g, `nonce="${nonce}" `))
+				},
+			}),
+		)
+		.pipeThrough(new TextEncoderStream())
 }
 
 export async function handleDataRequest(response: Response) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- migrate `services/site/app/entry.server.tsx` from `renderToPipeableStream` to `renderToReadableStream`
- return Web `ReadableStream` responses directly for bot and browser document rendering
- replace the Node stream transform for `data-evt-*` attributes with a Web `TransformStream`
- clear SSR abort timers and capture render errors with Sentry after CodeRabbit feedback

## Validation
- `npm run lint --workspace kentcdodds.com`
- `npm run typecheck --workspace kentcdodds.com`
- `npm run build --workspace kentcdodds.com`
- `npm run test:backend --workspace kentcdodds.com` (40 files / 136 tests)
- Built-server smoke with `.env.example` + `MOCKS=true`:
  - `/login` browser UA: `200`, `text/html; charset=UTF-8`
  - `/login` Googlebot UA: `200`, `text/html; charset=UTF-8`
  - `/login` with `Accept: text/markdown`: `200`, `text/markdown; charset=utf-8`, `Vary` includes `Accept`
  - `/blog/stop-using-isloading-booleans`: `200`, `data-evt-count=0`, `nonce-onload-count=4`
- Remote PR checks passed after the follow-up push:
  - `🔎 Plan Deploys`
  - `🚀 Site Pipeline / ✅ Site Gate`
  - `🚀 Site Pipeline / 🎭 Playwright`
  - `Cursor Bugbot`
  - `CodeRabbit`

## Notes
- No dedicated `entry.server` tests exist to adjust.
- Local `test:browser` could not be run because Playwright Chromium was missing and multiple install attempts in this VM hung after the download reached 100%. Remote Playwright passed on the PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e01dcb23-d2e7-47aa-a556-08b605760902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e01dcb23-d2e7-47aa-a556-08b605760902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and HTTP status reporting for server-side rendering.
  * Enhanced timeout/abort protection for both bot and browser requests.

* **Refactor**
  * Streamlined server-side streaming for more reliable and performant responses.
  * Centralized transformation of security-related attributes (CSP nonce handling) for consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->