### PR TITLE
Fix Refresh Content compare-SHA fallback after Workers cutover

### DIFF
--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -138,6 +138,13 @@ Two paths:
    updates `mdx-manifest:current`, and clears its manifest cache.
 
 `GET /__meta` returns `{ buildSha, contentVersion }` for deploy verification.
+Content-only refreshes (`🥬 Refresh Content`) still matter after the Workers
+cutover: when a push changes only `services/site/content/` and does not trigger
+a site redeploy, CI compiles MDX, publishes the artifact bundle via
+`POST /resources/mdx-artifacts`, and records the commit via
+`POST /action/refresh-cache`. Compare SHA resolution prefers
+`/refresh-commit-sha.json`, then falls back to `/__meta.buildSha` (the old
+Fly-era `/build/info.json` asset is no longer published).
 
 ## Bootstrap ↔ app bridge (globals contract)
 
@@ -222,9 +229,7 @@ runtime in the worker).
 ## Server-side MDX rendering (no eval)
 
 - Route loaders that return MDX pages call `ensureMdxComponentLoaded(page)`
-  (server-only), which does `await import(\`mdx/${contentDir}/${slug}.js\`)`
-  and caches the component in a module-level registry keyed by
-  `${contentDir}/${slug}`.
+  (server-only), which does `await import(\`mdx/${contentDir}/${slug}.js\`)`and caches the component in a module-level registry keyed by`${contentDir}/${slug}`.
 - `useMdxComponent` checks the server registry first (synchronously, during
   SSR); in the browser (or in Node dev) it falls back to the existing
   mdx-bundler `new Function` path via `getDocumentCode` / `CONTENT_RPC`. Both
@@ -269,7 +274,7 @@ shared `services/site/app/utils/media-serving.server.ts`):
   bytes with `Range` support; transforms are ignored.
 - **Input limit**: the binding fails on inputs over ~20 MiB
   ("Network connection lost"); `migrate-cloudinary-to-r2.mjs
-  --normalize-oversized` re-encoded such masters to ≤4096px.
+--normalize-oversized` re-encoded such masters to ≤4096px.
 - **Edge cache**: `caches.default`, 1-year immutable; media is excluded from
   dynamic rate limiting (asset tier).
 - URL building in the app goes exclusively through `buildMediaUrl` /
@@ -527,14 +532,14 @@ The worker listens on `http://127.0.0.1:8792` and exposes `GET /healthcheck`
 - Service bindings: same production oauth/search workers
 - Deploys from `.github/workflows/deployment.yml` → `deploy-site.yml` on pushes
   to `main` (`npm run provision:production`, `generate-worker-secrets.mjs
-  --target=production`, artifact publish via endpoint, D1 migrations, smoke).
+--target=production`, artifact publish via endpoint, D1 migrations, smoke).
 
 ### Resource naming
 
-| Target | Worker + D1 | KV + R2 |
-| ------ | ----------- | ------- |
+| Target                   | Worker + D1               | KV + R2                 |
+| ------------------------ | ------------------------- | ----------------------- |
 | Staging (branch preview) | `kentcdodds-com-staging*` | `kcd-site-cf-preview-*` |
-| Production (main) | `kentcdodds-com*` | `kentcdodds-com-*` |
+| Production (main)        | `kentcdodds-com*`         | `kentcdodds-com-*`      |
 
 `wrangler.jsonc` uses `env.production` overrides for production bindings; the
 default top-level config is staging. `provision-preview.mjs --target=staging|production`
@@ -546,7 +551,7 @@ The repo `CLOUDFLARE_API_TOKEN` can deploy worker scripts and upload secrets
 but **cannot** list/create D1/KV/R2 (auth error 10000). Therefore:
 
 - Resource IDs are committed in `services/site-worker/wrangler.jsonc`; `npm run
-  provision:preview` / `provision:production` skips Cloudflare API calls when IDs
+provision:preview` / `provision:production` skips Cloudflare API calls when IDs
   are present (use `--force-ensure` for fresh environments with a privileged token).
 - D1 migrations and seed steps in CI are **non-fatal** with a loud warning.
 - Artifact publish in CI uses `POST /resources/mdx-artifacts` (no R2/KV API
@@ -561,13 +566,13 @@ table. Do not rename migration files after deploy.
 D1 rejects `CREATE TEMP TABLE` in migrations — use a regular guard table and
 drop it in the same migration when needed.
 
-| Command | Target |
-| --- | --- |
-| `npm run d1:migrations:list:local --workspace site-worker` | List pending local Miniflare D1 |
-| `npm run d1:migrations:apply:local --workspace site-worker` | Apply to local Miniflare D1 |
-| `npm run d1:migrations:list:staging --workspace site-worker` | List pending remote staging D1 |
-| `npm run d1:migrations:apply:staging --workspace site-worker` | Apply to remote staging D1 |
-| `npm run d1:migrations:apply:production --workspace site-worker` | Apply to remote production D1 |
+| Command                                                          | Target                          |
+| ---------------------------------------------------------------- | ------------------------------- |
+| `npm run d1:migrations:list:local --workspace site-worker`       | List pending local Miniflare D1 |
+| `npm run d1:migrations:apply:local --workspace site-worker`      | Apply to local Miniflare D1     |
+| `npm run d1:migrations:list:staging --workspace site-worker`     | List pending remote staging D1  |
+| `npm run d1:migrations:apply:staging --workspace site-worker`    | Apply to remote staging D1      |
+| `npm run d1:migrations:apply:production --workspace site-worker` | Apply to remote production D1   |
 
 ### Runbook: schema changes
 

--- a/other/__tests__/compute-deploy-plan.test.js
+++ b/other/__tests__/compute-deploy-plan.test.js
@@ -1,855 +1,923 @@
-import { expect, test, vi } from 'vitest'
-import { computeDeployPlan } from '../compute-deploy-plan.ts'
+import { expect, test, vi } from "vitest";
+import { computeDeployPlan } from "../compute-deploy-plan.ts";
 
 function createLogger() {
-	return {
-		log: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-	}
+  return {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
 }
 
 function createMockDeploymentFetch(shaByEnvironment = {}) {
-	const defaultSha = shaByEnvironment['*'] ?? 'deployed-sha'
-	return vi.fn(async (url) => {
-		if (!url.includes('api.github.com') || !url.includes('deployments')) {
-			throw new Error(`Unexpected fetch URL: ${url}`)
-		}
-		if (url.includes('/statuses')) {
-			return { ok: true, json: async () => [{ state: 'success' }] }
-		}
-		const envMatch = url.match(/environment=([^&]+)/)
-		const env = envMatch ? decodeURIComponent(envMatch[1]) : 'default'
-		const sha = shaByEnvironment[env] ?? defaultSha
-		return { ok: true, json: async () => [{ id: 1, sha }] }
-	})
+  const defaultSha = shaByEnvironment["*"] ?? "deployed-sha";
+  return vi.fn(async (url) => {
+    if (!url.includes("api.github.com") || !url.includes("deployments")) {
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }
+    if (url.includes("/statuses")) {
+      return { ok: true, json: async () => [{ state: "success" }] };
+    }
+    const envMatch = url.match(/environment=([^&]+)/);
+    const env = envMatch ? decodeURIComponent(envMatch[1]) : "default";
+    const sha = shaByEnvironment[env] ?? defaultSha;
+    return { ok: true, json: async () => [{ id: 1, sha }] };
+  });
 }
 
 const defaultDeployPlanOpts = {
-	repository: 'owner/repo',
-	token: 'test-token',
-	refName: 'main',
-}
+  repository: "owner/repo",
+  token: "test-token",
+  refName: "main",
+};
 
-test('deploys the site when deployment diff includes a site-deployable file', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/app/routes/index.tsx' }]
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' }]
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' }]
-			}
-			if (compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("deploys the site when deployment diff includes a site-deployable file", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/app/routes/index.tsx",
+          },
+        ];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.refreshContent).toBe(false)
-	expect(deployPlan.indexSemanticContent).toBe(true)
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployCallKentAudioWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(false)
-})
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.refreshContent).toBe(false);
+  expect(deployPlan.indexSemanticContent).toBe(true);
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployCallKentAudioWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(false);
+});
 
-test('skips refresh content when site deploy will publish MDX artifacts', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [
-					{ changeType: 'modified', filename: 'services/site/app/routes/index.tsx' },
-					{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' },
-				]
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' }]
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' }]
-			}
-			if (compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("skips refresh content when site deploy will publish MDX artifacts", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/app/routes/index.tsx",
+          },
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.refreshContent).toBe(false)
-})
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.refreshContent).toBe(false);
+});
 
-test('deploys the site when the site workflow changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [
-					{
-						changeType: 'modified',
-						filename: '.github/workflows/deploy-site.yml',
-					},
-				]
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("deploys the site when the site workflow changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: ".github/workflows/deploy-site.yml",
+          },
+        ];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(false)
-})
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(false);
+});
 
-test('skips site deploy when deployment diff only includes non-site targets', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [
-					{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' },
-					{
-						changeType: 'modified',
-						filename: 'services/call-kent-audio-worker/src/index.ts',
-					},
-				]
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("skips site deploy when deployment diff only includes non-site targets", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+          {
+            changeType: "modified",
+            filename: "services/call-kent-audio-worker/src/index.ts",
+          },
+        ];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(false)
-})
+  expect(deployPlan.deploySite).toBe(false);
+});
 
-test('deploys the site when deployment diff only includes site-worker changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [
-					{
-						changeType: 'modified',
-						filename: 'services/site-worker/src/index.ts',
-					},
-					{
-						changeType: 'modified',
-						filename: '.github/workflows/cf-preview-deploy.yml',
-					},
-				]
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("deploys the site when deployment diff only includes site-worker changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site-worker/src/index.ts",
+          },
+          {
+            changeType: "modified",
+            filename: ".github/workflows/cf-preview-deploy.yml",
+          },
+        ];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-})
+  expect(deployPlan.deploySite).toBe(true);
+});
 
-test('plans search worker deploys for shared contract changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'search-worker-production': 'deployed-search-worker-sha',
-		'oauth-production': 'deployed-oauth-sha',
-		'call-kent-audio-worker-production': 'deployed-audio-worker-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [{ changeType: 'modified', filename: 'services/search-shared/src/search-shared.ts' }]
-			}
-			if (compareCommitSha === 'deployed-search-worker-sha') {
-				return [{ changeType: 'modified', filename: 'services/search-worker/src/index.ts' }]
-			}
-			if (compareCommitSha === 'deployed-oauth-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-audio-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("plans search worker deploys for shared contract changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "search-worker-production": "deployed-search-worker-sha",
+    "oauth-production": "deployed-oauth-sha",
+    "call-kent-audio-worker-production": "deployed-audio-worker-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/search-shared/src/search-shared.ts",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-search-worker-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/search-worker/src/index.ts",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-oauth-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-audio-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.deploySearchWorker).toBe(true)
-	expect(deployPlan.deployCallKentAudioWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(false)
-})
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.deploySearchWorker).toBe(true);
+  expect(deployPlan.deployCallKentAudioWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(false);
+});
 
-test('plans search worker deploys for search-shared package changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'search-worker-production': 'deployed-search-worker-sha',
-		'oauth-production': 'deployed-oauth-sha',
-		'call-kent-audio-worker-production': 'deployed-audio-worker-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [
-					{
-						changeType: 'modified',
-						filename: 'services/search-shared/src/search-shared.ts',
-					},
-				]
-			}
-			if (compareCommitSha === 'deployed-search-worker-sha') {
-				return [
-					{
-						changeType: 'modified',
-						filename: 'services/search-shared/src/search-shared.ts',
-					},
-				]
-			}
-			if (compareCommitSha === 'deployed-oauth-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-audio-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("plans search worker deploys for search-shared package changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "search-worker-production": "deployed-search-worker-sha",
+    "oauth-production": "deployed-oauth-sha",
+    "call-kent-audio-worker-production": "deployed-audio-worker-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/search-shared/src/search-shared.ts",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-search-worker-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/search-shared/src/search-shared.ts",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-oauth-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-audio-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.deploySearchWorker).toBe(true)
-})
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.deploySearchWorker).toBe(true);
+});
 
-test('plans audio deploys for workflow file changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'search-worker-production': 'deployed-search-worker-sha',
-		'oauth-production': 'deployed-oauth-sha',
-		'call-kent-audio-worker-production': 'deployed-audio-worker-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-audio-worker-sha') {
-				return [
-					{
-						changeType: 'modified',
-						filename: '.github/workflows/deploy-call-kent-audio-worker.yml',
-					},
-				]
-			}
-			if (compareCommitSha === 'deployed-search-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-oauth-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("plans audio deploys for workflow file changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "search-worker-production": "deployed-search-worker-sha",
+    "oauth-production": "deployed-oauth-sha",
+    "call-kent-audio-worker-production": "deployed-audio-worker-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-audio-worker-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: ".github/workflows/deploy-call-kent-audio-worker.yml",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-search-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-oauth-sha") {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployCallKentAudioWorker).toBe(true)
-	expect(deployPlan.deployOauthWorker).toBe(false)
-})
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployCallKentAudioWorker).toBe(true);
+  expect(deployPlan.deployOauthWorker).toBe(false);
+});
 
-test('plans oauth worker deploys for oauth changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'search-worker-production': 'deployed-search-worker-sha',
-		'oauth-production': 'deployed-oauth-sha',
-		'call-kent-audio-worker-production': 'deployed-audio-worker-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [{ changeType: 'modified', filename: 'services/oauth/src/index.ts' }]
-			}
-			if (compareCommitSha === 'deployed-oauth-sha') {
-				return [{ changeType: 'modified', filename: 'services/oauth/src/index.ts' }]
-			}
-			if (compareCommitSha === 'deployed-search-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-audio-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return [{ changeType: 'modified', filename: 'services/oauth/src/index.ts' }]
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("plans oauth worker deploys for oauth changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "search-worker-production": "deployed-search-worker-sha",
+    "oauth-production": "deployed-oauth-sha",
+    "call-kent-audio-worker-production": "deployed-audio-worker-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          { changeType: "modified", filename: "services/oauth/src/index.ts" },
+        ];
+      }
+      if (compareCommitSha === "deployed-oauth-sha") {
+        return [
+          { changeType: "modified", filename: "services/oauth/src/index.ts" },
+        ];
+      }
+      if (compareCommitSha === "deployed-search-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-audio-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [
+          { changeType: "modified", filename: "services/oauth/src/index.ts" },
+        ];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(false)
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(true)
-})
+  expect(deployPlan.deploySite).toBe(false);
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(true);
+});
 
-test('plans oauth worker deploys for workflow file changes', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'search-worker-production': 'deployed-search-worker-sha',
-		'oauth-production': 'deployed-oauth-sha',
-		'call-kent-audio-worker-production': 'deployed-audio-worker-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-oauth-sha') {
-				return [
-					{
-						changeType: 'modified',
-						filename: '.github/workflows/deploy-oauth-worker.yml',
-					},
-				]
-			}
-			if (compareCommitSha === 'deployed-search-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-audio-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("plans oauth worker deploys for workflow file changes", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "search-worker-production": "deployed-search-worker-sha",
+    "oauth-production": "deployed-oauth-sha",
+    "call-kent-audio-worker-production": "deployed-audio-worker-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-oauth-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: ".github/workflows/deploy-oauth-worker.yml",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-search-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-audio-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(true)
-})
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(true);
+});
 
-test('treats app changes as semantic-content updates', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch()
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha' || compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/app/utils/misc.ts' }]
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("treats app changes as semantic-content updates", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch();
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (
+        compareCommitSha === "deployed-site-sha" ||
+        compareCommitSha === "deployed-sha"
+      ) {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/app/utils/misc.ts",
+          },
+        ];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.indexSemanticContent).toBe(true)
-})
+  expect(deployPlan.indexSemanticContent).toBe(true);
+});
 
-test('plans deploy targets when no deployment state available', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const getChangedFilesImpl = vi.fn(async () => [])
-	const log = createLogger()
+test("plans deploy targets when no deployment state available", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const getChangedFilesImpl = vi.fn(async () => []);
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: null,
-		eventName: 'push',
-		repository: undefined,
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    currentCommitSha: "current-sha",
+    pushBeforeSha: null,
+    eventName: "push",
+    repository: undefined,
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    log,
+  });
 
-	expect(deployPlan.refreshContent).toBe(false)
-	expect(deployPlan.indexSemanticContent).toBe(true)
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.deploySearchWorker).toBe(true)
-	expect(deployPlan.deployCallKentAudioWorker).toBe(true)
-	expect(deployPlan.deployOauthWorker).toBe(true)
-})
+  expect(deployPlan.refreshContent).toBe(false);
+  expect(deployPlan.indexSemanticContent).toBe(true);
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.deploySearchWorker).toBe(true);
+  expect(deployPlan.deployCallKentAudioWorker).toBe(true);
+  expect(deployPlan.deployOauthWorker).toBe(true);
+});
 
-test('leaves push-only execution to workflow gating during pull requests', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'oauth-production': 'deployed-oauth-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' }]
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return [{ changeType: 'modified', filename: 'services/site/content/blog/post.mdx' }]
-			}
-			if (compareCommitSha === 'deployed-sha') {
-				return []
-			}
-			return []
-		},
-	)
-	const log = createLogger()
+test("leaves push-only execution to workflow gating during pull requests", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "oauth-production": "deployed-oauth-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [
+          {
+            changeType: "modified",
+            filename: "services/site/content/blog/post.mdx",
+          },
+        ];
+      }
+      if (compareCommitSha === "deployed-sha") {
+        return [];
+      }
+      return [];
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		eventName: 'pull_request',
-		refName: 'main',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    eventName: "pull_request",
+    refName: "main",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(false)
-	expect(deployPlan.refreshContent).toBe(true)
-	expect(deployPlan.indexSemanticContent).toBe(false)
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployCallKentAudioWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(false)
-})
+  expect(deployPlan.deploySite).toBe(false);
+  expect(deployPlan.refreshContent).toBe(true);
+  expect(deployPlan.indexSemanticContent).toBe(false);
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployCallKentAudioWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(false);
+});
 
-test('failed deploy stays deployable across unrelated push', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'deployed-site-sha',
-		'search-worker-production': 'deployed-search-worker-sha',
-		'oauth-production': 'last-successful-oauth-sha',
-		'call-kent-audio-worker-production': 'deployed-audio-worker-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'deployed-site-sha') {
-				return []
-			}
-			if (compareCommitSha === 'last-successful-oauth-sha') {
-				return [
-					{ changeType: 'modified', filename: 'services/oauth/src/index.ts' },
-					{ changeType: 'modified', filename: 'README.md' },
-				]
-			}
-			if (compareCommitSha === 'deployed-search-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'deployed-audio-worker-sha') {
-				return []
-			}
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return [{ changeType: 'modified', filename: 'README.md' }]
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("failed deploy stays deployable across unrelated push", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "deployed-site-sha",
+    "search-worker-production": "deployed-search-worker-sha",
+    "oauth-production": "last-successful-oauth-sha",
+    "call-kent-audio-worker-production": "deployed-audio-worker-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "deployed-site-sha") {
+        return [];
+      }
+      if (compareCommitSha === "last-successful-oauth-sha") {
+        return [
+          { changeType: "modified", filename: "services/oauth/src/index.ts" },
+          { changeType: "modified", filename: "README.md" },
+        ];
+      }
+      if (compareCommitSha === "deployed-search-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "deployed-audio-worker-sha") {
+        return [];
+      }
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [{ changeType: "modified", filename: "README.md" }];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(false)
-	expect(deployPlan.deploySearchWorker).toBe(false)
-	expect(deployPlan.deployOauthWorker).toBe(true)
-})
+  expect(deployPlan.deploySite).toBe(false);
+  expect(deployPlan.deploySearchWorker).toBe(false);
+  expect(deployPlan.deployOauthWorker).toBe(true);
+});
 
-test('non-main refs have no site deployment environment', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = createMockDeploymentFetch({
-		'site-production': 'production-deployed-sha',
-	})
-	const getChangedFilesImpl = vi.fn(
-		async (ignoredCurrentCommitSha, compareCommitSha) => {
-			if (compareCommitSha === 'refresh-sha') {
-				return []
-			}
-			if (compareCommitSha === 'push-before-sha') {
-				return []
-			}
-			throw new Error(`Unexpected compare sha: ${compareCommitSha}`)
-		},
-	)
-	const log = createLogger()
+test("non-main refs have no site deployment environment", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = createMockDeploymentFetch({
+    "site-production": "production-deployed-sha",
+  });
+  const getChangedFilesImpl = vi.fn(
+    async (ignoredCurrentCommitSha, compareCommitSha) => {
+      if (compareCommitSha === "refresh-sha") {
+        return [];
+      }
+      if (compareCommitSha === "push-before-sha") {
+        return [];
+      }
+      throw new Error(`Unexpected compare sha: ${compareCommitSha}`);
+    },
+  );
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		refName: 'dev',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    refName: "dev",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	// Without a deployment environment for the ref, unknown diffs default to
-	// deployable, but the deploy jobs themselves only run on main.
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.refreshContent).toBe(false)
-})
+  // Without a deployment environment for the ref, unknown diffs default to
+  // deployable, but the deploy jobs themselves only run on main.
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.refreshContent).toBe(false);
+});
 
-test('GitHub API failure defaults to deploy', async () => {
-	const fetchJsonImpl = vi.fn(async (url) => {
-		if (url.endsWith('/refresh-commit-sha.json')) {
-			return { sha: 'refresh-sha' }
-		}
-		if (url.endsWith('/build/info.json')) {
-			return { commit: { sha: 'fallback' } }
-		}
-		return null
-	})
-	const fetchImpl = vi.fn(async () => {
-		throw new Error('Network error')
-	})
-	const getChangedFilesImpl = vi.fn(async () => [])
-	const log = createLogger()
+test("GitHub API failure defaults to deploy", async () => {
+  const fetchJsonImpl = vi.fn(async (url) => {
+    if (url.endsWith("/refresh-commit-sha.json")) {
+      return { sha: "refresh-sha" };
+    }
+    if (url.endsWith("/__meta")) {
+      return { buildSha: "fallback" };
+    }
+    return null;
+  });
+  const fetchImpl = vi.fn(async () => {
+    throw new Error("Network error");
+  });
+  const getChangedFilesImpl = vi.fn(async () => []);
+  const log = createLogger();
 
-	const deployPlan = await computeDeployPlan({
-		...defaultDeployPlanOpts,
-		currentCommitSha: 'current-sha',
-		pushBeforeSha: 'push-before-sha',
-		eventName: 'push',
-		fetchJsonImpl,
-		getChangedFilesImpl,
-		fetchImpl,
-		log,
-	})
+  const deployPlan = await computeDeployPlan({
+    ...defaultDeployPlanOpts,
+    currentCommitSha: "current-sha",
+    pushBeforeSha: "push-before-sha",
+    eventName: "push",
+    fetchJsonImpl,
+    getChangedFilesImpl,
+    fetchImpl,
+    log,
+  });
 
-	expect(deployPlan.deploySite).toBe(true)
-	expect(deployPlan.deploySearchWorker).toBe(true)
-	expect(deployPlan.deployCallKentAudioWorker).toBe(true)
-	expect(deployPlan.deployOauthWorker).toBe(true)
-})
+  expect(deployPlan.deploySite).toBe(true);
+  expect(deployPlan.deploySearchWorker).toBe(true);
+  expect(deployPlan.deployCallKentAudioWorker).toBe(true);
+  expect(deployPlan.deployOauthWorker).toBe(true);
+});

--- a/other/__tests__/refresh-changed-content.test.js
+++ b/other/__tests__/refresh-changed-content.test.js
@@ -33,8 +33,51 @@ describe("refreshChangedContent", () => {
 
     expect(result).toEqual({ status: "no-compare-sha" });
     expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+    expect(fetchJsonImpl).toHaveBeenNthCalledWith(
+      2,
+      "https://example.test/__meta",
+      expect.objectContaining({ timeoutTime: expect.any(Number) }),
+    );
     expect(getChangedFilesImpl).not.toHaveBeenCalled();
     expect(postRefreshCacheImpl).not.toHaveBeenCalled();
+  });
+
+  test("falls back to /__meta buildSha when refresh-commit-sha is empty", async () => {
+    const fetchJsonImpl = vi.fn(async (url) => {
+      if (url.endsWith("/refresh-commit-sha.json")) return null;
+      if (url.endsWith("/__meta")) {
+        return { buildSha: "meta-build-sha", contentVersion: "v1" };
+      }
+      return null;
+    });
+    const getChangedFilesImpl = vi.fn(async () => [
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/some-post.mdx",
+      },
+    ]);
+    const postRefreshCacheImpl = vi.fn(async () => ({ ok: true }));
+    const log = createLogger();
+
+    const result = await refreshChangedContent({
+      currentCommitSha: "current-sha",
+      baseUrl: "https://example.test",
+      fetchJsonImpl,
+      getChangedFilesImpl,
+      postRefreshCacheImpl,
+      log,
+      skipPublish: true,
+    });
+
+    expect(result).toEqual({
+      status: "refreshed",
+      attempts: 1,
+      contentPaths: ["blog/some-post.mdx"],
+    });
+    expect(getChangedFilesImpl).toHaveBeenCalledWith(
+      "current-sha",
+      "meta-build-sha",
+    );
   });
 
   test("throws when currentCommitSha is missing", async () => {
@@ -116,7 +159,7 @@ describe("refreshChangedContent", () => {
     expect(postRefreshCacheImpl).toHaveBeenLastCalledWith({
       http: undefined,
       postData: {
-        commitSha: 'current-sha',
+        commitSha: "current-sha",
       },
       options: { hostname: "kentcdodds-com.kentcdodds.workers.dev" },
     });

--- a/other/__tests__/resolve-compare-commit-sha.test.js
+++ b/other/__tests__/resolve-compare-commit-sha.test.js
@@ -36,6 +36,26 @@ describe("resolveCompareCommitSha", () => {
     ).resolves.toBe("meta-sha");
   });
 
+  test("treats empty refresh sha as missing and falls back to /__meta", async () => {
+    const fetchJsonImpl = vi.fn(async (url) => {
+      if (url.endsWith("/refresh-commit-sha.json")) {
+        return { sha: "", date: "2026-01-01T00:00:00.000Z" };
+      }
+      if (url.endsWith("/__meta")) {
+        return { buildSha: "meta-sha", contentVersion: "v1" };
+      }
+      return null;
+    });
+
+    await expect(
+      resolveCompareCommitSha({
+        baseUrl: "https://example.test",
+        fetchJsonImpl,
+      }),
+    ).resolves.toBe("meta-sha");
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(2);
+  });
+
   test("ignores local-dev buildSha", async () => {
     const fetchJsonImpl = vi.fn(async (url) => {
       if (url.endsWith("/refresh-commit-sha.json")) return null;

--- a/other/__tests__/resolve-compare-commit-sha.test.js
+++ b/other/__tests__/resolve-compare-commit-sha.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, test, vi } from "vitest";
+import { resolveCompareCommitSha } from "../resolve-compare-commit-sha.ts";
+
+describe("resolveCompareCommitSha", () => {
+  test("prefers refresh-commit-sha when present", async () => {
+    const fetchJsonImpl = vi.fn(async (url) => {
+      if (url.endsWith("/refresh-commit-sha.json")) {
+        return { sha: "refresh-sha", date: "2026-01-01T00:00:00.000Z" };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await expect(
+      resolveCompareCommitSha({
+        baseUrl: "https://example.test",
+        fetchJsonImpl,
+      }),
+    ).resolves.toBe("refresh-sha");
+    expect(fetchJsonImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to /__meta buildSha", async () => {
+    const fetchJsonImpl = vi.fn(async (url) => {
+      if (url.endsWith("/refresh-commit-sha.json")) return null;
+      if (url.endsWith("/__meta")) {
+        return { buildSha: "meta-sha", contentVersion: "v1" };
+      }
+      return null;
+    });
+
+    await expect(
+      resolveCompareCommitSha({
+        baseUrl: "https://example.test",
+        fetchJsonImpl,
+      }),
+    ).resolves.toBe("meta-sha");
+  });
+
+  test("ignores local-dev buildSha", async () => {
+    const fetchJsonImpl = vi.fn(async (url) => {
+      if (url.endsWith("/refresh-commit-sha.json")) return null;
+      if (url.endsWith("/__meta")) {
+        return { buildSha: "local-dev", contentVersion: null };
+      }
+      return null;
+    });
+
+    await expect(
+      resolveCompareCommitSha({
+        baseUrl: "https://example.test",
+        fetchJsonImpl,
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/other/compute-deploy-plan.ts
+++ b/other/compute-deploy-plan.ts
@@ -1,557 +1,554 @@
 // try to keep this dep-free so we don't have to install deps
-import fs from 'fs/promises'
-import { pathToFileURL } from 'url'
-import { fetchJson, getChangedFiles } from './get-changed-files.js'
+import fs from "fs/promises";
+import { pathToFileURL } from "url";
+import { fetchJson, getChangedFiles } from "./get-changed-files.js";
+import { resolveCompareCommitSha } from "./resolve-compare-commit-sha.ts";
 
-const GITHUB_API_BASE = 'https://api.github.com'
+const GITHUB_API_BASE = "https://api.github.com";
 
 const defaultBaseUrl =
-	process.env.SITE_URL ?? 'https://kentcdodds-com.kentcdodds.workers.dev'
+  process.env.SITE_URL ?? "https://kentcdodds-com.kentcdodds.workers.dev";
 
-const defaultFetchTimeoutMs = 10_000
+const defaultFetchTimeoutMs = 10_000;
 
 const nonSiteDeployablePathPrefixes = [
-	'services/site/content/',
-	'services/call-kent-audio-worker/',
-	'services/search-worker/',
-	'services/oauth/',
-]
+  "services/site/content/",
+  "services/call-kent-audio-worker/",
+  "services/search-worker/",
+  "services/oauth/",
+];
 
 const nonSiteDeployableFiles = new Set([
-	'.github/workflows/deploy-call-kent-audio-worker.yml',
-	'.github/workflows/deploy-search-worker.yml',
-	'.github/workflows/deploy-oauth-worker.yml',
-	'.github/workflows/cf-preview-deploy.yml',
-])
+  ".github/workflows/deploy-call-kent-audio-worker.yml",
+  ".github/workflows/deploy-search-worker.yml",
+  ".github/workflows/deploy-oauth-worker.yml",
+  ".github/workflows/cf-preview-deploy.yml",
+]);
 
 const semanticContentPathPrefixes = [
-	'services/site/content/blog/',
-	'services/site/content/pages/',
-	'services/site/content/data/',
-	'services/site/app/',
-	'other/semantic-search/',
-]
+  "services/site/content/blog/",
+  "services/site/content/pages/",
+  "services/site/content/data/",
+  "services/site/app/",
+  "other/semantic-search/",
+];
 
-const callKentAudioWorkerPathPrefixes = ['services/call-kent-audio-worker/']
+const callKentAudioWorkerPathPrefixes = ["services/call-kent-audio-worker/"];
 const callKentAudioWorkerFiles = new Set([
-	'.github/workflows/deploy-call-kent-audio-worker.yml',
-])
+  ".github/workflows/deploy-call-kent-audio-worker.yml",
+]);
 
 const searchWorkerPathPrefixes = [
-	'services/search-worker/',
-	'services/search-shared/',
-]
-const searchWorkerFiles = new Set(['.github/workflows/deploy-search-worker.yml'])
+  "services/search-worker/",
+  "services/search-shared/",
+];
+const searchWorkerFiles = new Set([
+  ".github/workflows/deploy-search-worker.yml",
+]);
 
-const oauthWorkerPathPrefixes = ['services/oauth/']
-const oauthWorkerFiles = new Set(['.github/workflows/deploy-oauth-worker.yml'])
+const oauthWorkerPathPrefixes = ["services/oauth/"];
+const oauthWorkerFiles = new Set([".github/workflows/deploy-oauth-worker.yml"]);
 
 /**
  * GitHub deployment environment names per deploy target and ref.
  * Used to resolve last successful deployment SHA from GitHub Deployments API.
  */
 const DEPLOY_ENVIRONMENTS: Record<string, (refName: string) => string | null> =
-	{
-		deploySite: (refName) => (refName === 'main' ? 'site-production' : null),
-		deployOauthWorker: (refName) =>
-			refName === 'main' ? 'oauth-production' : null,
-		deployCallKentAudioWorker: (refName) =>
-			refName === 'main' ? 'call-kent-audio-worker-production' : null,
-		deploySearchWorker: (refName) =>
-			refName === 'main' ? 'search-worker-production' : null,
-	}
+  {
+    deploySite: (refName) => (refName === "main" ? "site-production" : null),
+    deployOauthWorker: (refName) =>
+      refName === "main" ? "oauth-production" : null,
+    deployCallKentAudioWorker: (refName) =>
+      refName === "main" ? "call-kent-audio-worker-production" : null,
+    deploySearchWorker: (refName) =>
+      refName === "main" ? "search-worker-production" : null,
+  };
 
 type ChangedFile = {
-	changeType: string
-	filename: string
-}
+  changeType: string;
+  filename: string;
+};
 
-type LogLike = Pick<typeof console, 'log' | 'warn'>
+type LogLike = Pick<typeof console, "log" | "warn">;
 
-type GitHubDeployment = { id: number; sha: string }
-type GitHubDeploymentStatus = { state: string }
+type GitHubDeployment = { id: number; sha: string };
+type GitHubDeploymentStatus = { state: string };
 
 async function fetchLastSuccessfulDeploymentSha({
-	owner,
-	repo,
-	ref,
-	environment,
-	token,
-	fetchImpl = fetch,
-	timeoutMs = defaultFetchTimeoutMs,
-	log = console,
+  owner,
+  repo,
+  ref,
+  environment,
+  token,
+  fetchImpl = fetch,
+  timeoutMs = defaultFetchTimeoutMs,
+  log = console,
 }: {
-	owner: string
-	repo: string
-	ref: string
-	environment: string
-	token: string | undefined
-	fetchImpl?: typeof fetch
-	timeoutMs?: number
-	log?: LogLike
+  owner: string;
+  repo: string;
+  ref: string;
+  environment: string;
+  token: string | undefined;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  log?: LogLike;
 }): Promise<string | null> {
-	if (!token) return null
+  if (!token) return null;
 
-	const controller = new AbortController()
-	const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-	try {
-		const deploymentsRes = await fetchImpl(
-			`${GITHUB_API_BASE}/repos/${owner}/${repo}/deployments?environment=${encodeURIComponent(environment)}&ref=${encodeURIComponent(ref)}&per_page=10`,
-			{
-				headers: {
-					Accept: 'application/vnd.github+json',
-					Authorization: `Bearer ${token}`,
-					'X-GitHub-Api-Version': '2022-11-28',
-				},
-				signal: controller.signal,
-			},
-		)
-		if (!deploymentsRes.ok) return null
+  try {
+    const deploymentsRes = await fetchImpl(
+      `${GITHUB_API_BASE}/repos/${owner}/${repo}/deployments?environment=${encodeURIComponent(environment)}&ref=${encodeURIComponent(ref)}&per_page=10`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        signal: controller.signal,
+      },
+    );
+    if (!deploymentsRes.ok) return null;
 
-		const deployments: Array<GitHubDeployment> = await deploymentsRes.json()
-		for (const deployment of deployments) {
-			const statusesRes = await fetchImpl(
-				`${GITHUB_API_BASE}/repos/${owner}/${repo}/deployments/${deployment.id}/statuses?per_page=10`,
-				{
-					headers: {
-						Accept: 'application/vnd.github+json',
-						Authorization: `Bearer ${token}`,
-						'X-GitHub-Api-Version': '2022-11-28',
-					},
-					signal: controller.signal,
-				},
-			)
-			if (!statusesRes.ok) continue
+    const deployments: Array<GitHubDeployment> = await deploymentsRes.json();
+    for (const deployment of deployments) {
+      const statusesRes = await fetchImpl(
+        `${GITHUB_API_BASE}/repos/${owner}/${repo}/deployments/${deployment.id}/statuses?per_page=10`,
+        {
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          signal: controller.signal,
+        },
+      );
+      if (!statusesRes.ok) continue;
 
-			const statuses: Array<GitHubDeploymentStatus> = await statusesRes.json()
-			const success = statuses.find((s) => s.state === 'success')
-			if (success) return deployment.sha
-		}
-		return null
-	} catch (error) {
-		log.warn('GitHub deployment lookup failed, planning deploy.', {
-			environment,
-			error,
-		})
-		return null
-	} finally {
-		clearTimeout(timeout)
-	}
+      const statuses: Array<GitHubDeploymentStatus> = await statusesRes.json();
+      const success = statuses.find((s) => s.state === "success");
+      if (success) return deployment.sha;
+    }
+    return null;
+  } catch (error) {
+    log.warn("GitHub deployment lookup failed, planning deploy.", {
+      environment,
+      error,
+    });
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function getDeploymentChangedFiles({
-	currentCommitSha,
-	refName,
-	target,
-	owner,
-	repo,
-	token,
-	fetchLastSuccessfulDeploymentShaImpl = fetchLastSuccessfulDeploymentSha,
-	getChangedFilesImpl,
-	fetchImpl,
-	log,
+  currentCommitSha,
+  refName,
+  target,
+  owner,
+  repo,
+  token,
+  fetchLastSuccessfulDeploymentShaImpl = fetchLastSuccessfulDeploymentSha,
+  getChangedFilesImpl,
+  fetchImpl,
+  log,
 }: {
-	currentCommitSha: string
-	refName: string
-	target: keyof typeof DEPLOY_ENVIRONMENTS
-	owner: string
-	repo: string
-	token: string | undefined
-	fetchLastSuccessfulDeploymentShaImpl?: typeof fetchLastSuccessfulDeploymentSha
-	getChangedFilesImpl: typeof getChangedFiles
-	fetchImpl?: typeof fetch
-	log: LogLike
+  currentCommitSha: string;
+  refName: string;
+  target: keyof typeof DEPLOY_ENVIRONMENTS;
+  owner: string;
+  repo: string;
+  token: string | undefined;
+  fetchLastSuccessfulDeploymentShaImpl?: typeof fetchLastSuccessfulDeploymentSha;
+  getChangedFilesImpl: typeof getChangedFiles;
+  fetchImpl?: typeof fetch;
+  log: LogLike;
 }): Promise<{
-	compareCommitSha: string | null
-	changedFiles: null | Array<ChangedFile>
+  compareCommitSha: string | null;
+  changedFiles: null | Array<ChangedFile>;
 }> {
-	const environment = DEPLOY_ENVIRONMENTS[target]?.(refName)
-	if (!environment) {
-		return { compareCommitSha: null, changedFiles: null }
-	}
+  const environment = DEPLOY_ENVIRONMENTS[target]?.(refName);
+  if (!environment) {
+    return { compareCommitSha: null, changedFiles: null };
+  }
 
-	const compareCommitSha = await fetchLastSuccessfulDeploymentShaImpl({
-		owner,
-		repo,
-		ref: refName,
-		environment,
-		token,
-		fetchImpl,
-		log,
-	})
+  const compareCommitSha = await fetchLastSuccessfulDeploymentShaImpl({
+    owner,
+    repo,
+    ref: refName,
+    environment,
+    token,
+    fetchImpl,
+    log,
+  });
 
-	if (!compareCommitSha) {
-		return { compareCommitSha: null, changedFiles: null }
-	}
+  if (!compareCommitSha) {
+    return { compareCommitSha: null, changedFiles: null };
+  }
 
-	const changedFiles = normalizeChangedFiles(
-		await getChangedFilesImpl(currentCommitSha, compareCommitSha),
-	)
-	return { compareCommitSha, changedFiles }
+  const changedFiles = normalizeChangedFiles(
+    await getChangedFilesImpl(currentCommitSha, compareCommitSha),
+  );
+  return { compareCommitSha, changedFiles };
 }
 
 function normalizeChangedFiles(changedFiles: null | Array<ChangedFile>) {
-	if (!Array.isArray(changedFiles)) return changedFiles
+  if (!Array.isArray(changedFiles)) return changedFiles;
 
-	return changedFiles.map((file) => ({
-		...file,
-		filename: file.filename.replace(/\\/g, '/'),
-	}))
+  return changedFiles.map((file) => ({
+    ...file,
+    filename: file.filename.replace(/\\/g, "/"),
+  }));
 }
 
 function hasChangedPath(
-	changedFiles: null | Array<ChangedFile>,
-	predicate: (filename: string) => boolean,
+  changedFiles: null | Array<ChangedFile>,
+  predicate: (filename: string) => boolean,
 ) {
-	return Array.isArray(changedFiles)
-		? changedFiles.some((file) => predicate(file.filename))
-		: false
+  return Array.isArray(changedFiles)
+    ? changedFiles.some((file) => predicate(file.filename))
+    : false;
 }
 
 function hasChangedPathPrefix(
-	changedFiles: null | Array<ChangedFile>,
-	pathPrefixes: Array<string>,
+  changedFiles: null | Array<ChangedFile>,
+  pathPrefixes: Array<string>,
 ) {
-	return hasChangedPath(changedFiles, (filename) =>
-		pathPrefixes.some((prefix) => filename.startsWith(prefix)),
-	)
+  return hasChangedPath(changedFiles, (filename) =>
+    pathPrefixes.some((prefix) => filename.startsWith(prefix)),
+  );
 }
 
 function hasChangedExactFile(
-	changedFiles: null | Array<ChangedFile>,
-	files: Set<string>,
+  changedFiles: null | Array<ChangedFile>,
+  files: Set<string>,
 ) {
-	return hasChangedPath(changedFiles, (filename) => files.has(filename))
+  return hasChangedPath(changedFiles, (filename) => files.has(filename));
 }
 
 function isSiteDeployablePath(filename: string) {
-	return (
-		!nonSiteDeployablePathPrefixes.some((prefix) =>
-			filename.startsWith(prefix),
-		) && !nonSiteDeployableFiles.has(filename)
-	)
+  return (
+    !nonSiteDeployablePathPrefixes.some((prefix) =>
+      filename.startsWith(prefix),
+    ) && !nonSiteDeployableFiles.has(filename)
+  );
 }
 
 function shouldDeploySite(changedFiles: null | Array<ChangedFile>) {
-	if (changedFiles === null) return true
-	if (changedFiles.length === 0) return false
-	return changedFiles.some((file) => isSiteDeployablePath(file.filename))
+  if (changedFiles === null) return true;
+  if (changedFiles.length === 0) return false;
+  return changedFiles.some((file) => isSiteDeployablePath(file.filename));
 }
 
 function shouldRunPathTarget({
-	changedFiles,
-	pathPrefixes = [],
-	files = new Set(),
-	runWhenUnknown = false,
+  changedFiles,
+  pathPrefixes = [],
+  files = new Set(),
+  runWhenUnknown = false,
 }: {
-	changedFiles: null | Array<ChangedFile>
-	pathPrefixes?: Array<string>
-	files?: Set<string>
-	runWhenUnknown?: boolean
+  changedFiles: null | Array<ChangedFile>;
+  pathPrefixes?: Array<string>;
+  files?: Set<string>;
+  runWhenUnknown?: boolean;
 }) {
-	if (changedFiles === null) return runWhenUnknown
+  if (changedFiles === null) return runWhenUnknown;
 
-	return (
-		hasChangedPathPrefix(changedFiles, pathPrefixes) ||
-		hasChangedExactFile(changedFiles, files)
-	)
+  return (
+    hasChangedPathPrefix(changedFiles, pathPrefixes) ||
+    hasChangedExactFile(changedFiles, files)
+  );
 }
 
 function isAllZerosSha(sha: string | undefined | null) {
-	return typeof sha === 'string' && /^0+$/.test(sha)
+  return typeof sha === "string" && /^0+$/.test(sha);
 }
 
 async function getRefreshChangedFiles({
-	currentCommitSha,
-	baseUrl,
-	fetchJsonImpl,
-	getChangedFilesImpl,
-	log,
+  currentCommitSha,
+  baseUrl,
+  fetchJsonImpl,
+  getChangedFilesImpl,
+  log,
 }: {
-	currentCommitSha: string
-	baseUrl: string
-	fetchJsonImpl: typeof fetchJson
-	getChangedFilesImpl: typeof getChangedFiles
-	log: LogLike
+  currentCommitSha: string;
+  baseUrl: string;
+  fetchJsonImpl: typeof fetchJson;
+  getChangedFilesImpl: typeof getChangedFiles;
+  log: LogLike;
 }) {
-	try {
-		const shaInfo = await fetchJsonImpl(`${baseUrl}/refresh-commit-sha.json`, {
-			timeoutTime: defaultFetchTimeoutMs,
-		})
-		let compareCommitSha = shaInfo?.sha
+  try {
+    const compareCommitSha = await resolveCompareCommitSha({
+      baseUrl,
+      fetchJsonImpl,
+      timeoutTime: defaultFetchTimeoutMs,
+    });
 
-		if (!compareCommitSha) {
-			const buildInfo = await fetchJsonImpl(`${baseUrl}/build/info.json`, {
-				timeoutTime: defaultFetchTimeoutMs,
-			})
-			compareCommitSha = buildInfo?.commit?.sha
-		}
+    if (typeof compareCommitSha !== "string") {
+      log.warn(
+        "Unable to determine refresh compare sha, skipping refresh planning.",
+      );
+      return { compareCommitSha: null, changedFiles: [] };
+    }
 
-		if (typeof compareCommitSha !== 'string') {
-			log.warn(
-				'Unable to determine refresh compare sha, skipping refresh planning.',
-			)
-			return { compareCommitSha: null, changedFiles: [] }
-		}
+    const changedFiles = normalizeChangedFiles(
+      await getChangedFilesImpl(currentCommitSha, compareCommitSha),
+    );
 
-		const changedFiles = normalizeChangedFiles(
-			await getChangedFilesImpl(currentCommitSha, compareCommitSha),
-		)
-
-		return { compareCommitSha, changedFiles }
-	} catch (error) {
-		log.warn(
-			'Unable to determine refresh plan from current site state, defaulting to refresh.',
-			{ error },
-		)
-		return { compareCommitSha: null, changedFiles: null }
-	}
+    return { compareCommitSha, changedFiles };
+  } catch (error) {
+    log.warn(
+      "Unable to determine refresh plan from current site state, defaulting to refresh.",
+      { error },
+    );
+    return { compareCommitSha: null, changedFiles: null };
+  }
 }
 
 async function getPushChangedFiles({
-	currentCommitSha,
-	pushBeforeSha,
-	getChangedFilesImpl,
-	isPushEvent,
-	log,
+  currentCommitSha,
+  pushBeforeSha,
+  getChangedFilesImpl,
+  isPushEvent,
+  log,
 }: {
-	currentCommitSha: string
-	pushBeforeSha: string | undefined | null
-	getChangedFilesImpl: typeof getChangedFiles
-	isPushEvent: boolean
-	log: LogLike
+  currentCommitSha: string;
+  pushBeforeSha: string | undefined | null;
+  getChangedFilesImpl: typeof getChangedFiles;
+  isPushEvent: boolean;
+  log: LogLike;
 }) {
-	if (!isPushEvent) {
-		return []
-	}
+  if (!isPushEvent) {
+    return [];
+  }
 
-	if (!pushBeforeSha || isAllZerosSha(pushBeforeSha)) {
-		log.warn(
-			'Push event did not provide a usable before sha. Planning conservatively.',
-		)
-		return null
-	}
+  if (!pushBeforeSha || isAllZerosSha(pushBeforeSha)) {
+    log.warn(
+      "Push event did not provide a usable before sha. Planning conservatively.",
+    );
+    return null;
+  }
 
-	return normalizeChangedFiles(
-		await getChangedFilesImpl(currentCommitSha, pushBeforeSha),
-	)
+  return normalizeChangedFiles(
+    await getChangedFilesImpl(currentCommitSha, pushBeforeSha),
+  );
 }
 
 function parseRepo(
-	repository: string | undefined,
+  repository: string | undefined,
 ): { owner: string; repo: string } | null {
-	if (!repository || !repository.includes('/')) return null
-	const [owner, repo] = repository.split('/', 2)
-	return owner && repo ? { owner, repo } : null
+  if (!repository || !repository.includes("/")) return null;
+  const [owner, repo] = repository.split("/", 2);
+  return owner && repo ? { owner, repo } : null;
 }
 
 export async function computeDeployPlan({
-	currentCommitSha,
-	pushBeforeSha = process.env.GITHUB_EVENT_BEFORE,
-	baseUrl = defaultBaseUrl,
-	eventName = process.env.GITHUB_EVENT_NAME,
-	refName = process.env.GITHUB_BASE_REF ||
-		process.env.GITHUB_REF_NAME ||
-		'main',
-	repository = process.env.GITHUB_REPOSITORY,
-	token = process.env.GITHUB_TOKEN,
-	fetchJsonImpl = fetchJson,
-	getChangedFilesImpl = getChangedFiles,
-	fetchImpl,
-	log = console,
+  currentCommitSha,
+  pushBeforeSha = process.env.GITHUB_EVENT_BEFORE,
+  baseUrl = defaultBaseUrl,
+  eventName = process.env.GITHUB_EVENT_NAME,
+  refName = process.env.GITHUB_BASE_REF ||
+    process.env.GITHUB_REF_NAME ||
+    "main",
+  repository = process.env.GITHUB_REPOSITORY,
+  token = process.env.GITHUB_TOKEN,
+  fetchJsonImpl = fetchJson,
+  getChangedFilesImpl = getChangedFiles,
+  fetchImpl,
+  log = console,
 }: {
-	currentCommitSha?: string
-	pushBeforeSha?: string
-	baseUrl?: string
-	eventName?: string
-	refName?: string
-	repository?: string
-	token?: string
-	fetchJsonImpl?: typeof fetchJson
-	getChangedFilesImpl?: typeof getChangedFiles
-	fetchImpl?: typeof fetch
-	log?: LogLike
+  currentCommitSha?: string;
+  pushBeforeSha?: string;
+  baseUrl?: string;
+  eventName?: string;
+  refName?: string;
+  repository?: string;
+  token?: string;
+  fetchJsonImpl?: typeof fetchJson;
+  getChangedFilesImpl?: typeof getChangedFiles;
+  fetchImpl?: typeof fetch;
+  log?: LogLike;
 } = {}) {
-	if (!currentCommitSha) {
-		throw new Error('currentCommitSha is required')
-	}
+  if (!currentCommitSha) {
+    throw new Error("currentCommitSha is required");
+  }
 
-	const isPushEvent = eventName === 'push'
-	const repo = parseRepo(repository)
+  const isPushEvent = eventName === "push";
+  const repo = parseRepo(repository);
 
-	const [
-		pushChangedFiles,
-		refreshResult,
-		siteDeployResult,
-		searchWorkerDeployResult,
-		oauthDeployResult,
-		audioWorkerDeployResult,
-	] = await Promise.all([
-		getPushChangedFiles({
-			currentCommitSha,
-			pushBeforeSha,
-			getChangedFilesImpl,
-			isPushEvent,
-			log,
-		}),
-		getRefreshChangedFiles({
-			currentCommitSha,
-			baseUrl,
-			fetchJsonImpl,
-			getChangedFilesImpl,
-			log,
-		}),
-		repo
-			? getDeploymentChangedFiles({
-					currentCommitSha,
-					refName,
-					target: 'deploySite',
-					owner: repo.owner,
-					repo: repo.repo,
-					token,
-					getChangedFilesImpl,
-					fetchImpl,
-					log,
-				})
-			: Promise.resolve({ compareCommitSha: null, changedFiles: null }),
-		repo
-			? getDeploymentChangedFiles({
-					currentCommitSha,
-					refName,
-					target: 'deploySearchWorker',
-					owner: repo.owner,
-					repo: repo.repo,
-					token,
-					getChangedFilesImpl,
-					fetchImpl,
-					log,
-				})
-			: Promise.resolve({ compareCommitSha: null, changedFiles: null }),
-		repo
-			? getDeploymentChangedFiles({
-					currentCommitSha,
-					refName,
-					target: 'deployOauthWorker',
-					owner: repo.owner,
-					repo: repo.repo,
-					token,
-					getChangedFilesImpl,
-					fetchImpl,
-					log,
-				})
-			: Promise.resolve({ compareCommitSha: null, changedFiles: null }),
-		repo
-			? getDeploymentChangedFiles({
-					currentCommitSha,
-					refName,
-					target: 'deployCallKentAudioWorker',
-					owner: repo.owner,
-					repo: repo.repo,
-					token,
-					getChangedFilesImpl,
-					fetchImpl,
-					log,
-				})
-			: Promise.resolve({ compareCommitSha: null, changedFiles: null }),
-	])
+  const [
+    pushChangedFiles,
+    refreshResult,
+    siteDeployResult,
+    searchWorkerDeployResult,
+    oauthDeployResult,
+    audioWorkerDeployResult,
+  ] = await Promise.all([
+    getPushChangedFiles({
+      currentCommitSha,
+      pushBeforeSha,
+      getChangedFilesImpl,
+      isPushEvent,
+      log,
+    }),
+    getRefreshChangedFiles({
+      currentCommitSha,
+      baseUrl,
+      fetchJsonImpl,
+      getChangedFilesImpl,
+      log,
+    }),
+    repo
+      ? getDeploymentChangedFiles({
+          currentCommitSha,
+          refName,
+          target: "deploySite",
+          owner: repo.owner,
+          repo: repo.repo,
+          token,
+          getChangedFilesImpl,
+          fetchImpl,
+          log,
+        })
+      : Promise.resolve({ compareCommitSha: null, changedFiles: null }),
+    repo
+      ? getDeploymentChangedFiles({
+          currentCommitSha,
+          refName,
+          target: "deploySearchWorker",
+          owner: repo.owner,
+          repo: repo.repo,
+          token,
+          getChangedFilesImpl,
+          fetchImpl,
+          log,
+        })
+      : Promise.resolve({ compareCommitSha: null, changedFiles: null }),
+    repo
+      ? getDeploymentChangedFiles({
+          currentCommitSha,
+          refName,
+          target: "deployOauthWorker",
+          owner: repo.owner,
+          repo: repo.repo,
+          token,
+          getChangedFilesImpl,
+          fetchImpl,
+          log,
+        })
+      : Promise.resolve({ compareCommitSha: null, changedFiles: null }),
+    repo
+      ? getDeploymentChangedFiles({
+          currentCommitSha,
+          refName,
+          target: "deployCallKentAudioWorker",
+          owner: repo.owner,
+          repo: repo.repo,
+          token,
+          getChangedFilesImpl,
+          fetchImpl,
+          log,
+        })
+      : Promise.resolve({ compareCommitSha: null, changedFiles: null }),
+  ]);
 
-	const siteChangedFiles = siteDeployResult.changedFiles
-	const {
-		compareCommitSha: refreshCompareCommitSha,
-		changedFiles: refreshChangedFiles,
-	} = refreshResult
+  const siteChangedFiles = siteDeployResult.changedFiles;
+  const {
+    compareCommitSha: refreshCompareCommitSha,
+    changedFiles: refreshChangedFiles,
+  } = refreshResult;
 
-	const deploySite = shouldDeploySite(siteChangedFiles)
-	const refreshContent = deploySite
-		? false
-		: shouldRunPathTarget({
-				changedFiles: refreshChangedFiles,
-				pathPrefixes: ['services/site/content/'],
-				runWhenUnknown: isPushEvent,
-			})
+  const deploySite = shouldDeploySite(siteChangedFiles);
+  const refreshContent = deploySite
+    ? false
+    : shouldRunPathTarget({
+        changedFiles: refreshChangedFiles,
+        pathPrefixes: ["services/site/content/"],
+        runWhenUnknown: isPushEvent,
+      });
 
-	const deployPlan = {
-		deploySite,
-		refreshContent,
-		indexSemanticContent: shouldRunPathTarget({
-			changedFiles: pushChangedFiles,
-			pathPrefixes: semanticContentPathPrefixes,
-			runWhenUnknown: isPushEvent,
-		}),
-		deploySearchWorker: shouldRunPathTarget({
-			changedFiles: searchWorkerDeployResult.changedFiles,
-			pathPrefixes: searchWorkerPathPrefixes,
-			files: searchWorkerFiles,
-			runWhenUnknown: isPushEvent,
-		}),
-		deployCallKentAudioWorker: shouldRunPathTarget({
-			changedFiles: audioWorkerDeployResult.changedFiles,
-			pathPrefixes: callKentAudioWorkerPathPrefixes,
-			files: callKentAudioWorkerFiles,
-			runWhenUnknown: isPushEvent,
-		}),
-		deployOauthWorker: shouldRunPathTarget({
-			changedFiles: oauthDeployResult.changedFiles,
-			pathPrefixes: oauthWorkerPathPrefixes,
-			files: oauthWorkerFiles,
-			runWhenUnknown: isPushEvent,
-		}),
-	}
+  const deployPlan = {
+    deploySite,
+    refreshContent,
+    indexSemanticContent: shouldRunPathTarget({
+      changedFiles: pushChangedFiles,
+      pathPrefixes: semanticContentPathPrefixes,
+      runWhenUnknown: isPushEvent,
+    }),
+    deploySearchWorker: shouldRunPathTarget({
+      changedFiles: searchWorkerDeployResult.changedFiles,
+      pathPrefixes: searchWorkerPathPrefixes,
+      files: searchWorkerFiles,
+      runWhenUnknown: isPushEvent,
+    }),
+    deployCallKentAudioWorker: shouldRunPathTarget({
+      changedFiles: audioWorkerDeployResult.changedFiles,
+      pathPrefixes: callKentAudioWorkerPathPrefixes,
+      files: callKentAudioWorkerFiles,
+      runWhenUnknown: isPushEvent,
+    }),
+    deployOauthWorker: shouldRunPathTarget({
+      changedFiles: oauthDeployResult.changedFiles,
+      pathPrefixes: oauthWorkerPathPrefixes,
+      files: oauthWorkerFiles,
+      runWhenUnknown: isPushEvent,
+    }),
+  };
 
-	log.log('Computed deploy plan.', {
-		currentCommitSha,
-		pushBeforeSha,
-		siteCompareCommitSha: siteDeployResult.compareCommitSha,
-		refreshCompareCommitSha,
-		deployPlan,
-	})
+  log.log("Computed deploy plan.", {
+    currentCommitSha,
+    pushBeforeSha,
+    siteCompareCommitSha: siteDeployResult.compareCommitSha,
+    refreshCompareCommitSha,
+    deployPlan,
+  });
 
-	return {
-		...deployPlan,
-		pushBeforeSha: pushBeforeSha ?? null,
-		siteCompareCommitSha: siteDeployResult.compareCommitSha,
-		refreshCompareCommitSha,
-		pushChangedFiles,
-		siteChangedFiles,
-		refreshChangedFiles,
-	}
+  return {
+    ...deployPlan,
+    pushBeforeSha: pushBeforeSha ?? null,
+    siteCompareCommitSha: siteDeployResult.compareCommitSha,
+    refreshCompareCommitSha,
+    pushChangedFiles,
+    siteChangedFiles,
+    refreshChangedFiles,
+  };
 }
 
 export async function writeDeployPlanOutputs({
-	deployPlan,
-	outputFile = process.env.GITHUB_OUTPUT,
+  deployPlan,
+  outputFile = process.env.GITHUB_OUTPUT,
 }: {
-	deployPlan: Awaited<ReturnType<typeof computeDeployPlan>>
-	outputFile?: string
+  deployPlan: Awaited<ReturnType<typeof computeDeployPlan>>;
+  outputFile?: string;
 }) {
-	if (!outputFile) return
+  if (!outputFile) return;
 
-	const outputLines = [
-		`deploy_site=${String(deployPlan.deploySite)}`,
-		`refresh_content=${String(deployPlan.refreshContent)}`,
-		`index_semantic_content=${String(deployPlan.indexSemanticContent)}`,
-		`deploy_search_worker=${String(deployPlan.deploySearchWorker)}`,
-		`deploy_call_kent_audio_worker=${String(
-			deployPlan.deployCallKentAudioWorker,
-		)}`,
-		`deploy_oauth_worker=${String(deployPlan.deployOauthWorker)}`,
-	]
+  const outputLines = [
+    `deploy_site=${String(deployPlan.deploySite)}`,
+    `refresh_content=${String(deployPlan.refreshContent)}`,
+    `index_semantic_content=${String(deployPlan.indexSemanticContent)}`,
+    `deploy_search_worker=${String(deployPlan.deploySearchWorker)}`,
+    `deploy_call_kent_audio_worker=${String(
+      deployPlan.deployCallKentAudioWorker,
+    )}`,
+    `deploy_oauth_worker=${String(deployPlan.deployOauthWorker)}`,
+  ];
 
-	await fs.appendFile(outputFile, `${outputLines.join('\n')}\n`)
+  await fs.appendFile(outputFile, `${outputLines.join("\n")}\n`);
 }
 
 const isMainModule =
-	process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
-	const [currentCommitSha] = process.argv.slice(2)
-	void computeDeployPlan({ currentCommitSha })
-		.then((deployPlan) => {
-			return writeDeployPlanOutputs({ deployPlan })
-		})
-		.catch((error) => {
-			console.error(error)
-			process.exitCode = 1
-		})
+  const [currentCommitSha] = process.argv.slice(2);
+  void computeDeployPlan({ currentCommitSha })
+    .then((deployPlan) => {
+      return writeDeployPlanOutputs({ deployPlan });
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
 }

--- a/other/get-changed-files.js
+++ b/other/get-changed-files.js
@@ -1,78 +1,97 @@
 // try to keep this dep-free so we don't have to install deps
-import { execSync } from 'child_process'
-import https from 'https'
+import { execSync } from "child_process";
+import https from "https";
 
-let warnedTimoutTime = false
+let warnedTimoutTime = false;
 
 export function fetchJson(url, { timeoutTime, timoutTime } = {}) {
-	if (
-		typeof timeoutTime === 'undefined' &&
-		typeof timoutTime !== 'undefined' &&
-		!warnedTimoutTime
-	) {
-		warnedTimoutTime = true
-		console.warn(
-			'[fetchJson] `timoutTime` is deprecated; use `timeoutTime` instead.',
-		)
-	}
+  if (
+    typeof timeoutTime === "undefined" &&
+    typeof timoutTime !== "undefined" &&
+    !warnedTimoutTime
+  ) {
+    warnedTimoutTime = true;
+    console.warn(
+      "[fetchJson] `timoutTime` is deprecated; use `timeoutTime` instead.",
+    );
+  }
 
-	return new Promise((resolve, reject) => {
-		const request = https
-			.get(url, (res) => {
-				let data = ''
-				res.on('data', (d) => {
-					data += d
-				})
+  return new Promise((resolve, reject) => {
+    const request = https
+      .get(url, (res) => {
+        let data = "";
+        res.on("data", (d) => {
+          data += d;
+        });
 
-				res.on('end', () => {
-					try {
-						resolve(JSON.parse(data))
-					} catch (error) {
-						reject(error)
-					}
-				})
-			})
-			.on('error', (e) => {
-				reject(e)
-			})
-		const effectiveTimeoutTime = timeoutTime ?? timoutTime
-		if (effectiveTimeoutTime) {
-			setTimeout(() => {
-				request.destroy(new Error('Request timed out'))
-			}, effectiveTimeoutTime)
-		}
-	})
+        res.on("end", () => {
+          const statusCode = res.statusCode ?? 0;
+          if (statusCode < 200 || statusCode >= 300) {
+            reject(
+              new Error(
+                `Request to ${url} failed with status ${statusCode}: ${data.slice(0, 200)}`,
+              ),
+            );
+            return;
+          }
+
+          if (!data) {
+            resolve(null);
+            return;
+          }
+
+          try {
+            resolve(JSON.parse(data));
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            reject(
+              new Error(`Request to ${url} returned non-JSON body: ${message}`),
+            );
+          }
+        });
+      })
+      .on("error", (e) => {
+        reject(e);
+      });
+    const effectiveTimeoutTime = timeoutTime ?? timoutTime;
+    if (effectiveTimeoutTime) {
+      setTimeout(() => {
+        request.destroy(new Error("Request timed out"));
+      }, effectiveTimeoutTime);
+    }
+  });
 }
 
 const changeTypes = {
-	M: 'modified',
-	A: 'added',
-	D: 'deleted',
-	R: 'moved',
-}
+  M: "modified",
+  A: "added",
+  D: "deleted",
+  R: "moved",
+};
 
 export async function getChangedFiles(currentCommitSha, compareCommitSha) {
-	try {
-		const lineParser = /^(?<change>\w).*?\s+(?<filename>.+$)/
-		const gitOutput = execSync(
-			`git diff --name-status ${currentCommitSha} ${compareCommitSha}`,
-		).toString()
-		const changedFiles = gitOutput
-			.split('\n')
-			.map((line) => line.match(lineParser)?.groups)
-			.filter(Boolean)
-		const changes = []
-		for (const { change, filename } of changedFiles) {
-			const changeType = changeTypes[change]
-			if (changeType) {
-				changes.push({ changeType: changeTypes[change], filename })
-			} else {
-				console.error(`Unknown change type: ${change} ${filename}`)
-			}
-		}
-		return changes
-	} catch (error) {
-		console.error(`Something went wrong trying to get changed files.`, error)
-		return null
-	}
+  try {
+    const lineParser = /^(?<change>\w).*?\s+(?<filename>.+$)/;
+    const gitOutput = execSync(
+      `git diff --name-status ${currentCommitSha} ${compareCommitSha}`,
+    ).toString();
+    const changedFiles = gitOutput
+      .split("\n")
+      .map((line) => line.match(lineParser)?.groups)
+      .filter(Boolean);
+    const changes = [];
+    for (const { change, filename } of changedFiles) {
+      const changeType = changeTypes[change];
+      if (changeType) {
+        changes.push({ changeType: changeTypes[change], filename });
+      } else {
+        console.error(`Unknown change type: ${change} ${filename}`);
+      }
+    }
+    return changes;
+  } catch (error) {
+    console.error(`Something went wrong trying to get changed files.`, error);
+    return null;
+  }
 }

--- a/other/get-changed-files.js
+++ b/other/get-changed-files.js
@@ -17,6 +17,23 @@ export function fetchJson(url, { timeoutTime, timoutTime } = {}) {
   }
 
   return new Promise((resolve, reject) => {
+    let settled = false;
+    let timer = null;
+
+    function clearTimer() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    }
+
+    function settle(callback) {
+      if (settled) return;
+      settled = true;
+      clearTimer();
+      callback();
+    }
+
     const request = https
       .get(url, (res) => {
         let data = "";
@@ -27,36 +44,43 @@ export function fetchJson(url, { timeoutTime, timoutTime } = {}) {
         res.on("end", () => {
           const statusCode = res.statusCode ?? 0;
           if (statusCode < 200 || statusCode >= 300) {
-            reject(
-              new Error(
-                `Request to ${url} failed with status ${statusCode}: ${data.slice(0, 200)}`,
+            settle(() =>
+              reject(
+                new Error(
+                  `Request to ${url} failed with status ${statusCode}: ${data.slice(0, 200)}`,
+                ),
               ),
             );
             return;
           }
 
           if (!data) {
-            resolve(null);
+            settle(() => resolve(null));
             return;
           }
 
           try {
-            resolve(JSON.parse(data));
+            const parsed = JSON.parse(data);
+            settle(() => resolve(parsed));
           } catch (error) {
             const message =
               error instanceof Error ? error.message : String(error);
-            reject(
-              new Error(`Request to ${url} returned non-JSON body: ${message}`),
+            settle(() =>
+              reject(
+                new Error(
+                  `Request to ${url} returned non-JSON body: ${message}`,
+                ),
+              ),
             );
           }
         });
       })
       .on("error", (e) => {
-        reject(e);
+        settle(() => reject(e));
       });
     const effectiveTimeoutTime = timeoutTime ?? timoutTime;
     if (effectiveTimeoutTime) {
-      setTimeout(() => {
+      timer = setTimeout(() => {
         request.destroy(new Error("Request timed out"));
       }, effectiveTimeoutTime);
     }

--- a/other/refresh-changed-content.ts
+++ b/other/refresh-changed-content.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { publishViaEndpoint as publishViaEndpointImpl } from "../services/site-worker/scripts/publish-artifacts-lib.mjs";
 import { getChangedFiles, fetchJson } from "./get-changed-files.js";
+import { resolveCompareCommitSha } from "./resolve-compare-commit-sha.ts";
 import { postRefreshCache } from "./utils.js";
 
 const defaultBaseUrl =
@@ -154,17 +155,11 @@ export async function refreshChangedContent({
     throw new Error("currentCommitSha is required");
   }
 
-  const shaInfo = await fetchJsonImpl(`${baseUrl}/refresh-commit-sha.json`, {
+  const compareSha = await resolveCompareCommitSha({
+    baseUrl,
+    fetchJsonImpl,
     timeoutTime: defaultFetchTimeoutMs,
   });
-  let compareSha = shaInfo?.sha;
-  if (!compareSha) {
-    const buildInfo = await fetchJsonImpl(`${baseUrl}/build/info.json`, {
-      timeoutTime: defaultFetchTimeoutMs,
-    });
-    compareSha = buildInfo?.commit?.sha;
-    log.log(`No compare sha found, using build sha: ${compareSha}`);
-  }
   if (typeof compareSha !== "string") {
     log.log("🤷‍♂️ No sha to compare to. Unsure what to refresh.");
     return { status: "no-compare-sha" as const };

--- a/other/resolve-compare-commit-sha.ts
+++ b/other/resolve-compare-commit-sha.ts
@@ -25,7 +25,7 @@ export async function resolveCompareCommitSha({
   const shaInfo = await fetchJsonImpl(`${baseUrl}/refresh-commit-sha.json`, {
     timeoutTime,
   });
-  if (typeof shaInfo?.sha === "string") {
+  if (typeof shaInfo?.sha === "string" && shaInfo.sha.length > 0) {
     return shaInfo.sha;
   }
 

--- a/other/resolve-compare-commit-sha.ts
+++ b/other/resolve-compare-commit-sha.ts
@@ -1,0 +1,45 @@
+import { fetchJson } from "./get-changed-files.js";
+
+const defaultFetchTimeoutMs = 10_000;
+
+/**
+ * Resolve the commit SHA currently reflected by the live site so content-only
+ * refreshes can diff against it.
+ *
+ * Prefer the last successful refresh SHA; fall back to the worker's deploy
+ * BUILD_SHA from `/__meta` (replaces the pre-migration `/build/info.json`).
+ */
+export async function resolveCompareCommitSha({
+  baseUrl,
+  fetchJsonImpl = fetchJson,
+  timeoutTime = defaultFetchTimeoutMs,
+}: {
+  baseUrl: string;
+  fetchJsonImpl?: typeof fetchJson;
+  timeoutTime?: number;
+}): Promise<string | null> {
+  if (!baseUrl) {
+    throw new Error("baseUrl is required");
+  }
+
+  const shaInfo = await fetchJsonImpl(`${baseUrl}/refresh-commit-sha.json`, {
+    timeoutTime,
+  });
+  if (typeof shaInfo?.sha === "string") {
+    return shaInfo.sha;
+  }
+
+  const meta = await fetchJsonImpl(`${baseUrl}/__meta`, {
+    timeoutTime,
+  });
+  const buildSha = meta?.buildSha;
+  if (
+    typeof buildSha === "string" &&
+    buildSha.length > 0 &&
+    buildSha !== "local-dev"
+  ) {
+    return buildSha;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

We still need **🥬 Refresh Content** for content-only pushes (MDX publish without a full site redeploy). The failed job was not obsolete — it broke because the Fly-era compare-SHA fallback no longer exists on the worker.

**Failure:** `Unexpected token 'N', "Not found" is not valid JSON` while fetching `/build/info.json` after `/refresh-commit-sha.json` returned `null`.

**Fix:**
- Resolve compare SHA via `/refresh-commit-sha.json`, then fall back to `/__meta.buildSha`
- Harden `fetchJson` to reject non-2xx / non-JSON bodies instead of throwing opaque parse errors
- Document that content-only refresh remains part of the post-cutover deploy path

## Test plan

- [x] Unit tests for `resolveCompareCommitSha`, refresh-changed-content, and compute-deploy-plan
- [x] Live probe: `resolveCompareCommitSha` against production returns current `/__meta.buildSha`
- [ ] After merge, re-run or wait for a content-only push and confirm Refresh Content succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-971a5801-1ef1-4a66-99a1-6f3bbe6db3ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-971a5801-1ef1-4a66-99a1-6f3bbe6db3ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared compare-SHA resolution helper for refresh planning, preferring refresh SHA metadata with fallback to build metadata.
* **Bug Fixes**
  * Improved behavior when metadata is missing or empty during refresh/deploy planning.
  * Hardened fetch/JSON handling: non-2xx responses now fail with clearer errors; empty bodies resolve to “no SHA.”
* **Documentation**
  * Updated Cloudflare Worker architecture documentation to clarify content-only refresh flow after cutover.
* **Tests**
  * Expanded and adjusted refresh/deploy plan coverage to match the updated metadata shape and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->