### PR TITLE
Avoid request-time blog list refresh

### DIFF
--- a/services/site/app/utils/mdx.server.ts
+++ b/services/site/app/utils/mdx.server.ts
@@ -20,6 +20,7 @@ type CachifiedOptions = {
 
 const defaultTTL = 1000 * 60 * 60 * 24 * 14
 const defaultStaleWhileRevalidate = 1000 * 60 * 60 * 24 * 365 * 100
+const blogListTTL = defaultStaleWhileRevalidate
 const notFoundTTL = 1000 * 60 * 60 * 24
 const notFoundStaleWhileRevalidate = 0
 
@@ -171,7 +172,7 @@ export async function getMdxDirList(
 }
 
 export async function getBlogMdxListItems(options: CachifiedOptions) {
-	const { request, forceFresh, ttl = defaultTTL, timings } = options
+	const { request, forceFresh, ttl = blogListTTL, timings } = options
 	const key = 'blog:mdx-list-items'
 	try {
 		return await cachified({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Keep the blog list cache from becoming stale during public requests so request traffic does not trigger heavy MDX revalidation on the single production event loop.
- Preserve explicit content refresh/deploy cache generation as the path for updating the blog list cache.

### Validation
- `npm run typecheck --workspace kentcdodds.com`
- `npm run lint --workspace kentcdodds.com`
- `npm run test:backend --workspace kentcdodds.com`
- `npm run build --workspace kentcdodds.com`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized blog content caching configuration to improve cache freshness and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->