### PR TITLE
Add ship-pr agent skill

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ship-pr
+description: >
+  Babysit a PR. Iterate with AI reviewers and CI. Get it ready and maybe merge.
+  Send summary message.
+---
+
+# Ship PR
+
+## Loop
+
+1. Mark ready — `kody:@kentcdodds/github-pr-tools/set-pr-review-status` with
+   `{ prUrl, status: 'ready' }`, or `{ owner, repo, prNumber, status: 'ready' }`
+2. Wait for CI — `gh pr checks` (compose `loop-on-ci`, `fix-ci`)
+3. Fix failures; address valid AI-reviewer feedback (ignore insignificant nits /
+   already-fixed / wrong)
+4. Green and no valid feedback left → break
+5. Push → repeat
+
+## Mode
+
+By default, continue to Discord message with summary and include PR link
+
+If explicitly requested, merge PR as Kody with
+`kody:@kentcdodds/github-pr-tools/merge-pr` using
+`{ prUrl, mergeMethod: 'squash' }` (or `{ owner, repo, prNumber, ... }`;
+optional `commitTitle`), watch CI deploy, when finished, continue to the discord
+message and include a summary with link to PR, deployed URL link, or failing job
+link.
+
+Other useful exports on the same package: `get-pr-checks` for check-run status
+without `gh`, and `github-client` (`ghRestFetch` / `ghGraphQL`) for one-off
+authenticated GitHub calls.
+
+## Done → Discord
+
+```javascript
+import sendMeAMessage from 'kody:@kentcdodds/discord-gateway/send-me-a-message'
+
+export default async function main() {
+	const content = ` ... `
+	return sendMeAMessage({ content })
+}
+```


### PR DESCRIPTION
Copies the `ship-pr` Cursor/agent skill from `kentcdodds/kody` into this repo.

Path: `.agents/skills/ship-pr/SKILL.md`

This skill babysits a PR: mark ready, wait for CI, fix failures / valid AI review feedback, then Discord-summary (and optionally merge via Kody).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only agent skill; no application runtime, auth, or deployment code changes.
> 
> **Overview**
> Adds **`.agents/skills/ship-pr/SKILL.md`**, a Cursor/agent skill copied from `kentcdodds/kody` that documents how to babysit a PR end-to-end.
> 
> The skill defines a **repeat loop**: mark the PR ready via Kody `set-pr-review-status`, wait on CI (`gh pr checks` / related skills), fix failures and substantive AI review feedback, then push and repeat until green.
> 
> It also covers **default vs merge mode** (optional squash merge through Kody `merge-pr`, deploy watch) and finishing with a **Discord summary** via `kody:@kentcdodds/discord-gateway/send-me-a-message`, plus pointers to `get-pr-checks` and `github-client` for GitHub automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fe631c718ec7af8eee2f04dbb9ca5c59162cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more guided PR completion flow that helps keep changes moving through review and checks until they’re ready.
  * Improved end-to-end handling for finalizing a PR, including a clear handoff for either sharing a status update or completing the merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->