### PR TITLE
Remove LiteFS cache runtime assumptions

### DIFF
--- a/services/site/app/components/calls/__tests__/submit-recording-form.test.browser.tsx
+++ b/services/site/app/components/calls/__tests__/submit-recording-form.test.browser.tsx
@@ -24,9 +24,7 @@ import { RecordingForm } from '#app/components/calls/recording-form.tsx'
 
 test('RecordingForm validates the title before uploading audio', async () => {
 	vi.clearAllMocks()
-	mockUseRootData.mockReturnValue({
-		requestInfo: { flyPrimaryInstance: null },
-	})
+	mockUseRootData.mockReturnValue({})
 	const fetchMock = vi.fn()
 	vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 	const createObjectURL = vi
@@ -60,9 +58,7 @@ test('RecordingForm validates the title before uploading audio', async () => {
 
 test('RecordingForm submits a valid recording and follows the redirect', async () => {
 	vi.clearAllMocks()
-	mockUseRootData.mockReturnValue({
-		requestInfo: { flyPrimaryInstance: 'primary-abc123' },
-	})
+	mockUseRootData.mockReturnValue({})
 
 	let loadEndListener: (() => void) | null = null
 	const readAsDataURL = vi.fn(function (this: SuccessfulFileReader) {
@@ -116,6 +112,10 @@ test('RecordingForm submits a valid recording and follows the redirect', async (
 		await expect.poll(() => fetchMock.mock.calls.length).toBe(1)
 		expect(readAsDataURL).toHaveBeenCalledTimes(1)
 		expect(fetchMock.mock.calls[0]?.[0]).toBe('/resources/calls/save')
+		const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit
+		expect(new Headers(requestInit.headers).has('fly-force-instance-id')).toBe(
+			false,
+		)
 		await expect.poll(() => mockNavigate.mock.calls.length).toBe(1)
 		expect(mockNavigate).toHaveBeenCalledWith(
 			'/calls/record/fake-call-id?ok=1#done',

--- a/services/site/app/components/calls/recording-form.tsx
+++ b/services/site/app/components/calls/recording-form.tsx
@@ -70,7 +70,6 @@ export function RecordingForm({
 	const navigate = useNavigate()
 	const revalidator = useRevalidator()
 	const { requestInfo, user, userInfo } = useRootData()
-	const flyPrimaryInstance = requestInfo.flyPrimaryInstance
 	const audioURL = React.useMemo(() => {
 		return URL.createObjectURL(audio)
 	}, [audio])
@@ -204,9 +203,6 @@ export function RecordingForm({
 				const headers = new Headers({
 					'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
 				})
-				if (flyPrimaryInstance) {
-					headers.set('fly-force-instance-id', flyPrimaryInstance)
-				}
 				const abortController = new AbortController()
 				abortControllerRef.current = abortController
 

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -19,7 +19,6 @@ import {
 } from 'react-router'
 import { useSpinDelay } from 'spin-delay'
 import { type KCDHandle } from '#app/types.ts'
-import { getInstanceInfo } from '#app/utils/litefs-js.server.ts'
 import {
 	useCapturedRouteError,
 	getDisplayUrl,
@@ -142,38 +141,32 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const podcastLinksAbortController = new AbortController()
 	const requestPath = new URL(request.url).pathname
 	const session = await getSession(request)
-	const [
-		user,
-		clientSession,
-		loginInfoSession,
-		primaryInstance,
-		latestPodcastSeasonLinks,
-	] = await Promise.all([
-		session.getUser({ timings }),
-		getClientSession(request, session.getUser({ timings })),
-		getLoginInfoSession(request),
-		getInstanceInfo().then((i) => i.primaryInstance),
-		time(
-			withTimeout(
-				getLatestPodcastSeasonLinks({
-					request,
-					timings,
-					signal: podcastLinksAbortController.signal,
-				}),
+	const [user, clientSession, loginInfoSession, latestPodcastSeasonLinks] =
+		await Promise.all([
+			session.getUser({ timings }),
+			getClientSession(request, session.getUser({ timings })),
+			getLoginInfoSession(request),
+			time(
+				withTimeout(
+					getLatestPodcastSeasonLinks({
+						request,
+						timings,
+						signal: podcastLinksAbortController.signal,
+					}),
+					{
+						timeoutMs: 2000,
+						fallback: PODCAST_LINKS_FALLBACK,
+						label: 'root:podcast-season-links',
+						onTimeout: () => podcastLinksAbortController.abort(),
+					},
+				),
 				{
-					timeoutMs: 2000,
-					fallback: PODCAST_LINKS_FALLBACK,
-					label: 'root:podcast-season-links',
-					onTimeout: () => podcastLinksAbortController.abort(),
+					timings,
+					type: 'root:podcast-season-links',
+					desc: 'podcast nav links (Simplecast + Transistor)',
 				},
 			),
-			{
-				timings,
-				type: 'root:podcast-season-links',
-				desc: 'podcast nav links (Simplecast + Transistor)',
-			},
-		),
-	])
+		])
 
 	const randomFooterImageKeys = Object.keys(illustrationImages)
 	const randomFooterImageKey = randomFooterImageKeys[
@@ -196,7 +189,6 @@ export async function loader({ request }: Route.LoaderArgs) {
 			hints: getHints(request),
 			origin: getDomainUrl(request),
 			path: requestPath,
-			flyPrimaryInstance: primaryInstance,
 			userPrefs: {
 				theme: getTheme(request),
 			},
@@ -529,20 +521,6 @@ export function ErrorBoundary() {
 			return (
 				<ErrorDoc>
 					<FourHundred error={error.data} />
-				</ErrorDoc>
-			)
-		}
-		if (error.status === 409) {
-			return (
-				<ErrorDoc>
-					<ErrorPage
-						heroProps={{
-							title: '409 - Oh no, you should never see this.',
-							subtitle: `"${location.pathname}" tried telling fly to replay your request and missed this one.`,
-							image: <Grimmacing className="rounded-lg" aspectRatio="3:4" />,
-							action: <ArrowLink href="/">Go home</ArrowLink>,
-						}}
-					/>
 				</ErrorDoc>
 			)
 		}

--- a/services/site/app/routes/action/refresh-cache.tsx
+++ b/services/site/app/routes/action/refresh-cache.tsx
@@ -42,11 +42,11 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const body = (await request.json()) as Body
 
-	function setShaInCache() {
+	async function setShaInCache() {
 		const { commitSha: sha } = body
 		if (sha) {
 			const value: RefreshShaInfo = { sha, date: new Date().toISOString() }
-			cache.set(commitShaKey, {
+			await cache.set(commitShaKey, {
 				value,
 				metadata: {
 					createdTime: new Date().getTime(),
@@ -59,9 +59,9 @@ export async function action({ request }: Route.ActionArgs) {
 
 	if ('keys' in body && Array.isArray(body.keys)) {
 		for (const key of body.keys) {
-			void cache.delete(key)
+			await cache.delete(key)
 		}
-		setShaInCache()
+		await setShaInCache()
 		return json({
 			message: 'Deleting cache keys',
 			keys: body.keys,
@@ -122,7 +122,7 @@ export async function action({ request }: Route.ActionArgs) {
 			await Promise.all(promises)
 		}
 
-		setShaInCache()
+		await setShaInCache()
 		return json({
 			message: 'Refreshing cache for content paths',
 			contentPaths: refreshingContentPaths,

--- a/services/site/app/routes/cache.admin.tsx
+++ b/services/site/app/routes/cache.admin.tsx
@@ -8,25 +8,17 @@ import {
 	useSubmit,
 } from 'react-router'
 import { Button } from '#app/components/button.tsx'
-import {
-	Field,
-	FieldContainer,
-	inputClassName,
-} from '#app/components/form-elements.tsx'
+import { Field } from '#app/components/form-elements.tsx'
 import { SearchIcon } from '#app/components/icons.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { H2, H3 } from '#app/components/typography.tsx'
 import {
 	cache,
 	getAllCacheKeys,
+	isFileCacheAvailable,
 	lruCache,
 	searchCacheKeys,
 } from '#app/utils/cache.server.ts'
-import {
-	ensureInstance,
-	getAllInstances,
-	getInstanceInfo,
-} from '#app/utils/litefs-js.server.ts'
 import {
 	useDebounce,
 	useDoubleCheck,
@@ -60,28 +52,28 @@ async function getMatchingCacheKeys({
 
 export async function loader({ request }: Route.LoaderArgs) {
 	await requireAdminUser(request)
+	if (!isFileCacheAvailable()) {
+		throw new Response('File cache admin is unavailable in this runtime.', {
+			status: 404,
+		})
+	}
 	const searchParams = new URL(request.url).searchParams
 	const query = searchParams.get('query')
 	const limit = Number(searchParams.get('limit') ?? 100)
 
-	const currentInstanceInfo = await getInstanceInfo()
-	const instance =
-		searchParams.get('instance') ?? currentInstanceInfo.currentInstance
-	const instances = await getAllInstances()
-	await ensureInstance(instance)
-
 	const cacheKeys = await getMatchingCacheKeys({ query, limit })
-	return json({ cacheKeys, instance, instances, currentInstanceInfo })
+	return json({ cacheKeys })
 }
 
 export async function action({ request }: Route.ActionArgs) {
 	await requireAdminUser(request)
+	if (!isFileCacheAvailable()) {
+		throw new Response('File cache admin is unavailable in this runtime.', {
+			status: 404,
+		})
+	}
 	const searchParams = new URL(request.url).searchParams
 	const formData = await request.formData()
-	const { currentInstance } = await getInstanceInfo()
-	const instance = formData.get('instance') ?? currentInstance
-	invariantResponse(typeof instance === 'string', 'instance must be a string')
-	await ensureInstance(instance)
 
 	const intent = formData.get('intent')
 	if (intent === deleteAllMatchingIntent) {
@@ -126,7 +118,6 @@ export default function CacheAdminRoute({
 	const submit = useSubmit()
 	const query = searchParams.get('query') ?? ''
 	const limit = searchParams.get('limit') ?? '100'
-	const instance = searchParams.get('instance') ?? data.instance
 	const matchingCacheValuesCount =
 		data.cacheKeys.sqlite.length + data.cacheKeys.lru.length
 
@@ -176,62 +167,24 @@ export default function CacheAdminRoute({
 						max="10000"
 						placeholder="results limit"
 					/>
-					<FieldContainer label="Instance" id="instance">
-						{({ inputProps }) => (
-							<select
-								{...inputProps}
-								name="instance"
-								defaultValue={instance}
-								className={inputClassName}
-							>
-								{Object.entries(data.instances).map(([inst, region]) => (
-									<option key={inst} value={inst}>
-										{[
-											inst,
-											`(${region})`,
-											inst === data.currentInstanceInfo.currentInstance
-												? '(current)'
-												: '',
-											inst === data.currentInstanceInfo.primaryInstance
-												? ' (primary)'
-												: '',
-										]
-											.filter(Boolean)
-											.join(' ')}
-									</option>
-								))}
-							</select>
-						)}
-					</FieldContainer>
 				</div>
 			</Form>
 			<Spacer size="2xs" />
 			<DeleteAllMatchingCacheValuesButton
-				instance={instance}
 				matchingCacheValuesCount={matchingCacheValuesCount}
 			/>
 			<Spacer size="2xs" />
 			<div className="flex flex-col gap-4">
 				<H3>LRU Cache:</H3>
 				{data.cacheKeys.lru.map((key) => (
-					<CacheKeyRow
-						key={key}
-						cacheKey={key}
-						instance={instance}
-						type="lru"
-					/>
+					<CacheKeyRow key={key} cacheKey={key} type="lru" />
 				))}
 			</div>
 			<Spacer size="3xs" />
 			<div className="flex flex-col gap-4">
 				<H3>SQLite Cache:</H3>
 				{data.cacheKeys.sqlite.map((key) => (
-					<CacheKeyRow
-						key={key}
-						cacheKey={key}
-						instance={instance}
-						type="sqlite"
-					/>
+					<CacheKeyRow key={key} cacheKey={key} type="sqlite" />
 				))}
 			</div>
 		</div>
@@ -239,10 +192,8 @@ export default function CacheAdminRoute({
 }
 
 function DeleteAllMatchingCacheValuesButton({
-	instance,
 	matchingCacheValuesCount,
 }: {
-	instance: string
 	matchingCacheValuesCount: number
 }) {
 	const fetcher = useFetcher()
@@ -253,7 +204,6 @@ function DeleteAllMatchingCacheValuesButton({
 	return (
 		<fetcher.Form method="POST">
 			<input type="hidden" name="intent" value={deleteAllMatchingIntent} />
-			<input type="hidden" name="instance" value={instance} />
 			<Button
 				size="small"
 				variant="danger"
@@ -270,22 +220,13 @@ function DeleteAllMatchingCacheValuesButton({
 	)
 }
 
-function CacheKeyRow({
-	cacheKey,
-	instance,
-	type,
-}: {
-	cacheKey: string
-	instance?: string
-	type: string
-}) {
+function CacheKeyRow({ cacheKey, type }: { cacheKey: string; type: string }) {
 	const fetcher = useFetcher()
 	const dc = useDoubleCheck()
 	return (
 		<div className="flex items-center gap-2 font-mono">
 			<fetcher.Form method="POST">
 				<input type="hidden" name="cacheKey" value={cacheKey} />
-				<input type="hidden" name="instance" value={instance} />
 				<input type="hidden" name="type" value={type} />
 				<Button
 					size="small"
@@ -299,11 +240,7 @@ function CacheKeyRow({
 						: 'Deleting...'}
 				</Button>
 			</fetcher.Form>
-			<a
-				href={`/resources/cache/${type}/${encodeURIComponent(
-					cacheKey,
-				)}?instance=${instance}`}
-			>
+			<a href={`/resources/cache/${type}/${encodeURIComponent(cacheKey)}`}>
 				{cacheKey}
 			</a>
 		</div>

--- a/services/site/app/routes/calls_.admin/$callId.tsx
+++ b/services/site/app/routes/calls_.admin/$callId.tsx
@@ -23,7 +23,7 @@ import { formatDate, useDoubleCheck } from '#app/utils/misc-react.tsx'
 import { prisma } from '#app/utils/prisma.server.ts'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { requireAdminUser } from '#app/utils/session.server.ts'
-import { useRootData, useUser } from '#app/utils/use-root-data.ts'
+import { useUser } from '#app/utils/use-root-data.ts'
 import { type Route } from './+types/$callId'
 
 export const handle: KCDHandle = {
@@ -376,8 +376,6 @@ function ResponseAudioDraftForm({
 	const navigate = useNavigate()
 	const location = useLocation()
 	const revalidator = useRevalidator()
-	const { requestInfo } = useRootData()
-	const flyPrimaryInstance = requestInfo.flyPrimaryInstance
 	const audioURL = React.useMemo(() => URL.createObjectURL(audio), [audio])
 	const abortControllerRef = React.useRef<AbortController | null>(null)
 	const [isSubmitting, setIsSubmitting] = React.useState(false)
@@ -417,9 +415,6 @@ function ResponseAudioDraftForm({
 				const headers = new Headers({
 					'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
 				})
-				if (flyPrimaryInstance) {
-					headers.set('fly-force-instance-id', flyPrimaryInstance)
-				}
 
 				abortControllerRef.current?.abort()
 				const abortController = new AbortController()

--- a/services/site/app/routes/refresh-commit-sha[.]json.tsx
+++ b/services/site/app/routes/refresh-commit-sha[.]json.tsx
@@ -20,7 +20,7 @@ export async function loader() {
 		}
 	} catch (error: unknown) {
 		console.error(`Error parsing commit sha from cache: ${error}`)
-		cache.delete(refreshCacheCommitShaKey)
+		await cache.delete(refreshCacheCommitShaKey)
 		return json(null)
 	}
 

--- a/services/site/app/routes/resources/__tests__/cache-routes.test.ts
+++ b/services/site/app/routes/resources/__tests__/cache-routes.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'node:crypto'
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+	clearRuntimeBindingSource,
+	setRuntimeBindingSource,
+} from '#app/utils/runtime-bindings.server.ts'
+
+const sessionServerMocks = vi.hoisted(() => ({
+	requireAdminUser: vi.fn(),
+}))
+
+vi.mock('#app/utils/session.server.ts', () => sessionServerMocks)
+
+import { loader as cacheAdminLoader } from '../../cache.admin.tsx'
+import { loader as lruCacheResourceLoader } from '../cache.lru.$cacheKey.ts'
+import { action as sqliteCacheAction } from '../cache.sqlite.ts'
+import { loader as sqliteCacheResourceLoader } from '../cache.sqlite_.$cacheKey.ts'
+
+afterEach(() => {
+	clearRuntimeBindingSource()
+	vi.clearAllMocks()
+})
+
+function createD1Binding() {
+	return {
+		prepare: vi.fn(),
+		batch: vi.fn(),
+		exec: vi.fn(),
+		dump: vi.fn(),
+		withSession: vi.fn(),
+	}
+}
+
+async function expectNotFound(promise: Promise<unknown>) {
+	await expect(promise).rejects.toMatchObject({ status: 404 })
+}
+
+test('cache admin is unavailable when the file cache backend is unavailable', async () => {
+	setRuntimeBindingSource({ APP_DB: createD1Binding() })
+
+	await expectNotFound(
+		cacheAdminLoader({
+			request: new Request('http://localhost/cache/admin'),
+		} as any),
+	)
+})
+
+test('sqlite cache resources are unavailable when the file cache backend is unavailable', async () => {
+	setRuntimeBindingSource({ APP_DB: createD1Binding() })
+
+	await expectNotFound(
+		sqliteCacheResourceLoader({
+			request: new Request('http://localhost/resources/cache/sqlite/key'),
+			params: { cacheKey: 'key' },
+		} as any),
+	)
+	await expectNotFound(
+		sqliteCacheAction({
+			request: new Request('http://localhost/resources/cache/sqlite', {
+				method: 'POST',
+				body: JSON.stringify({ key: 'key' }),
+			}),
+		} as any),
+	)
+})
+
+test('lru cache resources no longer expose instance metadata', async () => {
+	const { lruCache } = await import('#app/utils/cache.server.ts')
+	const cacheKey = `lru-route:${randomUUID()}`
+	const entry = {
+		value: { ok: true },
+		metadata: {
+			createdTime: Date.now(),
+			swr: 0,
+			ttl: 60_000,
+		},
+	}
+	lruCache.set(cacheKey, entry)
+
+	const result = (await lruCacheResourceLoader({
+		request: new Request(
+			`http://localhost/resources/cache/lru/${encodeURIComponent(cacheKey)}`,
+		),
+		params: { cacheKey },
+	} as any)) as {
+		type?: string
+		data?: unknown
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.data).toEqual({
+		cacheKey,
+		value: entry,
+	})
+})

--- a/services/site/app/routes/resources/cache.lru.$cacheKey.ts
+++ b/services/site/app/routes/resources/cache.lru.$cacheKey.ts
@@ -1,31 +1,14 @@
 import { invariantResponse } from '@epic-web/invariant'
 import { data as json } from 'react-router'
 import { lruCache } from '#app/utils/cache.server.ts'
-import {
-	ensureInstance,
-	getAllInstances,
-	getInstanceInfo,
-} from '#app/utils/litefs-js.server.ts'
 import { requireAdminUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/cache.lru.$cacheKey'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
 	await requireAdminUser(request)
-	const searchParams = new URL(request.url).searchParams
-	const currentInstanceInfo = await getInstanceInfo()
-	const allInstances = await getAllInstances()
-	const instance =
-		searchParams.get('instance') ?? currentInstanceInfo.currentInstance
-	await ensureInstance(instance)
-
 	const { cacheKey } = params
 	invariantResponse(cacheKey, 'cacheKey is required')
 	return json({
-		instance: {
-			hostname: instance,
-			region: allInstances[instance],
-			isPrimary: currentInstanceInfo.primaryInstance === instance,
-		},
 		cacheKey,
 		value: lruCache.get(cacheKey),
 	})

--- a/services/site/app/routes/resources/cache.sqlite.ts
+++ b/services/site/app/routes/resources/cache.sqlite.ts
@@ -1,9 +1,17 @@
 import { data as json, redirect } from 'react-router'
-import { cache } from '#app/utils/cache.server.ts'
+import { cache, isFileCacheAvailable } from '#app/utils/cache.server.ts'
 import { getEnv } from '#app/utils/env.server.ts'
 import { type Route } from './+types/cache.sqlite'
 
 export async function action({ request }: Route.ActionArgs) {
+	if (!isFileCacheAvailable()) {
+		throw new Response(
+			'SQLite cache resources are unavailable in this runtime.',
+			{
+				status: 404,
+			},
+		)
+	}
 	const token = getEnv().INTERNAL_COMMAND_TOKEN
 	const isAuthorized =
 		request.headers.get('Authorization') === `Bearer ${token}`

--- a/services/site/app/routes/resources/cache.sqlite_.$cacheKey.ts
+++ b/services/site/app/routes/resources/cache.sqlite_.$cacheKey.ts
@@ -1,32 +1,24 @@
 import { invariantResponse } from '@epic-web/invariant'
 import { data as json } from 'react-router'
-import { cache } from '#app/utils/cache.server.ts'
-import {
-	ensureInstance,
-	getAllInstances,
-	getInstanceInfo,
-} from '#app/utils/litefs-js.server.ts'
+import { cache, isFileCacheAvailable } from '#app/utils/cache.server.ts'
 import { requireAdminUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/cache.sqlite_.$cacheKey'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
 	await requireAdminUser(request)
-	const searchParams = new URL(request.url).searchParams
-	const currentInstanceInfo = await getInstanceInfo()
-	const allInstances = await getAllInstances()
-	const instance =
-		searchParams.get('instance') ?? currentInstanceInfo.currentInstance
-	await ensureInstance(instance)
+	if (!isFileCacheAvailable()) {
+		throw new Response(
+			'SQLite cache resources are unavailable in this runtime.',
+			{
+				status: 404,
+			},
+		)
+	}
 
 	const { cacheKey } = params
 	invariantResponse(cacheKey, 'cacheKey is required')
 	return json({
-		instance: {
-			hostname: instance,
-			region: allInstances[instance],
-			isPrimary: currentInstanceInfo.primaryInstance === instance,
-		},
 		cacheKey,
-		value: cache.get(cacheKey),
+		value: await cache.get(cacheKey),
 	})
 }

--- a/services/site/app/utils/__tests__/cache.server.test.ts
+++ b/services/site/app/utils/__tests__/cache.server.test.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from 'node:crypto'
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+	clearRuntimeBindingSource,
+	setRuntimeBindingSource,
+} from '../runtime-bindings.server.ts'
+
+vi.mock('../session.server.ts', () => ({
+	getUser: vi.fn(),
+}))
+
+afterEach(() => {
+	clearRuntimeBindingSource()
+})
+
+function createD1Binding() {
+	return {
+		prepare: vi.fn(),
+		batch: vi.fn(),
+		exec: vi.fn(),
+		dump: vi.fn(),
+		withSession: vi.fn(),
+	}
+}
+
+test('uses the lru cache when an APP_DB binding is present', async () => {
+	setRuntimeBindingSource({ APP_DB: createD1Binding() })
+	const { cache, getAllCacheKeys } = await import('../cache.server.ts')
+	const key = `worker-cache:${randomUUID()}`
+	const entry = {
+		value: { ok: true },
+		metadata: {
+			createdTime: Date.now(),
+			swr: 0,
+			ttl: 60_000,
+		},
+	}
+
+	await cache.set(key, entry)
+
+	await expect(cache.get(key)).resolves.toEqual(entry)
+	await expect(getAllCacheKeys(100)).resolves.toMatchObject({
+		sqlite: [],
+		lru: expect.arrayContaining([key]),
+	})
+})

--- a/services/site/app/utils/__tests__/env.server.test.ts
+++ b/services/site/app/utils/__tests__/env.server.test.ts
@@ -95,3 +95,25 @@ test('getEnv cache distinguishes unset values from empty strings', () => {
 
 	expect(getEnv().SENTRY_DSN).toBe('')
 })
+
+test('getEnv accepts Worker-shaped config without LiteFS or file cache paths', () => {
+	setRuntimeEnvSource(
+		createRuntimeEnvSource({
+			DATABASE_URL: 'd1://app-db',
+			DATABASE_PATH: undefined,
+			CACHE_DATABASE_PATH: undefined,
+			FLY_APP_NAME: undefined,
+			FLY_REGION: undefined,
+			FLY_MACHINE_ID: undefined,
+			LITEFS_DIR: undefined,
+		}),
+	)
+
+	const env = getEnv()
+
+	expect(env.DATABASE_PATH).toBe('')
+	expect(env.CACHE_DATABASE_PATH).toBeUndefined()
+	expect(env.FLY_APP_NAME).toBe('')
+	expect(env.FLY_REGION).toBe('unknown')
+	expect(env.FLY_MACHINE_ID).toBe('unknown')
+})

--- a/services/site/app/utils/__tests__/runtime-bindings.server.test.ts
+++ b/services/site/app/utils/__tests__/runtime-bindings.server.test.ts
@@ -7,6 +7,7 @@ import {
 import {
 	clearRuntimeBindingSource,
 	getRuntimeBinding,
+	hasAppDbBinding,
 	setRuntimeBindingSource,
 } from '../runtime-bindings.server.ts'
 
@@ -57,6 +58,20 @@ test('getRuntimeBinding prefers the configured binding source', () => {
 
 	expect(getRuntimeBinding('DB')).toBe(d1Binding)
 	expect(getRuntimeBinding('SEARCH_WORKER_TOKEN')).toBe('binding-search-token')
+})
+
+test('hasAppDbBinding recognizes D1-shaped APP_DB bindings', () => {
+	setRuntimeBindingSource({
+		APP_DB: {
+			prepare() {},
+			batch() {},
+			exec() {},
+			dump() {},
+			withSession() {},
+		},
+	})
+
+	expect(hasAppDbBinding()).toBe(true)
 })
 
 test('getRuntimeBinding falls back to getEnv after clearing the binding source', () => {

--- a/services/site/app/utils/cache.server.ts
+++ b/services/site/app/utils/cache.server.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs'
-import path from 'node:path'
-import { DatabaseSync } from 'node:sqlite'
 import {
 	type Cache,
 	cachified as baseCachified,
@@ -12,18 +9,51 @@ import {
 import { siteCacheReporter } from '#app/utils/cache-reporter.server.ts'
 import { remember } from '@epic-web/remember'
 import { LRUCache } from 'lru-cache'
-import { getEnv } from '#app/utils/env.server.ts'
+import {
+	getRuntimeBinding,
+	hasAppDbBinding,
+} from '#app/utils/runtime-bindings.server.ts'
 import { getUser } from './session.server.ts'
 import { time, type Timings } from './timing.server.ts'
 
-const cacheDb = remember('cacheDb', createDatabase)
+type DatabaseSync = import('node:sqlite').DatabaseSync
+type StatementSync = ReturnType<DatabaseSync['prepare']>
 
-export function getCacheDb() {
-	return cacheDb
+type SqliteCacheState = {
+	db: DatabaseSync
+	preparedGet: StatementSync
+	preparedSet: StatementSync
+	preparedDelete: StatementSync
+	preparedAllKeys: StatementSync
+	preparedKeySearch: StatementSync
 }
 
-function createDatabase(tryAgain = true): DatabaseSync {
-	const cacheDatabasePath = getEnv().CACHE_DATABASE_PATH
+const sqliteCacheStates = remember(
+	'sqlite-cache-states',
+	() => new Map<string, Promise<SqliteCacheState>>(),
+)
+
+function getCacheDatabasePath() {
+	const cacheDatabasePath = getRuntimeBinding<string>(
+		'CACHE_DATABASE_PATH',
+	)?.trim()
+	if (cacheDatabasePath) return cacheDatabasePath
+	throw new Error(
+		'CACHE_DATABASE_PATH is required for the SQLite cache backend',
+	)
+}
+
+export async function getCacheDb() {
+	return (await getSqliteCacheState()).db
+}
+
+async function createDatabase(
+	cacheDatabasePath: string,
+	tryAgain = true,
+): Promise<DatabaseSync> {
+	const fs = await import('node:fs')
+	const path = await import('node:path')
+	const { DatabaseSync } = await import('node:sqlite')
 	const parentDir = path.dirname(cacheDatabasePath)
 	fs.mkdirSync(parentDir, { recursive: true })
 	const db = new DatabaseSync(cacheDatabasePath)
@@ -43,17 +73,47 @@ function createDatabase(tryAgain = true): DatabaseSync {
 			console.error(
 				`Error creating cache database, deleting the file at "${cacheDatabasePath}" and trying again...`,
 			)
-			return createDatabase(false)
+			return createDatabase(cacheDatabasePath, false)
 		}
 		throw error
 	}
 	return db
 }
 
+function getSqliteCacheState() {
+	const cacheDatabasePath = getCacheDatabasePath()
+	let state = sqliteCacheStates.get(cacheDatabasePath)
+	if (!state) {
+		state = createSqliteCacheState(cacheDatabasePath)
+		sqliteCacheStates.set(cacheDatabasePath, state)
+	}
+	return state
+}
+
+async function createSqliteCacheState(cacheDatabasePath: string) {
+	const db = await createDatabase(cacheDatabasePath)
+	return {
+		db,
+		preparedGet: db.prepare('SELECT value, metadata FROM cache WHERE key = ?'),
+		preparedSet: db.prepare(
+			'INSERT OR REPLACE INTO cache (key, value, metadata) VALUES (?, ?, ?)',
+		),
+		preparedDelete: db.prepare('DELETE FROM cache WHERE key = ?'),
+		preparedAllKeys: db.prepare('SELECT key FROM cache LIMIT ?'),
+		preparedKeySearch: db.prepare(
+			'SELECT key FROM cache WHERE key LIKE ? LIMIT ?',
+		),
+	}
+}
+
 const lruInstance = remember(
 	'lru-cache',
 	() => new LRUCache<string, CacheEntry<unknown>>({ max: 5000 }),
 )
+
+export function isFileCacheAvailable() {
+	return !hasAppDbBinding()
+}
 
 export const lruCache = {
 	set(key, value) {
@@ -71,14 +131,18 @@ export const lruCache = {
 	},
 } satisfies Cache
 
-const isBuffer = (obj: unknown): obj is Buffer =>
-	Buffer.isBuffer(obj) || obj instanceof Uint8Array
+const getBuffer = () => (globalThis as { Buffer?: typeof Buffer }).Buffer
+
+const isBuffer = (obj: unknown) =>
+	getBuffer()?.isBuffer(obj) || obj instanceof Uint8Array
 
 function bufferReplacer(_key: string, value: unknown) {
 	if (isBuffer(value)) {
+		const BufferConstructor = getBuffer()
+		if (!BufferConstructor) return value
 		return {
 			__isBuffer: true,
-			data: value.toString('base64'),
+			data: BufferConstructor.from(value).toString('base64'),
 		}
 	}
 	return value
@@ -91,22 +155,18 @@ function bufferReviver(_key: string, value: unknown) {
 		'__isBuffer' in value &&
 		(value as any).data
 	) {
-		return Buffer.from((value as any).data, 'base64')
+		const BufferConstructor = getBuffer()
+		if (!BufferConstructor) return value
+		return BufferConstructor.from((value as any).data, 'base64')
 	}
 	return value
 }
 
-const preparedGet = cacheDb.prepare(
-	'SELECT value, metadata FROM cache WHERE key = ?',
-)
-const preparedSet = cacheDb.prepare(
-	'INSERT OR REPLACE INTO cache (key, value, metadata) VALUES (?, ?, ?)',
-)
-const preparedDelete = cacheDb.prepare('DELETE FROM cache WHERE key = ?')
-
 export const cache: CachifiedCache = {
-	name: 'SQLite cache',
-	get(key) {
+	name: 'Application cache',
+	async get(key) {
+		if (hasAppDbBinding()) return lruCache.get(key) ?? null
+		const { preparedGet } = await getSqliteCacheState()
 		const result = preparedGet.get(key) as any
 		if (!result) return null
 		return {
@@ -115,6 +175,11 @@ export const cache: CachifiedCache = {
 		}
 	},
 	async set(key, entry) {
+		if (hasAppDbBinding()) {
+			lruCache.set(key, entry)
+			return
+		}
+		const { preparedSet } = await getSqliteCacheState()
 		preparedSet.run(
 			key,
 			JSON.stringify(entry.value, bufferReplacer),
@@ -122,28 +187,35 @@ export const cache: CachifiedCache = {
 		)
 	},
 	async delete(key) {
+		if (hasAppDbBinding()) {
+			lruCache.delete(key)
+			return
+		}
+		const { preparedDelete } = await getSqliteCacheState()
 		preparedDelete.run(key)
 	},
 }
 
-const preparedAllKeys = cacheDb.prepare('SELECT key FROM cache LIMIT ?')
 export async function getAllCacheKeys(limit: number) {
+	const sqlite = hasAppDbBinding()
+		? []
+		: (await getSqliteCacheState()).preparedAllKeys
+				.all(limit)
+				.map((row) => (row as { key: string }).key)
 	return {
-		sqlite: preparedAllKeys
-			.all(limit)
-			.map((row) => (row as { key: string }).key),
+		sqlite,
 		lru: [...lruInstance.keys()],
 	}
 }
 
-const preparedKeySearch = cacheDb.prepare(
-	'SELECT key FROM cache WHERE key LIKE ? LIMIT ?',
-)
 export async function searchCacheKeys(search: string, limit: number) {
+	const sqlite = hasAppDbBinding()
+		? []
+		: (await getSqliteCacheState()).preparedKeySearch
+				.all(`%${search}%`, limit)
+				.map((row) => (row as { key: string }).key)
 	return {
-		sqlite: preparedKeySearch
-			.all(`%${search}%`, limit)
-			.map((row) => (row as { key: string }).key),
+		sqlite,
 		lru: [...lruInstance.keys()].filter((key) => key.includes(search)),
 	}
 }

--- a/services/site/app/utils/env.server.ts
+++ b/services/site/app/utils/env.server.ts
@@ -22,16 +22,16 @@ const schemaBase = z.object({
 
 	ALLOWED_ACTION_ORIGINS: z.string().trim().optional(),
 
-	FLY_APP_NAME: nonEmptyString,
-	FLY_REGION: nonEmptyString,
-	FLY_MACHINE_ID: nonEmptyString,
-	LITEFS_DIR: nonEmptyString,
+	FLY_APP_NAME: z.string().trim().optional(),
+	FLY_REGION: z.string().trim().optional(),
+	FLY_MACHINE_ID: z.string().trim().optional(),
+	LITEFS_DIR: z.string().trim().optional(),
 
-	// Used by LiteFS + tooling. Optional because it can be derived from
+	// Used by local/Fly SQLite tooling. Optional because it can be derived from
 	// `DATABASE_URL` when using SQLite `file:` URLs.
 	DATABASE_PATH: z.string().trim().optional(),
 	DATABASE_URL: nonEmptyString,
-	CACHE_DATABASE_PATH: nonEmptyString,
+	CACHE_DATABASE_PATH: z.string().trim().optional(),
 
 	BOT_GITHUB_TOKEN: nonEmptyString,
 	CALL_KENT_PODCAST_ID: nonEmptyString,
@@ -152,17 +152,6 @@ const schema = schemaBase.superRefine((values, ctx) => {
 		})
 	}
 
-	// If we weren't explicitly given a DATABASE_PATH, require a `file:` URL so we
-	// can derive one deterministically.
-	if (!values.DATABASE_PATH && !values.DATABASE_URL.startsWith('file:')) {
-		ctx.addIssue({
-			code: 'custom',
-			message:
-				'DATABASE_PATH is required when DATABASE_URL is not a SQLite file: URL',
-			path: ['DATABASE_PATH'],
-		})
-	}
-
 	const port = Number(values.PORT)
 	if (!Number.isFinite(port) || port <= 0) {
 		ctx.addIssue({
@@ -182,15 +171,21 @@ export type Env = Omit<
 	| 'PORT'
 	| 'MOCKS'
 	| 'DATABASE_PATH'
+	| 'FLY_APP_NAME'
+	| 'FLY_REGION'
 	| 'FLY_MACHINE_ID'
+	| 'CACHE_DATABASE_PATH'
 	| 'CLOUDFLARE_AI_EMBEDDING_GATEWAY_ID'
 > & {
 	PORT: number
 	MOCKS: boolean
 	DATABASE_PATH: string
 	allowedActionOrigins: string[]
+	FLY_APP_NAME: string
+	FLY_REGION: string
 	/** Instance identifier; fallback for startup race when env may not be injected yet. */
 	FLY_MACHINE_ID: string
+	CACHE_DATABASE_PATH?: string
 	/**
 	 * Defaults to `CLOUDFLARE_AI_TEXT_MODEL` when not explicitly set.
 	 * This keeps Call Kent metadata generation aligned with the site's configured
@@ -238,7 +233,7 @@ function computeAllowedActionOrigins(values: BaseEnv) {
 
 function deriveDatabasePath(values: BaseEnv) {
 	if (values.DATABASE_PATH) return values.DATABASE_PATH
-	// superRefine ensures this is a `file:` URL at this point.
+	if (!values.DATABASE_URL.startsWith('file:')) return ''
 	return values.DATABASE_URL.slice('file:'.length)
 }
 
@@ -292,6 +287,8 @@ export function getEnv(): Env {
 		MOCKS: values.MOCKS === 'true',
 		DATABASE_PATH: deriveDatabasePath(values),
 		allowedActionOrigins: computeAllowedActionOrigins(values),
+		FLY_APP_NAME: values.FLY_APP_NAME ?? '',
+		FLY_REGION: values.FLY_REGION ?? 'unknown',
 		FLY_MACHINE_ID: values.FLY_MACHINE_ID ?? 'unknown',
 		R2_ENDPOINT: derivedR2Endpoint,
 		CALL_KENT_AUDIO_CF_API_BASE_URL: callKentAudioCfApiBaseUrl,

--- a/services/site/app/utils/instance-info.server.ts
+++ b/services/site/app/utils/instance-info.server.ts
@@ -13,11 +13,3 @@ export function getInstanceInfoSync() {
 export async function getInstanceInfo() {
 	return getInstanceInfoSync()
 }
-
-export async function getAllInstances() {
-	const env = getEnv()
-	const { currentInstance } = getInstanceInfoSync()
-	return { [currentInstance]: env.FLY_REGION }
-}
-
-export async function ensureInstance(_instance: string) {}

--- a/services/site/app/utils/prisma-adapter.server.ts
+++ b/services/site/app/utils/prisma-adapter.server.ts
@@ -1,7 +1,10 @@
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { PrismaD1 } from '@prisma/adapter-d1'
 import { getEnv } from '#app/utils/env.server.ts'
-import { getRuntimeBinding } from '#app/utils/runtime-bindings.server.ts'
+import {
+	getRuntimeBinding,
+	isD1Database,
+} from '#app/utils/runtime-bindings.server.ts'
 import { Prisma } from './prisma-generated.server/client.ts'
 
 function getPrismaAdapter({
@@ -12,17 +15,11 @@ function getPrismaAdapter({
 	databaseUrl?: string
 } = {}): NonNullable<Prisma.PrismaClientOptions['adapter']> {
 	if (isD1Database(appDbBinding)) {
-		return new PrismaD1(appDbBinding as ConstructorParameters<typeof PrismaD1>[0])
+		return new PrismaD1(
+			appDbBinding as ConstructorParameters<typeof PrismaD1>[0],
+		)
 	}
 	return new PrismaBetterSqlite3({ url: databaseUrl ?? getEnv().DATABASE_URL })
-}
-
-function isD1Database(value: unknown) {
-	if (!value || typeof value !== 'object') return false
-	const binding = value as Record<string, unknown>
-	return ['prepare', 'batch', 'exec', 'dump', 'withSession'].every(
-		(method) => typeof binding[method] === 'function',
-	)
 }
 
 export { getPrismaAdapter }

--- a/services/site/app/utils/runtime-bindings.server.ts
+++ b/services/site/app/utils/runtime-bindings.server.ts
@@ -24,3 +24,15 @@ export function getRuntimeBinding<T = unknown>(name: string): T | undefined {
 	const env = getEnv() as RuntimeBindingSource
 	return env[name] as T | undefined
 }
+
+export function isD1Database(value: unknown) {
+	if (!value || typeof value !== 'object') return false
+	const binding = value as Record<string, unknown>
+	return ['prepare', 'batch', 'exec', 'dump', 'withSession'].every(
+		(method) => typeof binding[method] === 'function',
+	)
+}
+
+export function hasAppDbBinding(appDbBinding = getRuntimeBinding('APP_DB')) {
+	return isD1Database(appDbBinding)
+}

--- a/services/site/server/expired-sessions-cleanup.ts
+++ b/services/site/server/expired-sessions-cleanup.ts
@@ -1,5 +1,5 @@
 import { getEnv } from '../app/utils/env.server.ts'
-import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
+import { getInstanceInfo } from '../app/utils/instance-info.server.ts'
 import {
 	deleteExpiredSessions,
 	deleteExpiredVerifications,

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -22,7 +22,7 @@ import serverTiming from 'server-timing'
 import sourceMapSupport from 'source-map-support'
 import { type WebSocketServer } from 'ws'
 import { getEnv } from '../app/utils/env.server.ts'
-import { getInstanceInfo } from '../app/utils/litefs-js.server.ts'
+import { getInstanceInfo } from '../app/utils/instance-info.server.ts'
 
 sourceMapSupport.install()
 
@@ -184,8 +184,6 @@ app.post('/__metronome', (req: any, res: any) => {
 })
 
 app.get('/healthcheck', (_req, res) => {
-	// Keep Fly's app health check process-local so it can stay green even when
-	// LiteFS metadata or downstream dependencies are slow.
 	res.type('text/plain')
 	return res.send('OK')
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rename the remaining LiteFS instance shim to neutral instance info and remove dead Fly replay/force-instance request paths.
- Make cache runtime Worker-aware: file SQLite cache is lazy/Node-only, `APP_DB` binding falls back to LRU, and file cache admin/SQLite resource routes 404 when unavailable.
- Relax Fly/LiteFS/file-cache env assumptions for Worker-shaped config and add focused cache/runtime tests.

## Verification
- `npm run test:backend -- app/utils/__tests__/cache.server.test.ts app/utils/__tests__/env.server.test.ts app/utils/__tests__/runtime-bindings.server.test.ts app/utils/__tests__/prisma.server.test.ts app/routes/resources/__tests__/cache-routes.test.ts app/utils/__tests__/mdx-not-found-cache.test.ts`
- `npm run test:browser -- app/components/calls/__tests__/submit-recording-form.test.browser.tsx`
- `npm run lint`
- `npm run typecheck`
- Pre-commit hook: `npm run format:staged && npm run lint:all && npm run typecheck:all && npm run build:all`
- Pre-push hook: full workspace test target passed (`45` backend test files, `8` browser test files passed, `1` browser file skipped)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e3523b4-1223-4840-8ba4-5aaff0c159e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e3523b4-1223-4840-8ba4-5aaff0c159e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

