### PR TITLE
Fix Call Kent recording submissions

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -115,7 +115,7 @@ output). If it didn't, run `node prisma/seed.ts` from `services/site/`.
   as the seed admin user (`me@kentcdodds.com` / `iliketwix`).
 - If `node --version` still reports an older version after `nvm use 26`, the
   `/exec-daemon/node` shim is ahead of nvm on `PATH`; prefix commands with
-  `PATH="$HOME/.nvm/versions/node/v26.3.0/bin:$PATH"` when testing.
+  `PATH="$(dirname "$(nvm which 26)"):$PATH"` when testing.
 - The first request after starting the dev server compiles all MDX blog posts
   and can take ~30 s; subsequent loads are fast.
 - In cloud VMs, Chrome may block camera/microphone access by default. Visiting

--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -113,6 +113,9 @@ output). If it didn't, run `node prisma/seed.ts` from `services/site/`.
   Chrome is configured to
   open `localhost:3000` on startup and new tabs, and the browser pre-logged-in
   as the seed admin user (`me@kentcdodds.com` / `iliketwix`).
+- If `node --version` still reports an older version after `nvm use 26`, the
+  `/exec-daemon/node` shim is ahead of nvm on `PATH`; prefix commands with
+  `PATH="$HOME/.nvm/versions/node/v26.3.0/bin:$PATH"` when testing.
 - The first request after starting the dev server compiles all MDX blog posts
   and can take ~30 s; subsequent loads are fast.
 - In cloud VMs, Chrome may block camera/microphone access by default. Visiting

--- a/services/site/app/components/calls/__tests__/submit-recording-form.test.browser.tsx
+++ b/services/site/app/components/calls/__tests__/submit-recording-form.test.browser.tsx
@@ -64,29 +64,6 @@ test('RecordingForm submits a valid recording and follows the redirect', async (
 		requestInfo: { flyPrimaryInstance: 'primary-abc123' },
 	})
 
-	let loadEndListener: (() => void) | null = null
-	const readAsDataURL = vi.fn(function (this: SuccessfulFileReader) {
-		this.result = 'data:audio/wav;base64,ZmFrZQ=='
-		loadEndListener?.()
-	})
-
-	class SuccessfulFileReader {
-		result: string | ArrayBuffer | null = null
-		addEventListener(
-			eventName: string,
-			listener: EventListenerOrEventListenerObject,
-		) {
-			if (eventName === 'loadend') {
-				loadEndListener =
-					typeof listener === 'function'
-						? () => listener(new Event('loadend'))
-						: null
-			}
-		}
-		removeEventListener() {}
-		readAsDataURL = readAsDataURL
-	}
-
 	const fetchMock = vi.fn().mockResolvedValue({
 		ok: true,
 		redirected: true,
@@ -94,10 +71,6 @@ test('RecordingForm submits a valid recording and follows the redirect', async (
 		headers: new Headers(),
 	} as unknown as Response)
 
-	vi.stubGlobal(
-		'FileReader',
-		SuccessfulFileReader as unknown as typeof FileReader,
-	)
 	vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 	const createObjectURL = vi
 		.spyOn(URL, 'createObjectURL')
@@ -107,15 +80,27 @@ test('RecordingForm submits a valid recording and follows the redirect', async (
 		.mockImplementation(() => {})
 
 	try {
+		const recording = new Blob(['audio'], { type: 'audio/webm' })
 		const screen = await render(
-			<RecordingForm audio={new Blob(['audio'])} intent="create-call" />,
+			<RecordingForm audio={recording} intent="create-call" />,
 		)
 		await screen.getByLabelText('Title').fill('My First Call')
 		await screen.getByRole('button', { name: 'Submit Recording' }).click()
 
 		await expect.poll(() => fetchMock.mock.calls.length).toBe(1)
-		expect(readAsDataURL).toHaveBeenCalledTimes(1)
 		expect(fetchMock.mock.calls[0]?.[0]).toBe('/resources/calls/save')
+		const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit
+		expect(requestInit.body).toBeInstanceOf(FormData)
+		const body = requestInit.body as FormData
+		expect(body.get('title')).toBe('My First Call')
+		expect(body.get('audio')).toBeInstanceOf(File)
+		const audio = body.get('audio') as File
+		expect(audio.size).toBe(recording.size)
+		expect(audio.type).toBe(recording.type)
+		expect((requestInit.headers as Headers).get('content-type')).toBeNull()
+		expect((requestInit.headers as Headers).get('fly-force-instance-id')).toBe(
+			'primary-abc123',
+		)
 		await expect.poll(() => mockNavigate.mock.calls.length).toBe(1)
 		expect(mockNavigate).toHaveBeenCalledWith(
 			'/calls/record/fake-call-id?ok=1#done',

--- a/services/site/app/components/calls/recording-form.tsx
+++ b/services/site/app/components/calls/recording-form.tsx
@@ -185,82 +185,54 @@ export function RecordingForm({
 			return
 		}
 
-		const reader = new FileReader()
-		const handleLoadEnd = async () => {
+		form.set('audio', audio, 'call-recording')
+		const headers = new Headers()
+		if (flyPrimaryInstance) {
+			headers.set('fly-force-instance-id', flyPrimaryInstance)
+		}
+		const abortController = new AbortController()
+		abortControllerRef.current = abortController
+		setIsSubmitting(true)
+
+		void (async () => {
 			try {
-				if (typeof reader.result !== 'string') {
-					setRequestError('Unable to read recording. Please try again.')
-					return
-				}
-				form.append('audio', reader.result)
-
-				const body = new URLSearchParams()
-				for (const [key, value] of form.entries()) {
-					if (typeof value === 'string') {
-						body.append(key, value)
-					}
-				}
-
-				const headers = new Headers({
-					'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+				const response = await fetch(recordingFormActionPath, {
+					method: 'POST',
+					body: form,
+					headers,
+					signal: abortController.signal,
 				})
-				if (flyPrimaryInstance) {
-					headers.set('fly-force-instance-id', flyPrimaryInstance)
-				}
-				const abortController = new AbortController()
-				abortControllerRef.current = abortController
 
-				try {
-					const response = await fetch(recordingFormActionPath, {
-						method: 'POST',
-						body,
-						headers,
-						signal: abortController.signal,
-					})
-
-					const redirectPath = getNavigationPathFromResponse(response)
-					if (redirectPath) {
-						await navigate(redirectPath)
-						return
-					}
-
-					if (response.ok) {
-						await revalidator.revalidate()
-						return
-					}
-
-					const actionData = await response.json().catch(() => null)
-					if (actionData && typeof actionData === 'object') {
-						setSubmissionData(actionData as RecordingFormData)
-					} else {
-						setRequestError('Something went wrong submitting your recording.')
-					}
+				const redirectPath = getNavigationPathFromResponse(response)
+				if (redirectPath) {
+					await navigate(redirectPath)
 					return
-				} catch (error: unknown) {
-					if (error instanceof DOMException && error.name === 'AbortError') {
-						return
-					}
-					console.error('Unable to submit recording', error)
-					setRequestError('Unable to submit recording. Please try again.')
-				} finally {
-					if (abortControllerRef.current === abortController) {
-						abortControllerRef.current = null
-					}
 				}
+
+				if (response.ok) {
+					await revalidator.revalidate()
+					return
+				}
+
+				const actionData = await response.json().catch(() => null)
+				if (actionData && typeof actionData === 'object') {
+					setSubmissionData(actionData as RecordingFormData)
+				} else {
+					setRequestError('Something went wrong submitting your recording.')
+				}
+			} catch (error: unknown) {
+				if (error instanceof DOMException && error.name === 'AbortError') {
+					return
+				}
+				console.error('Unable to submit recording', error)
+				setRequestError('Unable to submit recording. Please try again.')
 			} finally {
+				if (abortControllerRef.current === abortController) {
+					abortControllerRef.current = null
+				}
 				setIsSubmitting(false)
 			}
-		}
-		reader.addEventListener('loadend', handleLoadEnd, { once: true })
-		setIsSubmitting(true)
-		try {
-			reader.readAsDataURL(audio)
-		} catch (error: unknown) {
-			reader.removeEventListener('loadend', handleLoadEnd)
-			console.error('Unable to read recording', error)
-			setRequestError('Unable to read recording. Please try again.')
-			setIsSubmitting(false)
-		}
+		})()
 	}
 
 	const generalError = submissionData?.errors.generalError || requestError

--- a/services/site/app/routes/calls_.admin/$callId.tsx
+++ b/services/site/app/routes/calls_.admin/$callId.tsx
@@ -399,32 +399,25 @@ function ResponseAudioDraftForm({
 		const callTitleValue = String(formData.get('callTitle') ?? '')
 		const notesValue = String(formData.get('notes') ?? '')
 
-		const reader = new FileReader()
-		const handleLoadEnd = async () => {
+		const body = new FormData()
+		body.set('intent', 'create-episode-draft')
+		body.set('callId', callId)
+		body.set('audio', audio, 'response-recording')
+		body.set('callTitle', callTitleValue)
+		body.set('notes', notesValue)
+
+		const headers = new Headers()
+		if (flyPrimaryInstance) {
+			headers.set('fly-force-instance-id', flyPrimaryInstance)
+		}
+
+		abortControllerRef.current?.abort()
+		const abortController = new AbortController()
+		abortControllerRef.current = abortController
+		setIsSubmitting(true)
+
+		void (async () => {
 			try {
-				if (typeof reader.result !== 'string') {
-					setError('Unable to read recording. Please try again.')
-					return
-				}
-
-				const body = new URLSearchParams()
-				body.set('intent', 'create-episode-draft')
-				body.set('callId', callId)
-				body.set('audio', reader.result)
-				body.set('callTitle', callTitleValue)
-				body.set('notes', notesValue)
-
-				const headers = new Headers({
-					'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-				})
-				if (flyPrimaryInstance) {
-					headers.set('fly-force-instance-id', flyPrimaryInstance)
-				}
-
-				abortControllerRef.current?.abort()
-				const abortController = new AbortController()
-				abortControllerRef.current = abortController
-
 				const response = await fetch(recordingFormActionPath, {
 					method: 'POST',
 					body,
@@ -455,19 +448,12 @@ function ResponseAudioDraftForm({
 				if (e instanceof DOMException && e.name === 'AbortError') return
 				setError(e instanceof Error ? e.message : 'Unable to submit response.')
 			} finally {
+				if (abortControllerRef.current === abortController) {
+					abortControllerRef.current = null
+				}
 				setIsSubmitting(false)
 			}
-		}
-
-		reader.addEventListener('loadend', handleLoadEnd, { once: true })
-		setIsSubmitting(true)
-		try {
-			reader.readAsDataURL(audio)
-		} catch (e: unknown) {
-			reader.removeEventListener('loadend', handleLoadEnd)
-			setIsSubmitting(false)
-			setError(e instanceof Error ? e.message : 'Unable to read recording.')
-		}
+		})()
 	}
 
 	return (

--- a/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
+++ b/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
@@ -1,0 +1,107 @@
+import { expect, test, vi } from 'vitest'
+
+vi.mock('#app/components/calls/recording-form.tsx', () => ({}))
+
+vi.mock('#app/utils/cache.server.ts', () => ({
+	cache: {},
+	lruCache: {},
+	cachified: vi.fn(
+		async ({ getFreshValue }: { getFreshValue: () => unknown }) =>
+			getFreshValue(),
+	),
+	shouldForceFresh: vi.fn(() => false),
+}))
+
+vi.mock('#app/utils/session.server.ts', () => ({
+	requireUser: vi.fn(async () => ({
+		id: 'user_1',
+		email: 'probe@example.com',
+		firstName: 'Probe',
+		team: 'BLUE',
+		discordId: null,
+	})),
+	requireAdminUser: vi.fn(),
+}))
+
+vi.mock('#app/utils/prisma.server.ts', () => ({
+	prisma: {
+		call: {
+			create: vi.fn(async ({ data }: { data: { id: string } }) => ({
+				id: data.id,
+			})),
+		},
+	},
+}))
+
+vi.mock('#app/utils/call-kent-caller-transcript.server.ts', () => ({
+	startCallKentCallerTranscriptProcessing: vi.fn(),
+}))
+
+vi.mock('#app/utils/discord.server.ts', () => ({
+	sendMessageFromDiscordBot: vi.fn(),
+}))
+
+vi.mock('#app/utils/send-email.server.ts', () => ({
+	sendEmail: vi.fn(),
+}))
+
+vi.mock('#app/utils/transistor.server.ts', () => ({
+	createEpisode: vi.fn(),
+}))
+
+vi.mock('#app/utils/markdown.server.ts', () => ({
+	markdownToHtml: vi.fn(async (value: string) => value),
+}))
+
+vi.mock('#app/utils/call-kent-audio-processor.server.ts', () => ({
+	requestCallKentEpisodeAudioGeneration: vi.fn(),
+}))
+
+import { action } from '../save.tsx'
+
+test('create-call accepts a large multipart audio file', async () => {
+	const body = new FormData()
+	body.set('intent', 'create-call')
+	body.set('title', 'My large call')
+	body.set('notes', 'A large recording should submit successfully.')
+	body.set(
+		'audio',
+		new File([new Uint8Array(16 * 1024 * 1024)], 'call.webm', {
+			type: 'audio/webm',
+		}),
+	)
+	const request = new Request('http://localhost/resources/calls/save', {
+		method: 'POST',
+		headers: {
+			host: 'localhost',
+		},
+		body,
+	})
+
+	const response = (await action({ request } as never)) as Response
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('location')).toMatch(/^\/calls\/record\//)
+}, 30_000)
+
+test('create-call still accepts a urlencoded audio data URL', async () => {
+	const body = new URLSearchParams({
+		intent: 'create-call',
+		title: 'My data URL call',
+		notes: 'A legacy recording should submit successfully.',
+		audio: 'data:audio/webm;codecs=opus;base64,ZmFrZQ==',
+	})
+	const request = new Request('http://localhost/resources/calls/save', {
+		method: 'POST',
+		headers: {
+			host: 'localhost',
+			'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
+		},
+		body,
+	})
+
+	const response = (await action({ request } as never)) as Response
+
+	expect(response.status).toBe(302)
+	expect(response.headers.get('location')).toMatch(/^\/calls\/record\//)
+})

--- a/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
+++ b/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest'
+import { type RecordingFormData } from '#app/components/calls/recording-form.tsx'
 
 vi.mock('#app/components/calls/recording-form.tsx', () => ({}))
 
@@ -57,6 +58,43 @@ vi.mock('#app/utils/call-kent-audio-processor.server.ts', () => ({
 	requestCallKentEpisodeAudioGeneration: vi.fn(),
 }))
 
+vi.mock('#app/utils/call-kent-audio-storage.server.ts', () => ({
+	deleteAudioObject: vi.fn(async () => {}),
+	getAudioBuffer: vi.fn(async () => Buffer.from('audio')),
+	parseBase64DataUrl: vi.fn((dataUrl: string) => ({
+		buffer: Buffer.from(dataUrl),
+		contentType: 'audio/webm',
+	})),
+	putCallAudioFromBuffer: vi.fn(
+		async ({
+			callId,
+			audio,
+			contentType,
+		}: {
+			callId: string
+			audio: Uint8Array
+			contentType: string
+		}) => ({
+			key: `audio-${callId}`,
+			contentType,
+			size: audio.byteLength,
+		}),
+	),
+	putCallAudioFromDataUrl: vi.fn(
+		async ({ callId }: { callId: string; dataUrl: string }) => ({
+			key: `audio-${callId}`,
+			contentType: 'audio/webm',
+			size: 1024,
+		}),
+	),
+	putEpisodeDraftResponseAudioFromBuffer: vi.fn(async () => ({
+		key: 'response-audio',
+		contentType: 'audio/webm',
+		size: 1024,
+	})),
+}))
+
+import { putCallAudioFromDataUrl } from '#app/utils/call-kent-audio-storage.server.ts'
 import { action } from '../save.tsx'
 
 test('create-call accepts a large multipart audio file', async () => {
@@ -107,6 +145,7 @@ test('create-call still accepts a urlencoded audio data URL', async () => {
 })
 
 test('create-call rejects malformed legacy audio strings', async () => {
+	vi.mocked(putCallAudioFromDataUrl).mockClear()
 	const body = new URLSearchParams({
 		intent: 'create-call',
 		title: 'My malformed audio call',
@@ -121,16 +160,18 @@ test('create-call rejects malformed legacy audio strings', async () => {
 		body,
 	})
 
-	const response = await action({ request } as never)
+	const result = (await action({ request } as never)) as {
+		type?: string
+		data?: RecordingFormData
+		init?: ResponseInit | null
+	}
 
-	expect(response).toMatchObject({
-		init: {
-			status: 400,
-		},
-		data: {
-			errors: {
-				audio: 'Audio file is required',
-			},
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(400)
+	expect(result.data).toMatchObject({
+		errors: {
+			audio: 'Audio file is required',
 		},
 	})
+	expect(putCallAudioFromDataUrl).not.toHaveBeenCalled()
 })

--- a/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
+++ b/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
@@ -105,3 +105,32 @@ test('create-call still accepts a urlencoded audio data URL', async () => {
 	expect(response.status).toBe(302)
 	expect(response.headers.get('location')).toMatch(/^\/calls\/record\//)
 })
+
+test('create-call rejects malformed legacy audio strings', async () => {
+	const body = new URLSearchParams({
+		intent: 'create-call',
+		title: 'My malformed audio call',
+		audio: 'not-a-data-url',
+	})
+	const request = new Request('http://localhost/resources/calls/save', {
+		method: 'POST',
+		headers: {
+			host: 'localhost',
+			'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
+		},
+		body,
+	})
+
+	const response = await action({ request } as never)
+
+	expect(response).toMatchObject({
+		init: {
+			status: 400,
+		},
+		data: {
+			errors: {
+				audio: 'Audio file is required',
+			},
+		},
+	})
+})

--- a/services/site/app/routes/resources/calls/save.tsx
+++ b/services/site/app/routes/resources/calls/save.tsx
@@ -6,6 +6,7 @@ import {
 	deleteAudioObject,
 	getAudioBuffer,
 	parseBase64DataUrl,
+	putCallAudioFromBuffer,
 	putCallAudioFromDataUrl,
 	putEpisodeDraftResponseAudioFromBuffer,
 } from '#app/utils/call-kent-audio-storage.server.ts'
@@ -41,9 +42,42 @@ function getCheckboxFormValue(formData: FormData, key: string) {
 	return value === 'on' || value === 'true'
 }
 
+function getAudioFormValue(formData: FormData, key: string) {
+	const value = formData.get(key)
+	if (typeof value === 'string') return value
+	if (typeof File !== 'undefined' && value instanceof File) return value
+	return null
+}
+
+async function getAudioBufferFromFormValue(audio: string | File) {
+	if (typeof audio === 'string') {
+		return parseBase64DataUrl(audio)
+	}
+
+	return {
+		buffer: Buffer.from(await audio.arrayBuffer()),
+		contentType: audio.type || 'application/octet-stream',
+	}
+}
+
+async function putCallAudioFromFormValue({
+	callId,
+	audio,
+}: {
+	callId: string
+	audio: string | File
+}) {
+	if (typeof audio === 'string') {
+		return await putCallAudioFromDataUrl({ callId, dataUrl: audio })
+	}
+
+	const { buffer, contentType } = await getAudioBufferFromFormValue(audio)
+	return await putCallAudioFromBuffer({ callId, audio: buffer, contentType })
+}
+
 function getActionData(formData: FormData) {
 	const fields = {
-		audio: getStringFormValue(formData, 'audio'),
+		audio: getAudioFormValue(formData, 'audio'),
 		title: getStringFormValue(formData, 'title'),
 		notes: getStringFormValue(formData, 'notes'),
 	}
@@ -96,7 +130,7 @@ async function createCall({
 		}
 
 		const callId = randomUUID()
-		const stored = await putCallAudioFromDataUrl({ callId, dataUrl: audio })
+		const stored = await putCallAudioFromFormValue({ callId, audio })
 		let createdCall: { id: string }
 		try {
 			createdCall = await prisma.call.create({
@@ -399,7 +433,7 @@ async function createEpisodeDraft({
 	formData: FormData
 }) {
 	const callId = getStringFormValue(formData, 'callId')
-	const responseAudio = getStringFormValue(formData, 'audio')
+	const responseAudio = getAudioFormValue(formData, 'audio')
 	const formCallTitle = getStringFormValue(formData, 'callTitle')
 	const formNotes = getStringFormValue(formData, 'notes')
 	if (!callId) return redirectCallNotFound()
@@ -475,7 +509,9 @@ async function createEpisodeDraft({
 		if (!call.audioKey) {
 			throw new Error('Call audio is missing (audioKey is null).')
 		}
-		const parsedResponseAudio = parseBase64DataUrl(responseAudio!)
+		const parsedResponseAudio = await getAudioBufferFromFormValue(
+			responseAudio!,
+		)
 		const storedResponseAudio = await putEpisodeDraftResponseAudioFromBuffer({
 			draftId: draft.id,
 			audio: parsedResponseAudio.buffer,

--- a/services/site/app/utils/call-kent.ts
+++ b/services/site/app/utils/call-kent.ts
@@ -31,9 +31,12 @@ function getErrorForNotes(notes: string | null) {
 	return null
 }
 
-function getErrorForAudio(audio: string | null) {
-	if (!audio) return 'Audio file is required'
-	return null
+function getErrorForAudio(audio: unknown) {
+	if (typeof audio === 'string' && audio.length > 0) return null
+	if (typeof File !== 'undefined' && audio instanceof File && audio.size > 0) {
+		return null
+	}
+	return 'Audio file is required'
 }
 
 export type Params = {

--- a/services/site/app/utils/call-kent.ts
+++ b/services/site/app/utils/call-kent.ts
@@ -32,7 +32,12 @@ function getErrorForNotes(notes: string | null) {
 }
 
 function getErrorForAudio(audio: unknown) {
-	if (typeof audio === 'string' && audio.length > 0) return null
+	if (typeof audio === 'string') {
+		const value = audio.trim()
+		if (!value) return 'Audio file is required'
+		if (/^data:.+;base64,.+$/i.test(value)) return null
+		return 'Audio file is required'
+	}
 	if (typeof File !== 'undefined' && audio instanceof File && audio.size > 0) {
 		return null
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Submit Call Kent recordings as multipart `FormData` files instead of base64 data URLs in URL-encoded bodies.
- Accept multipart `File` uploads and validate legacy data URL submissions in the save action.
- Add create-call regression coverage for large multipart audio, legacy data URL audio, and malformed legacy audio.
- Mock audio storage in save-action tests so they do not hit R2-backed storage.

## Testing
- `npm exec vitest -- --run --config vitest.config.ts app/routes/resources/calls/__tests__/save-create-call.test.ts`
- `npm run typecheck --workspace kentcdodds.com`
- `npm run lint --workspace kentcdodds.com`
- `npm run test:browser --workspace kentcdodds.com -- app/components/calls/__tests__/submit-recording-form.test.browser.tsx`
- `git push -u origin cursor/fix-call-recording-submit-3084` (pre-push `npm run test:all` passed)
- PR CI: Site Gate, Playwright, Cursor Bugbot, and CodeRabbit are green.
- Manual fake-media browser walkthrough: accepted recorded audio, filled the form, submitted, and redirected to `/calls/record/<uuid>` with no stack overflow error.

<a href="https://cursor.com/agents/bc-31e86e66-378a-4901-96c8-4229a2193084/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcall-recording-multipart-submit.mp4"><img src="https://cursor.com/artifacts/c/art-814ad3bf-8158-49d6-91de-758d82f3184c" alt="call-recording-multipart-submit.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31e86e66-378a-4901-96c8-4229a2193084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31e86e66-378a-4901-96c8-4229a2193084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for NVM configuration in cloud/headless testing.

* **Bug Fixes**
  * Recording uploads now use multipart/form-data and accept both uploaded files and legacy data-URLs.
  * Improved validation and clearer error responses for missing or malformed audio inputs.
  * Submission lifecycle more robust to aborts and failure conditions.

* **Tests**
  * Expanded tests covering new upload paths, validation cases, and redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->