### PR TITLE
Fix deploy job name showing raw expression when skipped

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -129,7 +129,8 @@ jobs:
           retention-days: 30
 
   deploy:
-    name: 🚀 Deploy ${{ inputs.deploy_target == 'production' && 'Production' || 'Staging' }} Worker
+    # Static name: GitHub does not evaluate job.name expressions for skipped jobs.
+    name: 🚀 Deploy Site Worker
     runs-on: ubuntu-latest
     needs: [verify]
     if: ${{ inputs.should_deploy && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The deploy job in `deploy-site.yml` used a dynamic name:

```yaml
name: 🚀 Deploy ${{ inputs.deploy_target == 'production' && 'Production' || 'Staging' }} Worker
```

On PR runs, that job is skipped (`should_deploy=false`), and GitHub Actions does not evaluate `job.name` expressions for skipped jobs ([actions/runner#1215](https://github.com/actions/runner/issues/1215)). The raw `${{ ... }}` syntax showed up in the GitHub UI and Discord webhook notifications.

## Fix

Use a static job name (`🚀 Deploy Site Worker`). When the job actually runs, the deployment target is still visible via the `site-production` / `site-staging` environment name in the GitHub UI.

## Test plan

- [ ] Open a PR and confirm the deploy job shows `🚀 Deploy Site Worker` instead of the raw expression when skipped
- [ ] Push to `main` with a site change and confirm the deploy job still runs and deploys correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec3373f5-eef1-491d-9bc0-843f72ce34e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec3373f5-eef1-491d-9bc0-843f72ce34e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the deployment job label to a consistent name in the site deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->