### PR TITLE
Fix production deploy: preserve Fly-synced R2 access keys

### DIFF
--- a/services/site-worker/scripts/generate-worker-secrets.mjs
+++ b/services/site-worker/scripts/generate-worker-secrets.mjs
@@ -89,6 +89,11 @@ const INTEGRATION_SECRET_KEYS = [
 	'R2_BUCKET',
 	'CALL_KENT_R2_BUCKET',
 	'CALL_KENT_AUDIO_CF_QUEUE_ID',
+	// R2 access keys were synced from Fly directly onto the worker and are not
+	// GitHub CI secrets, so production must preserve the existing worker values
+	// rather than derive placeholders.
+	'R2_ACCESS_KEY_ID',
+	'R2_SECRET_ACCESS_KEY',
 	// Must match the secret set manually on kcd-call-kent-audio-worker; the
 	// production value was synced from Fly and may not equal the GitHub copy.
 	'CALL_KENT_AUDIO_PROCESSOR_CALLBACK_SECRET',
@@ -184,18 +189,6 @@ async function main() {
 		CHATS_WITH_KENT_PODCAST_ID: deriveOrEnv(
 			'CHATS_WITH_KENT_PODCAST_ID',
 			`${secretPrefix}CHATS_WITH_KENT_PODCAST_ID`,
-			refreshCacheSecret,
-			derivedFallbacks,
-		),
-		R2_ACCESS_KEY_ID: deriveOrEnv(
-			'R2_ACCESS_KEY_ID',
-			`${secretPrefix}R2_ACCESS_KEY_ID`,
-			refreshCacheSecret,
-			derivedFallbacks,
-		),
-		R2_SECRET_ACCESS_KEY: deriveOrEnv(
-			'R2_SECRET_ACCESS_KEY',
-			`${secretPrefix}R2_SECRET_ACCESS_KEY`,
 			refreshCacheSecret,
 			derivedFallbacks,
 		),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The first post-merge production deploy (from #813) failed at the **Generate worker secrets** step:

```
⚠️  CUTOVER BLOCKER: the following secrets used derived fallbacks
  - R2_ACCESS_KEY_ID
  - R2_SECRET_ACCESS_KEY
Refusing to emit derived fallbacks for production secrets.
```

`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` were still in the "infra" group that derives a placeholder when absent from the CI env. But these keys are **not** GitHub CI secrets — they were synced directly from Fly onto the production worker. So the generator derived placeholders, and the hard-fail guard (added in #813 to prevent exactly this class of silent clobber) correctly refused to overwrite the real values with garbage.

The worker deploy itself succeeded (it runs before the secrets step); only the secret upload, MDX publish, and smoke check were skipped. The worker is healthy on workers.dev and serving current content, but the deploy job is red and MDX artifacts for this build weren't published via the endpoint.

## Fix

Move `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` into `INTEGRATION_SECRET_KEYS` — the same group as `SESSION_SECRET`, `R2_BUCKET`, and the other Fly-synced values — so the production bulk upload omits them and preserves the existing worker values. Staging behavior is unchanged (still derives from env/fallback).

Verified: the production worker already has both keys set (52 secrets present, including both R2 keys), and the generator now exits 0 for production with them omitted from the bulk payload.

## Testing
- Generator run with the CI env set produces a valid production payload with zero derived-fallback blockers and both R2 keys omitted.
- `npm test --workspace site-worker` (98 tests) green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b429de5c-9adc-44eb-8822-420b05b92309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b429de5c-9adc-44eb-8822-420b05b92309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of R2 access credentials so production keeps the existing worker values instead of generating placeholders.
  * Staging environments can still resolve these values from available environment settings as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->