### PR TITLE
Update nesting closures post for protected tweet link

### DIFF
--- a/services/site/content/blog/why-i-avoid-nesting-closures.mdx
+++ b/services/site/content/blog/why-i-avoid-nesting-closures.mdx
@@ -101,9 +101,7 @@ I've had some conversations about this on twitter that have been interesting and
 I think the most interesting insight so far has been from a thread where
 [Lily Scott](https://x.com/suchipi) described
 [a side-effect](https://x.com/suchipi/status/1206061075587682304) which
-[Jed Fox](https://x.com/jed_fox1) summed up well in this tweet:
-
-https://x.com/jed_fox1/status/1206061752737320960
+[Jed Fox](https://x.com/jed_fox1) summed up well in what is now a protected tweet.
 
 So yes, this concept has nuance and there are trade-offs. I think I still prefer
 extracting things because most of the time my files are only a few hundred lines


### PR DESCRIPTION
## Summary
- Updates the "why I avoid nesting closures" blog post to remove a dead tweet link
- Notes that Jed Fox's summary tweet is now protected

## Test plan
- [ ] Verify the blog post renders correctly at `/blog/why-i-avoid-nesting-closures`
- [ ] Confirm the Jed Fox reference reads naturally without the broken link


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a blog post citation to reflect that the referenced tweet is now protected.
  * Removed the previously displayed tweet content and link from the quoted section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->