### PR TITLE
Disable root podcast refresh during requests

### DIFF
--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -53,7 +53,6 @@ import { getClientSession } from './utils/client.server.ts'
 import { getPublicEnv } from './utils/env.server.ts'
 import { getLoginInfoSession } from './utils/login.server.ts'
 import { useNonce } from './utils/nonce-provider.ts'
-import { getLatestPodcastSeasonLinks } from './utils/podcast-latest-season.server.ts'
 import {
 	PRODUCT_ENGINEERING_WORKSHOP_URL,
 	getProductEngineeringWorkshopPromotification,
@@ -137,48 +136,22 @@ const PODCAST_LINKS_FALLBACK = {
 export async function loader({ request }: Route.LoaderArgs) {
 	const timings = {}
 	const loaderStart = performance.now()
-	const podcastLinksAbortController = new AbortController()
 	const requestPath = new URL(request.url).pathname
 	const session = await getSession(request)
-	const [
-		user,
-		clientSession,
-		loginInfoSession,
-		primaryInstance,
-		latestPodcastSeasonLinks,
-	] = await Promise.all([
-		session.getUser({ timings }),
-		getClientSession(request, session.getUser({ timings })),
-		getLoginInfoSession(request),
-		withTimeout(
-			getInstanceInfo().then((i) => i.primaryInstance),
-			{
-				timeoutMs: 500,
-				fallback: null,
-				label: 'root:get-instance-info',
-			},
-		),
-		time(
+	const [user, clientSession, loginInfoSession, primaryInstance] =
+		await Promise.all([
+			session.getUser({ timings }),
+			getClientSession(request, session.getUser({ timings })),
+			getLoginInfoSession(request),
 			withTimeout(
-				getLatestPodcastSeasonLinks({
-					request,
-					timings,
-					signal: podcastLinksAbortController.signal,
-				}),
+				getInstanceInfo().then((i) => i.primaryInstance),
 				{
-					timeoutMs: 2000,
-					fallback: PODCAST_LINKS_FALLBACK,
-					label: 'root:podcast-season-links',
-					onTimeout: () => podcastLinksAbortController.abort(),
+					timeoutMs: 500,
+					fallback: null,
+					label: 'root:get-instance-info',
 				},
 			),
-			{
-				timings,
-				type: 'root:podcast-season-links',
-				desc: 'podcast nav links (Simplecast + Transistor)',
-			},
-		),
-	])
+		])
 
 	const randomFooterImageKeys = Object.keys(illustrationImages)
 	const randomFooterImageKey = randomFooterImageKeys[
@@ -190,7 +163,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const data = {
 		user,
 		userInfo: user ? await getUserInfo(user, { request, timings }) : null,
-		latestPodcastSeasonLinks,
+		latestPodcastSeasonLinks: PODCAST_LINKS_FALLBACK,
 		productEngineeringWorkshopPromotification:
 			productEngineeringWorkshopPromotification
 				? {

--- a/services/site/app/utils/monitoring.client.tsx
+++ b/services/site/app/utils/monitoring.client.tsx
@@ -1,8 +1,6 @@
 import {
 	init as sentryInit,
 	reactRouterTracingIntegration,
-	replayIntegration,
-	browserProfilingIntegration,
 } from '@sentry/react-router'
 
 export function init() {
@@ -33,21 +31,16 @@ export function init() {
 		beforeSendTransaction(event) {
 			return event
 		},
-		integrations: [
-			reactRouterTracingIntegration(),
-			replayIntegration(),
-			browserProfilingIntegration(),
-		],
+		integrations: [reactRouterTracingIntegration()],
 
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production
-		tracesSampleRate: 1.0,
+		tracesSampleRate: 0.01,
 
-		// Capture Replay for 10% of all sessions,
-		// plus for 100% of sessions with an error
-		replaysSessionSampleRate: 0.1,
-		replaysOnErrorSampleRate: 1.0,
+		// Keep error reporting on while avoiding replay/profiling load during incidents.
+		replaysSessionSampleRate: 0,
+		replaysOnErrorSampleRate: 0,
 	})
 }
 

--- a/services/site/server/utils/monitoring.ts
+++ b/services/site/server/utils/monitoring.ts
@@ -1,4 +1,3 @@
-import { nodeProfilingIntegration } from '@sentry/profiling-node'
 import * as Sentry from '@sentry/react-router'
 import { getEnv } from '../../app/utils/env.server.ts'
 
@@ -15,7 +14,7 @@ export function init() {
 	Sentry.init({
 		dsn: env.SENTRY_DSN,
 		environment: env.NODE_ENV,
-		tracesSampleRate: env.NODE_ENV === 'production' ? 1 : 0,
+		tracesSampleRate: env.NODE_ENV === 'production' ? 0.01 : 0,
 		denyUrls: [
 			/\/healthcheck/,
 			// TODO: be smarter about the public assets...
@@ -28,17 +27,13 @@ export function init() {
 			/\/favicon.ico/,
 			/\/site\.webmanifest/,
 		],
-		integrations: [
-			Sentry.httpIntegration(),
-			Sentry.prismaIntegration(),
-			nodeProfilingIntegration(),
-		],
+		integrations: [Sentry.httpIntegration(), Sentry.prismaIntegration()],
 		tracesSampler(samplingContext) {
 			// ignore healthcheck transactions by other services (consul, etc.)
 			if (samplingContext.request?.url?.includes('/healthcheck')) {
 				return 0
 			}
-			return 1
+			return env.NODE_ENV === 'production' ? 0.01 : 0
 		},
 		beforeSendTransaction(event) {
 			// ignore all healthcheck related transactions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Stop the root loader from refreshing Simplecast/Transistor podcast season links on every document request.
- Keep static `/chats` and `/calls` nav links in root data during the incident.
- Reduce Sentry tracing to 1% and disable server/client profiling and replay to preserve error reporting without adding process load.

## Testing
- `npm --workspace kentcdodds.com run typecheck` passed.
- `npm --workspace kentcdodds.com run test:backend` passed.
- Runtime diagnosis on release 856 showed the actual app process (`node ./index.ts`) running with ~668 MB RSS, high main-thread CPU, many sockets, and open SQLite/cache DB files while `/healthcheck` and static assets timed out; this fix removes the universal root-loader podcast refresh and Sentry profiling/replay load from that path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec628-2b9c-77ea-ba47-4b3eb747880b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized server-side rendering by using default podcast links instead of fetching during load.
  * Reduced performance monitoring sampling to 1% to improve efficiency.
  * Disabled session replay monitoring and removed profiling data collection to reduce overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->