### PR TITLE
Fix cold document route timeouts

### DIFF
--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -154,7 +154,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 			getInstanceInfo().then((i) => i.primaryInstance),
 			{
 				timeoutMs: 500,
-				fallback: 'unknown',
+				fallback: null,
 				label: 'root:get-instance-info',
 			},
 		),

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -150,7 +150,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 		session.getUser({ timings }),
 		getClientSession(request, session.getUser({ timings })),
 		getLoginInfoSession(request),
-		getInstanceInfo().then((i) => i.primaryInstance),
+		withTimeout(
+			getInstanceInfo().then((i) => i.primaryInstance),
+			{
+				timeoutMs: 500,
+				fallback: 'unknown',
+				label: 'root:get-instance-info',
+			},
+		),
 		time(
 			withTimeout(
 				getLatestPodcastSeasonLinks({

--- a/services/site/app/routes/blog.tsx
+++ b/services/site/app/routes/blog.tsx
@@ -93,25 +93,82 @@ export const links: LinksFunction = () => {
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings: Timings = {}
-	let postsDegraded = false
-	const posts = await withTimeout(
-		getBlogMdxListItems({ request, timings })
-			.then((allPosts) => allPosts.filter((p) => !p.frontmatter.draft))
-			.catch((error: unknown) => {
-				postsDegraded = true
+	let loaderDataDegraded = false
+	const withLoaderTimeout = <T,>(
+		promise: Promise<T>,
+		{
+			timeoutMs,
+			fallback,
+			label,
+		}: { timeoutMs: number; fallback: T; label: string },
+	) =>
+		withTimeout(
+			promise.catch((error: unknown) => {
+				loaderDataDegraded = true
 				throw error
 			}),
+			{
+				timeoutMs,
+				fallback,
+				label,
+				onTimeout: () => {
+					loaderDataDegraded = true
+				},
+			},
+		)
+	const postsPromise = withLoaderTimeout(
+		getBlogMdxListItems({ request, timings }).then((allPosts) =>
+			allPosts.filter((p) => !p.frontmatter.draft),
+		),
 		{
 			timeoutMs: BLOG_CONTENT_TIMEOUT_MS,
 			fallback: [],
 			label: 'blog:mdx-list-items',
-			onTimeout: () => {
-				postsDegraded = true
-			},
 		},
 	)
+	const readRankingsPromise = withLoaderTimeout(
+		getBlogReadRankings({ request, timings }),
+		{
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: [],
+			label: 'blog:read-rankings',
+		},
+	)
+	const totalReadsPromise = withLoaderTimeout(
+		getTotalPostReads({ request, timings }),
+		{
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: 0,
+			label: 'blog:total-post-reads',
+		},
+	)
+	const totalBlogReadersPromise = withLoaderTimeout(
+		getReaderCount({ request, timings }),
+		{
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: 0,
+			label: 'blog:reader-count',
+		},
+	)
+	const postReadCountsPromise = withLoaderTimeout(
+		getBlogPostReadCounts({ request, timings }),
+		{
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: {},
+			label: 'blog:post-read-counts',
+		},
+	)
+	const userReadsPromise = withLoaderTimeout(
+		getSlugReadsByUser({ request, timings }),
+		{
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: [],
+			label: 'blog:slug-reads-by-user',
+		},
+	)
+	const posts = await postsPromise
 	if (posts.length === 0) {
-		postsDegraded = true
+		loaderDataDegraded = true
 	}
 	const [
 		[recommended],
@@ -123,44 +180,27 @@ export async function loader({ request }: Route.LoaderArgs) {
 		userReads,
 	] = await Promise.all([
 		posts.length
-			? withTimeout(getBlogRecommendations({ request, limit: 1, timings }), {
-					timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
-					fallback: [],
-					label: 'blog:recommendations',
-				})
+			? withLoaderTimeout(
+					getBlogRecommendations({ request, limit: 1, timings }),
+					{
+						timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+						fallback: [],
+						label: 'blog:recommendations',
+					},
+				)
 			: [],
-		withTimeout(getBlogReadRankings({ request, timings }), {
-			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
-			fallback: [],
-			label: 'blog:read-rankings',
-		}),
-		withTimeout(getTotalPostReads({ request, timings }), {
-			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
-			fallback: 0,
-			label: 'blog:total-post-reads',
-		}),
-		withTimeout(getReaderCount({ request, timings }), {
-			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
-			fallback: 0,
-			label: 'blog:reader-count',
-		}),
+		readRankingsPromise,
+		totalReadsPromise,
+		totalBlogReadersPromise,
 		posts.length
-			? withTimeout(getAllBlogPostReadRankings({ request, timings }), {
+			? withLoaderTimeout(getAllBlogPostReadRankings({ request, timings }), {
 					timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
 					fallback: ALL_POST_READ_RANKINGS_FALLBACK,
 					label: 'blog:all-post-read-rankings',
 				})
 			: ALL_POST_READ_RANKINGS_FALLBACK,
-		withTimeout(getBlogPostReadCounts({ request, timings }), {
-			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
-			fallback: {},
-			label: 'blog:post-read-counts',
-		}),
-		withTimeout(getSlugReadsByUser({ request, timings }), {
-			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
-			fallback: [],
-			label: 'blog:slug-reads-by-user',
-		}),
+		postReadCountsPromise,
+		userReadsPromise,
 	])
 
 	const tags = new Set<string>()
@@ -185,7 +225,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 	return json(data, {
 		headers: {
-			'Cache-Control': postsDegraded
+			'Cache-Control': loaderDataDegraded
 				? 'private, max-age=0, must-revalidate'
 				: 'private, max-age=3600',
 			Vary: 'Cookie',

--- a/services/site/app/routes/blog.tsx
+++ b/services/site/app/routes/blog.tsx
@@ -110,6 +110,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 			},
 		},
 	)
+	if (posts.length === 0) {
+		postsDegraded = true
+	}
 	const [
 		[recommended],
 		readRankings,

--- a/services/site/app/routes/blog.tsx
+++ b/services/site/app/routes/blog.tsx
@@ -60,11 +60,17 @@ import {
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { useTeam } from '#app/utils/team-provider.tsx'
-import { getServerTimeHeader } from '#app/utils/timing.server.ts'
+import { getServerTimeHeader, withTimeout } from '#app/utils/timing.server.ts'
 import { useRootData } from '#app/utils/use-root-data.ts'
 import { type Route } from './+types/blog'
 
 const handleId = 'blog'
+const BLOG_CONTENT_TIMEOUT_MS = 3000
+const BLOG_SECONDARY_DATA_TIMEOUT_MS = 1000
+const ALL_POST_READ_RANKINGS_FALLBACK: Awaited<
+	ReturnType<typeof getAllBlogPostReadRankings>
+> = {}
+
 export const handle: KCDHandle = {
 	id: handleId,
 	getSitemapEntries: () => [{ route: `/blog`, priority: 0.7 }],
@@ -83,8 +89,17 @@ export const links: LinksFunction = () => {
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
+	const posts = await withTimeout(
+		getBlogMdxListItems({ request }).then((allPosts) =>
+			allPosts.filter((p) => !p.frontmatter.draft),
+		),
+		{
+			timeoutMs: BLOG_CONTENT_TIMEOUT_MS,
+			fallback: [],
+			label: 'blog:mdx-list-items',
+		},
+	)
 	const [
-		posts,
 		[recommended],
 		readRankings,
 		totalReads,
@@ -93,16 +108,45 @@ export async function loader({ request }: Route.LoaderArgs) {
 		postReadCounts,
 		userReads,
 	] = await Promise.all([
-		getBlogMdxListItems({ request }).then((allPosts) =>
-			allPosts.filter((p) => !p.frontmatter.draft),
-		),
-		getBlogRecommendations({ request, limit: 1, timings }),
-		getBlogReadRankings({ request, timings }),
-		getTotalPostReads({ request, timings }),
-		getReaderCount({ request, timings }),
-		getAllBlogPostReadRankings({ request, timings }),
-		getBlogPostReadCounts({ request, timings }),
-		getSlugReadsByUser({ request, timings }),
+		posts.length
+			? withTimeout(getBlogRecommendations({ request, limit: 1, timings }), {
+					timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+					fallback: [],
+					label: 'blog:recommendations',
+				})
+			: [],
+		withTimeout(getBlogReadRankings({ request, timings }), {
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: [],
+			label: 'blog:read-rankings',
+		}),
+		withTimeout(getTotalPostReads({ request, timings }), {
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: 0,
+			label: 'blog:total-post-reads',
+		}),
+		withTimeout(getReaderCount({ request, timings }), {
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: 0,
+			label: 'blog:reader-count',
+		}),
+		posts.length
+			? withTimeout(getAllBlogPostReadRankings({ request, timings }), {
+					timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+					fallback: ALL_POST_READ_RANKINGS_FALLBACK,
+					label: 'blog:all-post-read-rankings',
+				})
+			: ALL_POST_READ_RANKINGS_FALLBACK,
+		withTimeout(getBlogPostReadCounts({ request, timings }), {
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: {},
+			label: 'blog:post-read-counts',
+		}),
+		withTimeout(getSlugReadsByUser({ request, timings }), {
+			timeoutMs: BLOG_SECONDARY_DATA_TIMEOUT_MS,
+			fallback: [],
+			label: 'blog:slug-reads-by-user',
+		}),
 	])
 
 	const tags = new Set<string>()

--- a/services/site/app/routes/blog.tsx
+++ b/services/site/app/routes/blog.tsx
@@ -60,7 +60,11 @@ import {
 import { getSocialMetas } from '#app/utils/seo.ts'
 import { type SerializeFrom } from '#app/utils/serialize-from.ts'
 import { useTeam } from '#app/utils/team-provider.tsx'
-import { getServerTimeHeader, withTimeout } from '#app/utils/timing.server.ts'
+import {
+	getServerTimeHeader,
+	withTimeout,
+	type Timings,
+} from '#app/utils/timing.server.ts'
 import { useRootData } from '#app/utils/use-root-data.ts'
 import { type Route } from './+types/blog'
 
@@ -88,15 +92,22 @@ export const links: LinksFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-	const timings = {}
+	const timings: Timings = {}
+	let postsDegraded = false
 	const posts = await withTimeout(
-		getBlogMdxListItems({ request }).then((allPosts) =>
-			allPosts.filter((p) => !p.frontmatter.draft),
-		),
+		getBlogMdxListItems({ request, timings })
+			.then((allPosts) => allPosts.filter((p) => !p.frontmatter.draft))
+			.catch((error: unknown) => {
+				postsDegraded = true
+				throw error
+			}),
 		{
 			timeoutMs: BLOG_CONTENT_TIMEOUT_MS,
 			fallback: [],
 			label: 'blog:mdx-list-items',
+			onTimeout: () => {
+				postsDegraded = true
+			},
 		},
 	)
 	const [
@@ -171,7 +182,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 	return json(data, {
 		headers: {
-			'Cache-Control': 'private, max-age=3600',
+			'Cache-Control': postsDegraded
+				? 'private, max-age=0, must-revalidate'
+				: 'private, max-age=3600',
 			Vary: 'Cookie',
 			'Server-Timing': getServerTimeHeader(timings),
 		},

--- a/services/site/app/routes/index.tsx
+++ b/services/site/app/routes/index.tsx
@@ -54,6 +54,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 			},
 		},
 	)
+	if (posts.length === 0) {
+		postsDegraded = true
+	}
 	const [totalBlogReads, blogRankings, totalBlogReaders, blogRecommendations] =
 		await Promise.all([
 			withTimeout(getTotalPostReads({ request, timings }), {

--- a/services/site/app/routes/index.tsx
+++ b/services/site/app/routes/index.tsx
@@ -39,43 +39,72 @@ const HOMEPAGE_BLOG_STATS_TIMEOUT_MS = 1000
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings: Timings = {}
 	const userPromise = getUser(request)
-	let postsDegraded = false
-	const posts = await withTimeout(
-		getBlogMdxListItems({ request, timings }).catch((error: unknown) => {
-			postsDegraded = true
-			throw error
-		}),
+	let loaderDataDegraded = false
+	const withLoaderTimeout = <T,>(
+		promise: Promise<T>,
+		{
+			timeoutMs,
+			fallback,
+			label,
+		}: { timeoutMs: number; fallback: T; label: string },
+	) =>
+		withTimeout(
+			promise.catch((error: unknown) => {
+				loaderDataDegraded = true
+				throw error
+			}),
+			{
+				timeoutMs,
+				fallback,
+				label,
+				onTimeout: () => {
+					loaderDataDegraded = true
+				},
+			},
+		)
+	const postsPromise = withLoaderTimeout(
+		getBlogMdxListItems({ request, timings }),
 		{
 			timeoutMs: HOMEPAGE_BLOG_CONTENT_TIMEOUT_MS,
 			fallback: [],
 			label: 'index:blog-mdx-list-items',
-			onTimeout: () => {
-				postsDegraded = true
-			},
 		},
 	)
+	const totalBlogReadsPromise = withLoaderTimeout(
+		getTotalPostReads({ request, timings }),
+		{
+			timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+			fallback: 0,
+			label: 'index:total-post-reads',
+		},
+	)
+	const blogRankingsPromise = withLoaderTimeout(
+		getBlogReadRankings({ request, timings }),
+		{
+			timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+			fallback: [],
+			label: 'index:blog-read-rankings',
+		},
+	)
+	const totalBlogReadersPromise = withLoaderTimeout(
+		getReaderCount({ request, timings }),
+		{
+			timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+			fallback: 0,
+			label: 'index:reader-count',
+		},
+	)
+	const posts = await postsPromise
 	if (posts.length === 0) {
-		postsDegraded = true
+		loaderDataDegraded = true
 	}
 	const [totalBlogReads, blogRankings, totalBlogReaders, blogRecommendations] =
 		await Promise.all([
-			withTimeout(getTotalPostReads({ request, timings }), {
-				timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
-				fallback: 0,
-				label: 'index:total-post-reads',
-			}),
-			withTimeout(getBlogReadRankings({ request, timings }), {
-				timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
-				fallback: [],
-				label: 'index:blog-read-rankings',
-			}),
-			withTimeout(getReaderCount({ request, timings }), {
-				timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
-				fallback: 0,
-				label: 'index:reader-count',
-			}),
+			totalBlogReadsPromise,
+			blogRankingsPromise,
+			totalBlogReadersPromise,
 			posts.length
-				? withTimeout(getBlogRecommendations({ request, timings }), {
+				? withLoaderTimeout(getBlogRecommendations({ request, timings }), {
 						timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
 						fallback: [],
 						label: 'index:blog-recommendations',
@@ -104,7 +133,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		},
 		{
 			headers: {
-				'Cache-Control': postsDegraded
+				'Cache-Control': loaderDataDegraded
 					? 'private, max-age=0, must-revalidate'
 					: 'private, max-age=3600',
 				Vary: 'Cookie',

--- a/services/site/app/routes/index.tsx
+++ b/services/site/app/routes/index.tsx
@@ -26,26 +26,46 @@ import {
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
 import { getUser } from '#app/utils/session.server.ts'
-import { getServerTimeHeader } from '#app/utils/timing.server.ts'
+import { getServerTimeHeader, withTimeout } from '#app/utils/timing.server.ts'
 import { type Route } from './+types/index'
+
+const HOMEPAGE_BLOG_CONTENT_TIMEOUT_MS = 3000
+const HOMEPAGE_BLOG_STATS_TIMEOUT_MS = 1000
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
-	const [
-		user,
-		posts,
-		totalBlogReads,
-		blogRankings,
-		totalBlogReaders,
-		blogRecommendations,
-	] = await Promise.all([
-		getUser(request),
-		getBlogMdxListItems({ request, timings }),
-		getTotalPostReads({ request, timings }),
-		getBlogReadRankings({ request, timings }),
-		getReaderCount({ request, timings }),
-		getBlogRecommendations({ request, timings }),
-	])
+	const userPromise = getUser(request)
+	const posts = await withTimeout(getBlogMdxListItems({ request, timings }), {
+		timeoutMs: HOMEPAGE_BLOG_CONTENT_TIMEOUT_MS,
+		fallback: [],
+		label: 'index:blog-mdx-list-items',
+	})
+	const [totalBlogReads, blogRankings, totalBlogReaders, blogRecommendations] =
+		await Promise.all([
+			withTimeout(getTotalPostReads({ request, timings }), {
+				timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+				fallback: 0,
+				label: 'index:total-post-reads',
+			}),
+			withTimeout(getBlogReadRankings({ request, timings }), {
+				timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+				fallback: [],
+				label: 'index:blog-read-rankings',
+			}),
+			withTimeout(getReaderCount({ request, timings }), {
+				timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+				fallback: 0,
+				label: 'index:reader-count',
+			}),
+			posts.length
+				? withTimeout(getBlogRecommendations({ request, timings }), {
+						timeoutMs: HOMEPAGE_BLOG_STATS_TIMEOUT_MS,
+						fallback: [],
+						label: 'index:blog-recommendations',
+					})
+				: [],
+		])
+	const user = await userPromise
 
 	return json(
 		{

--- a/services/site/app/routes/index.tsx
+++ b/services/site/app/routes/index.tsx
@@ -26,20 +26,34 @@ import {
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
 import { getUser } from '#app/utils/session.server.ts'
-import { getServerTimeHeader, withTimeout } from '#app/utils/timing.server.ts'
+import {
+	getServerTimeHeader,
+	withTimeout,
+	type Timings,
+} from '#app/utils/timing.server.ts'
 import { type Route } from './+types/index'
 
 const HOMEPAGE_BLOG_CONTENT_TIMEOUT_MS = 3000
 const HOMEPAGE_BLOG_STATS_TIMEOUT_MS = 1000
 
 export async function loader({ request }: Route.LoaderArgs) {
-	const timings = {}
+	const timings: Timings = {}
 	const userPromise = getUser(request)
-	const posts = await withTimeout(getBlogMdxListItems({ request, timings }), {
-		timeoutMs: HOMEPAGE_BLOG_CONTENT_TIMEOUT_MS,
-		fallback: [],
-		label: 'index:blog-mdx-list-items',
-	})
+	let postsDegraded = false
+	const posts = await withTimeout(
+		getBlogMdxListItems({ request, timings }).catch((error: unknown) => {
+			postsDegraded = true
+			throw error
+		}),
+		{
+			timeoutMs: HOMEPAGE_BLOG_CONTENT_TIMEOUT_MS,
+			fallback: [],
+			label: 'index:blog-mdx-list-items',
+			onTimeout: () => {
+				postsDegraded = true
+			},
+		},
+	)
 	const [totalBlogReads, blogRankings, totalBlogReaders, blogRecommendations] =
 		await Promise.all([
 			withTimeout(getTotalPostReads({ request, timings }), {
@@ -87,7 +101,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 		},
 		{
 			headers: {
-				'Cache-Control': 'private, max-age=3600',
+				'Cache-Control': postsDegraded
+					? 'private, max-age=0, must-revalidate'
+					: 'private, max-age=3600',
 				Vary: 'Cookie',
 				'Server-Timing': getServerTimeHeader(timings),
 			},

--- a/services/site/app/utils/timing.server.ts
+++ b/services/site/app/utils/timing.server.ts
@@ -47,8 +47,10 @@ export async function withTimeout<T>(
 	},
 ): Promise<T> {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	let didTimeout = false
 	const timeoutPromise = new Promise<never>((_, reject) => {
 		timeoutId = setTimeout(() => {
+			didTimeout = true
 			try {
 				onTimeout?.()
 			} catch (error) {
@@ -63,6 +65,11 @@ export async function withTimeout<T>(
 		return result
 	} catch (error) {
 		clearTimeout(timeoutId)
+		if (didTimeout) {
+			promise.catch((lateError: unknown) => {
+				console.warn(`${label}: failed after timeout fallback`, lateError)
+			})
+		}
 		console.warn(`${label}: timeout or error, using fallback`, error)
 		return fallback
 	}

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -126,11 +126,14 @@ const getHost = (req: { get: (key: string) => string | undefined }) =>
 
 async function getInstanceInfoWithFallback() {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	let didTimeout = false
+	const instanceInfoPromise = getInstanceInfo()
 	try {
-		return await Promise.race([
-			getInstanceInfo(),
+		const instanceInfo = await Promise.race([
+			instanceInfoPromise,
 			new Promise<Awaited<ReturnType<typeof getInstanceInfo>>>((resolve) => {
 				timeoutId = setTimeout(() => {
+					didTimeout = true
 					console.warn(
 						`getInstanceInfo timed out after ${INSTANCE_INFO_TIMEOUT_MS}ms; using local instance fallback`,
 					)
@@ -143,6 +146,12 @@ async function getInstanceInfoWithFallback() {
 				}, INSTANCE_INFO_TIMEOUT_MS)
 			}),
 		])
+		if (didTimeout) {
+			instanceInfoPromise.catch((lateError: unknown) => {
+				console.warn('getInstanceInfo failed after timeout fallback', lateError)
+			})
+		}
+		return instanceInfo
 	} catch (error: unknown) {
 		console.warn('getInstanceInfo failed; using local instance fallback', error)
 		const currentInstance = env.FLY_MACHINE_ID

--- a/services/site/server/index.ts
+++ b/services/site/server/index.ts
@@ -120,8 +120,41 @@ const getBuild = async (): Promise<ServerBuild> => {
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const here = (...d: Array<string>) => path.join(__dirname, ...d)
 const primaryHost = 'kentcdodds.com'
+const INSTANCE_INFO_TIMEOUT_MS = 500
 const getHost = (req: { get: (key: string) => string | undefined }) =>
 	req.get('X-Forwarded-Host') ?? req.get('host') ?? ''
+
+async function getInstanceInfoWithFallback() {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			getInstanceInfo(),
+			new Promise<Awaited<ReturnType<typeof getInstanceInfo>>>((resolve) => {
+				timeoutId = setTimeout(() => {
+					console.warn(
+						`getInstanceInfo timed out after ${INSTANCE_INFO_TIMEOUT_MS}ms; using local instance fallback`,
+					)
+					const currentInstance = env.FLY_MACHINE_ID
+					resolve({
+						currentInstance,
+						primaryInstance: currentInstance,
+						currentIsPrimary: true,
+					})
+				}, INSTANCE_INFO_TIMEOUT_MS)
+			}),
+		])
+	} catch (error: unknown) {
+		console.warn('getInstanceInfo failed; using local instance fallback', error)
+		const currentInstance = env.FLY_MACHINE_ID
+		return {
+			currentInstance,
+			primaryInstance: currentInstance,
+			currentIsPrimary: true,
+		}
+	} finally {
+		clearTimeout(timeoutId)
+	}
+}
 
 const SHOULD_INIT_SENTRY =
 	MODE === 'production' &&
@@ -193,7 +226,7 @@ app.get('/healthcheck', (_req, res) => {
 app.use((req, res, next) => {
 	const metricName = 'middleware-get-instance-info'
 	startServerMetric(res, metricName, 'populate fly response headers')
-	getInstanceInfo()
+	getInstanceInfoWithFallback()
 		.then(({ currentInstance, primaryInstance }) => {
 			res.set('X-Powered-By', 'Kody the Koala')
 			res.set('X-Fly-Region', env.FLY_REGION)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Timebox non-critical Fly instance metadata so dynamic requests do not block on LiteFS/Fly discovery.
- Timebox cold homepage and blog loader cache work, returning safe fallbacks while cache refresh continues.
- Track degraded fallbacks across primary and secondary blog data so fallback responses use conservative caching.

### Validation
- `npm run typecheck --workspace kentcdodds.com`
- `npm run lint --workspace kentcdodds.com`
- `npm run test:backend --workspace kentcdodds.com`
- `npm run build --workspace kentcdodds.com`
- Local production smoke with `MOCKS=true`: `/` and `/blog` returned 200 on the latest build with `Server-Timing` headers.
- PR CI is green on commit `110ad6a8`: Site Gate, Playwright, CodeRabbit, and Cursor Bugbot all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance & Reliability**
  * Added bounded-timeout handling for instance information and key blog/homepage data requests to avoid slow or hanging pages.
  * Improved graceful degradation: when blog data fails or times out, the site now uses safe fallback values and continues rendering.
  * Reduced unnecessary work by only fetching recommendations when there is relevant blog content.
  * Adjusted caching so degraded pages are cached more conservatively.
  * Improved visibility by logging errors that occur after fallback responses have been served.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->