### PR TITLE
Read blog list metadata from local content

### DIFF
--- a/services/site/app/routes/action/refresh-cache.tsx
+++ b/services/site/app/routes/action/refresh-cache.tsx
@@ -4,7 +4,11 @@ import { cache } from '#app/utils/cache.server.ts'
 import { getPeople } from '#app/utils/credits.server.ts'
 import { getEnv } from '#app/utils/env.server.ts'
 import { ensurePrimary } from '#app/utils/litefs-js.server.ts'
-import { getMdxDirList, getMdxPage } from '#app/utils/mdx.server.ts'
+import {
+	getBlogMdxListItems,
+	getMdxDirList,
+	getMdxPage,
+} from '#app/utils/mdx.server.ts'
 import { getResumeData } from '#app/utils/resume.server.ts'
 import { getTalksAndTags } from '#app/utils/talks.server.ts'
 import { getTestimonials } from '#app/utils/testimonials.server.ts'
@@ -106,7 +110,7 @@ export async function action({ request }: Route.ActionArgs) {
 		// so it will appear on the blog page.
 		if (refreshingContentPaths.some((p) => p.startsWith('blog'))) {
 			promises.push(cache.delete('blog:dir-list'))
-			promises.push(cache.delete('blog:mdx-list-items'))
+			promises.push(getBlogMdxListItems({ forceFresh: true }))
 		}
 		if (refreshingContentPaths.some((p) => p.startsWith('pages'))) {
 			promises.push(getMdxDirList('pages', { forceFresh: true }))

--- a/services/site/app/utils/mdx.server.ts
+++ b/services/site/app/utils/mdx.server.ts
@@ -1,4 +1,8 @@
+import { type Dirent } from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { buildImageUrl } from 'cloudinary-build-url'
+import pLimit from 'p-limit'
 import calculateReadingTime from 'reading-time'
 import * as YAML from 'yaml'
 import { type GitHubFile, type MdxPage } from '#app/types.ts'
@@ -25,6 +29,8 @@ const defaultStaleWhileRevalidate = 1000 * 60 * 60 * 24 * 365 * 100
 const blogListTTL = defaultStaleWhileRevalidate
 const notFoundTTL = 1000 * 60 * 60 * 24
 const notFoundStaleWhileRevalidate = 0
+const localBlogListItemLimit = pLimit(8)
+const downloadMdxFileLimit = pLimit(4)
 
 /** Spread SWR background refreshes so many stale keys don't hit the compile queue at once. */
 function staleRefreshJitterMs(key: string): number {
@@ -64,27 +70,77 @@ function parseYamlFrontmatter(source: string): Record<string, unknown> {
 	}
 }
 
-async function getMdxListItemFromDownloadedFiles({
+async function firstExistingFile(filePaths: Array<string>) {
+	for (const filePath of filePaths) {
+		try {
+			const stats = await fs.stat(filePath)
+			if (stats.isFile()) return filePath
+		} catch {
+			// try the next candidate
+		}
+	}
+	return null
+}
+
+function toGitHubEditPath(filePath: string) {
+	const relativePath = path
+		.relative(process.cwd(), filePath)
+		.replace(/\\/g, '/')
+	return relativePath.startsWith('services/site/')
+		? relativePath
+		: `services/site/${relativePath}`
+}
+
+async function getLocalBlogMdxFiles() {
+	const blogDir = path.join(process.cwd(), 'content', 'blog')
+	let entries: Array<Dirent>
+	try {
+		entries = await fs.readdir(blogDir, { withFileTypes: true })
+	} catch (error: unknown) {
+		console.error('mdx: failed to read local blog content directory', error)
+		return []
+	}
+
+	const files: Array<{ slug: string; filePath: string }> = []
+	for (const entry of entries) {
+		const name = entry.name
+		if (!name || name.startsWith('.') || entry.isSymbolicLink()) continue
+
+		if (entry.isFile() && /\.(mdx|md)$/i.test(name)) {
+			const slug = name.replace(/\.(mdx|md)$/i, '')
+			if (!slug) continue
+			files.push({ slug, filePath: path.join(blogDir, name) })
+			continue
+		}
+
+		if (entry.isDirectory()) {
+			const slug = name
+			if (!slug) continue
+			const filePath = await firstExistingFile([
+				path.join(blogDir, slug, 'index.mdx'),
+				path.join(blogDir, slug, 'index.md'),
+			])
+			if (filePath) files.push({ slug, filePath })
+		}
+	}
+
+	return files
+}
+
+async function getLocalBlogMdxListItem({
 	slug,
-	entry,
-	files,
+	filePath,
 }: {
 	slug: string
-	entry: string
-	files: Array<GitHubFile>
+	filePath: string
 }): Promise<Omit<MdxPage, 'code'> | null> {
-	const indexRegex = new RegExp(`${slug}\\/index.mdx?$`)
-	const indexFile = files.find(({ path }) => indexRegex.test(path))
-	if (!indexFile) return null
-
-	const frontmatter = parseYamlFrontmatter(
-		indexFile.content,
-	) as MdxPage['frontmatter']
+	const source = await fs.readFile(filePath, 'utf8')
+	const frontmatter = parseYamlFrontmatter(source) as MdxPage['frontmatter']
 
 	return {
 		slug,
-		editLink: `https://github.com/kentcdodds/kentcdodds.com/edit/main/${entry}`,
-		readTime: calculateReadingTime(indexFile.content),
+		editLink: `https://github.com/kentcdodds/kentcdodds.com/edit/main/${toGitHubEditPath(filePath)}`,
+		readTime: calculateReadingTime(source),
 		dateDisplay: frontmatter.date ? formatDate(frontmatter.date) : undefined,
 		frontmatter,
 	}
@@ -227,20 +283,14 @@ export async function getBlogMdxListItems(options: CachifiedOptions) {
 			forceFresh,
 			key,
 			getFreshValue: async () => {
-				const dirList = await getMdxDirList('blog', options)
+				const localFiles = await getLocalBlogMdxFiles()
 				let pages = (
 					await Promise.all(
-						dirList.map(async ({ slug }) => {
-							const downloaded = await downloadMdxFilesCached(
-								'blog',
-								slug,
-								options,
-							)
-							return getMdxListItemFromDownloadedFiles({
-								slug,
-								...downloaded,
-							})
-						}),
+						localFiles.map(({ slug, filePath }) =>
+							localBlogListItemLimit(() =>
+								getLocalBlogMdxListItem({ slug, filePath }),
+							),
+						),
 					)
 				)
 					.filter(typedBoolean)
@@ -299,7 +349,9 @@ export async function downloadMdxFilesCached(
 			return true
 		},
 		getFreshValue: async (context) => {
-			const result = await downloadMdxFileOrDirectory(`${contentDir}/${slug}`)
+			const result = await downloadMdxFileLimit(() =>
+				downloadMdxFileOrDirectory(`${contentDir}/${slug}`),
+			)
 			if (!result.files.length) {
 				applyNotFoundCacheMetadata(context.metadata, ttl)
 			}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Build blog list metadata from local `content/blog` files instead of per-post GitHub downloads.
- Warm the cheap local blog list in `/action/refresh-cache` after blog content changes.
- Limit remaining GitHub MDX downloads to avoid future cold-miss fanout.

## Testing
- `npm --workspace kentcdodds.com run typecheck` passed.
- `npm --workspace kentcdodds.com run test:backend` passed.
- Fresh-cache local production smoke on `PORT=4304`, `MOCKS=true`, `LITEFS_ENABLED=false`: cold `/blog` returned 200 in ~1.72s while `/healthcheck` stayed responsive; warm `/blog`, `/`, and `/build/info.json` returned 200 in 92ms, 36ms, and 2ms via Node fetch.
- Cache DB check showed zero `blog:%:downloaded` entries after list generation, confirming blog-list metadata no longer creates per-post GitHub download cache misses.
- Local refresh-cache smoke returned 200 in 0.93s while `/healthcheck` stayed responsive and warmed `blog:mdx-list-items`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced blog content caching with an optimized refresh mechanism and improved concurrency controls for more efficient and reliable content operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->