### PR TITLE
Add staging D1 infrastructure for site worker

### DIFF
--- a/.github/workflows/validate-site-worker.yml
+++ b/.github/workflows/validate-site-worker.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     paths:
       - .github/workflows/validate-site-worker.yml
+      - docs/agents/cloudflare-staging-d1.md
       - package-lock.json
       - package.json
+      - services/site/prisma/migrations/**
       - services/site-worker/**
   workflow_dispatch:
 
@@ -39,6 +41,12 @@ jobs:
 
       - name: Test site worker
         run: npm run test --workspace site-worker
+
+      - name: Validate staging D1 migrations
+        working-directory: services/site-worker
+        env:
+          CI: "true"
+        run: npm run d1:migrations:apply:local
 
       - name: Wrangler deploy dry run
         working-directory: services/site-worker

--- a/docs/agents/cloudflare-staging-d1.md
+++ b/docs/agents/cloudflare-staging-d1.md
@@ -1,0 +1,79 @@
+# Cloudflare staging D1
+
+This is Phase 2 staging infrastructure for `services/site-worker`. It does not
+replace the production Fly deploy, cut over DNS, or change production secrets.
+Production stays on the current single-machine Fly app with direct SQLite until
+the cutover phase is planned separately.
+
+## Binding
+
+`services/site-worker/wrangler.jsonc` declares:
+
+- `APP_DB`: staging D1 database for the future React Router Worker runtime.
+
+The Worker does not wire the React Router request handler yet. Do not add
+production routes or production secrets while validating this database setup.
+
+An `ASSETS` binding is intentionally not configured yet because the site-worker
+does not build or serve the React Router client bundle. When the RR handler is
+wired, add the asset binding to the actual client build output in the same PR
+that serves those assets.
+
+## Create the staging D1 database
+
+Use a non-production Cloudflare account/environment:
+
+```sh
+npm exec --workspace site-worker wrangler -- d1 create kentcdodds-com-staging-app-db
+```
+
+Copy the returned `database_id` into the `APP_DB` binding in
+`services/site-worker/wrangler.jsonc`.
+
+## Apply existing site migrations
+
+The site-worker D1 binding points `migrations_dir` at
+`../site/prisma/migrations`, so Wrangler applies the committed Prisma SQLite
+migrations directly. Do not duplicate the migration SQL into the worker
+workspace.
+
+Validate and apply migrations to the local Miniflare D1 database:
+
+```sh
+npm run d1:migrations:apply:local --workspace site-worker
+```
+
+Apply the same migrations to remote staging D1:
+
+```sh
+npm run d1:migrations:apply:staging --workspace site-worker
+```
+
+To inspect pending migrations without applying them:
+
+```sh
+npm run d1:migrations:list:local --workspace site-worker
+npm run d1:migrations:list:staging --workspace site-worker
+```
+
+## Local worker development
+
+After local migrations are applied, start the staging worker shell:
+
+```sh
+npm run dev --workspace site-worker
+```
+
+The worker listens on `http://127.0.0.1:8788` and currently exposes only
+`GET /health`. Future RR wiring can read the D1 binding as `env.APP_DB`.
+
+## CI validation
+
+`Validate Site Worker` runs:
+
+- lint, typecheck, and tests for `services/site-worker`
+- local D1 migration application against Miniflare
+- `wrangler deploy --dry-run` to validate the worker bundle and Wrangler config
+
+This validation intentionally avoids remote staging deploys and production Fly
+deploys.

--- a/docs/agents/cloudflare-staging-d1.md
+++ b/docs/agents/cloudflare-staging-d1.md
@@ -32,10 +32,11 @@ Copy the returned `database_id` into the `APP_DB` binding in
 
 ## Apply existing site migrations
 
-The site-worker D1 binding points `migrations_dir` at
-`../site/prisma/migrations`, so Wrangler applies the committed Prisma SQLite
-migrations directly. Do not duplicate the migration SQL into the worker
-workspace.
+The site-worker migration scripts generate Wrangler-compatible flat SQL files in
+`services/site-worker/.wrangler/site-prisma-migrations` from the committed
+`services/site/prisma/migrations/*/migration.sql` files before running
+`wrangler d1 migrations`. Do not commit or hand-edit the generated files, and do
+not duplicate the migration SQL into the worker workspace.
 
 Validate and apply migrations to the local Miniflare D1 database:
 
@@ -54,6 +55,12 @@ To inspect pending migrations without applying them:
 ```sh
 npm run d1:migrations:list:local --workspace site-worker
 npm run d1:migrations:list:staging --workspace site-worker
+```
+
+To regenerate the ignored D1 migration files without contacting D1:
+
+```sh
+npm run d1:migrations:prepare --workspace site-worker
 ```
 
 ## Local worker development

--- a/docs/agents/cloudflare-staging-d1.md
+++ b/docs/agents/cloudflare-staging-d1.md
@@ -38,6 +38,11 @@ The site-worker migration scripts generate Wrangler-compatible flat SQL files in
 `wrangler d1 migrations`. Do not commit or hand-edit the generated files, and do
 not duplicate the migration SQL into the worker workspace.
 
+The generated copy normalizes `CREATE TEMP TABLE` to `CREATE TABLE` because D1
+rejects temporary tables in migrations. The affected guard table is dropped in
+the same migration, so this keeps the safety check without changing the
+committed Prisma migration.
+
 Validate and apply migrations to the local Miniflare D1 database:
 
 ```sh

--- a/services/site-worker/package.json
+++ b/services/site-worker/package.json
@@ -11,6 +11,10 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev --port 8788",
     "start": "wrangler dev --port 8788",
+    "d1:migrations:list:local": "wrangler d1 migrations list APP_DB --local",
+    "d1:migrations:apply:local": "wrangler d1 migrations apply APP_DB --local",
+    "d1:migrations:list:staging": "wrangler d1 migrations list APP_DB --remote",
+    "d1:migrations:apply:staging": "wrangler d1 migrations apply APP_DB --remote",
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {

--- a/services/site-worker/package.json
+++ b/services/site-worker/package.json
@@ -11,10 +11,11 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev --port 8788",
     "start": "wrangler dev --port 8788",
-    "d1:migrations:list:local": "wrangler d1 migrations list APP_DB --local",
-    "d1:migrations:apply:local": "wrangler d1 migrations apply APP_DB --local",
-    "d1:migrations:list:staging": "wrangler d1 migrations list APP_DB --remote",
-    "d1:migrations:apply:staging": "wrangler d1 migrations apply APP_DB --remote",
+    "d1:migrations:prepare": "node ./scripts/prepare-d1-migrations.mjs",
+    "d1:migrations:list:local": "npm run d1:migrations:prepare && wrangler d1 migrations list APP_DB --local",
+    "d1:migrations:apply:local": "npm run d1:migrations:prepare && wrangler d1 migrations apply APP_DB --local",
+    "d1:migrations:list:staging": "npm run d1:migrations:prepare && wrangler d1 migrations list APP_DB --remote",
+    "d1:migrations:apply:staging": "npm run d1:migrations:prepare && wrangler d1 migrations apply APP_DB --remote",
     "cf-typegen": "wrangler types"
   },
   "devDependencies": {

--- a/services/site-worker/readme.md
+++ b/services/site-worker/readme.md
@@ -16,3 +16,9 @@ minimal health endpoint:
   - `npm run test --workspace site-worker`
 - Validate the Worker bundle with:
   - `cd services/site-worker && npm exec wrangler -- deploy --dry-run`
+
+## Staging D1
+
+The staging worker declares an `APP_DB` D1 binding and uses the existing
+`services/site/prisma/migrations` directory as its Wrangler migration source.
+See `docs/agents/cloudflare-staging-d1.md` for setup and migration commands.

--- a/services/site-worker/readme.md
+++ b/services/site-worker/readme.md
@@ -19,6 +19,7 @@ minimal health endpoint:
 
 ## Staging D1
 
-The staging worker declares an `APP_DB` D1 binding and uses the existing
-`services/site/prisma/migrations` directory as its Wrangler migration source.
-See `docs/agents/cloudflare-staging-d1.md` for setup and migration commands.
+The staging worker declares an `APP_DB` D1 binding. Its migration scripts
+generate Wrangler-compatible D1 migration files from the existing
+`services/site/prisma/migrations` directory. See
+`docs/agents/cloudflare-staging-d1.md` for setup and migration commands.

--- a/services/site-worker/scripts/prepare-d1-migrations.mjs
+++ b/services/site-worker/scripts/prepare-d1-migrations.mjs
@@ -34,6 +34,12 @@ async function getPrismaMigrationDirs() {
 		.toSorted()
 }
 
+function prepareSqlForD1(sql) {
+	// D1 rejects TEMP tables in migrations; the guard table is dropped in the
+	// same migration, so a regular table preserves the check without persisting.
+	return sql.replaceAll('CREATE TEMP TABLE ', 'CREATE TABLE ')
+}
+
 await fs.rm(d1MigrationsDir, { recursive: true, force: true })
 await fs.mkdir(d1MigrationsDir, { recursive: true })
 
@@ -51,7 +57,7 @@ for (const migrationDir of migrationDirs) {
 		throw new Error(`Missing Prisma migration SQL file: ${source}`)
 	}
 
-	const sql = await fs.readFile(source, 'utf8')
+	const sql = prepareSqlForD1(await fs.readFile(source, 'utf8'))
 
 	if (!sql.trim()) {
 		throw new Error(`Prisma migration SQL file is empty: ${source}`)

--- a/services/site-worker/scripts/prepare-d1-migrations.mjs
+++ b/services/site-worker/scripts/prepare-d1-migrations.mjs
@@ -1,0 +1,68 @@
+import { constants } from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const workerDir = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'..',
+)
+const prismaMigrationsDir = path.resolve(
+	workerDir,
+	'../site/prisma/migrations',
+)
+const d1MigrationsDir = path.resolve(
+	workerDir,
+	'.wrangler/site-prisma-migrations',
+)
+
+async function pathExists(filePath) {
+	try {
+		await fs.access(filePath, constants.F_OK)
+		return true
+	} catch {
+		return false
+	}
+}
+
+async function getPrismaMigrationDirs() {
+	const entries = await fs.readdir(prismaMigrationsDir, { withFileTypes: true })
+
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.toSorted()
+}
+
+await fs.rm(d1MigrationsDir, { recursive: true, force: true })
+await fs.mkdir(d1MigrationsDir, { recursive: true })
+
+const migrationDirs = await getPrismaMigrationDirs()
+
+if (migrationDirs.length === 0) {
+	throw new Error(`No Prisma migration directories found in ${prismaMigrationsDir}`)
+}
+
+for (const migrationDir of migrationDirs) {
+	const source = path.join(prismaMigrationsDir, migrationDir, 'migration.sql')
+	const target = path.join(d1MigrationsDir, `${migrationDir}.sql`)
+
+	if (!(await pathExists(source))) {
+		throw new Error(`Missing Prisma migration SQL file: ${source}`)
+	}
+
+	const sql = await fs.readFile(source, 'utf8')
+
+	if (!sql.trim()) {
+		throw new Error(`Prisma migration SQL file is empty: ${source}`)
+	}
+
+	await fs.writeFile(target, sql)
+}
+
+console.log(
+	`Prepared ${migrationDirs.length} D1 migration files in ${path.relative(
+		workerDir,
+		d1MigrationsDir,
+	)}`,
+)

--- a/services/site-worker/wrangler.jsonc
+++ b/services/site-worker/wrangler.jsonc
@@ -4,5 +4,14 @@
 	"main": "src/index.ts",
 	"compatibility_date": "2026-03-17",
 	"compatibility_flags": ["nodejs_compat"],
-	"workers_dev": true
+	"workers_dev": true,
+	"d1_databases": [
+		{
+			"binding": "APP_DB",
+			"database_name": "kentcdodds-com-staging-app-db",
+			// Replace this after `wrangler d1 create kentcdodds-com-staging-app-db`.
+			"database_id": "00000000-0000-0000-0000-000000000000",
+			"migrations_dir": "../site/prisma/migrations"
+		}
+	]
 }

--- a/services/site-worker/wrangler.jsonc
+++ b/services/site-worker/wrangler.jsonc
@@ -11,7 +11,7 @@
 			"database_name": "kentcdodds-com-staging-app-db",
 			// Replace this after `wrangler d1 create kentcdodds-com-staging-app-db`.
 			"database_id": "00000000-0000-0000-0000-000000000000",
-			"migrations_dir": "../site/prisma/migrations"
+			"migrations_dir": ".wrangler/site-prisma-migrations"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a staging `APP_DB` D1 binding to `services/site-worker/wrangler.jsonc`
- Add site-worker scripts to prepare, list, and apply existing `services/site/prisma` migrations to local or remote staging D1
- Document staging D1 setup and extend site-worker CI to validate local migration application plus Wrangler dry-run

## Scope
- Non-production Cloudflare Worker staging infrastructure only
- Does not wire the React Router app
- Does not touch production Fly deploy, DNS, or production secrets

## Validation
- `npm run lint --workspace site-worker`
- `npm run typecheck --workspace site-worker`
- `npm run test --workspace site-worker` (3 tests passed)
- Fresh local D1 apply: prepared 17 generated D1 migration files and applied all 17 via `wrangler d1 migrations apply APP_DB --local --persist-to <fresh-state>`
- Exact CI command shape: `CI=true npm run d1:migrations:apply:local --workspace site-worker`
- `cd services/site-worker && npm exec wrangler -- deploy --dry-run` (dry-run shows `env.APP_DB` D1 binding)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1745b231-becc-4c17-9828-8216cd33a42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1745b231-becc-4c17-9828-8216cd33a42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

