### PR TITLE
docs(agents): note Playwright browser install caveats on Node 26

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -123,8 +123,11 @@ Unit tests apply committed SQL migrations via `app/utils/db/test-helpers.server.
 
 ## Cloud / headless manual testing
 
-- The Cursor Cloud VM snapshot ships with Node 24 via nvm, so run
-  `nvm install 26 && nvm use 26` before installing dependencies or testing.
+- The Cursor Cloud VM snapshot's default nvm Node is older than the required
+  Node 26 (it has shipped Node 22/24 in different snapshots), so run
+  `nvm install 26 && nvm use 26` before installing dependencies or testing. The
+  startup update script already selects Node 26 via nvm, but interactive shells
+  do not inherit that, so switch again in your shell.
   If the shell still resolves `/exec-daemon/node`, prepend nvm after switching:
   `export PATH="$NVM_BIN:$PATH"`.
   Chrome is configured to
@@ -135,6 +138,22 @@ Unit tests apply committed SQL migrations via `app/utils/db/test-helpers.server.
   `PATH="$(dirname "$(nvm which 26)"):$PATH"` when testing.
 - The first request after starting the dev server may compile all MDX blog posts
   via the sidecar watcher and can take ~30 s; subsequent loads are fast.
+- Playwright browsers (needed for `npm run test:browser` and `test:e2e:*`) are
+  pre-installed in the VM snapshot under `~/.cache/ms-playwright`, so you should
+  not normally need to reinstall them. On Node 26, `npm run test:e2e:install`
+  (i.e. `npx playwright install`) hangs during archive extraction (the download
+  reaches 100% but never finishes unpacking). If a browser is missing or its
+  revision changed, install it manually instead: `curl` the build zips from
+  `https://cdn.playwright.dev/builds/...` and unzip them into the matching
+  `~/.cache/ms-playwright/<name>-<revision>/` directory, then `touch` an
+  `INSTALLATION_COMPLETE` marker in each so Playwright treats them as installed.
+  Both `chrome-linux64` (chromium) and `chrome-headless-shell-linux64`
+  (chromium-headless-shell) come from the `builds/cft/<version>/linux64/` path;
+  ffmpeg comes from `builds/ffmpeg/<rev>/ffmpeg-linux.zip`.
+- Run the Playwright e2e suite with `npm run test:e2e:run` (CI mode, its own
+  server on port 8811). It fails to start if a dev server is already bound to
+  port 3000/3099 (the MDX sidecar), so stop `npm run dev` first, or set
+  `PW_REUSE_EXISTING_SERVER=true` to reuse a running dev server.
 - In cloud VMs, Chrome may block camera/microphone access by default. Visiting
   `/calls/record/new` can hit the route ErrorBoundary unless `localhost` is
   allowed mic/camera access in site settings (even if you intend to use the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

While setting up the Cursor Cloud development environment for this repo, I documented two non-obvious caveats in `docs/agents/project-context.md` (the source-of-truth doc referenced by `AGENTS.md`):

- **Playwright browser install hangs on Node 26.** `npm run test:e2e:install` (`npx playwright install`) reaches 100% download but never finishes extraction. Documented the manual `curl` + `unzip` + `INSTALLATION_COMPLETE` marker workaround, and the exact CfT/ffmpeg CDN paths.
- **`npm run test:e2e:run` port conflict.** It starts its own server on 3000/3099, so a running `npm run dev` must be stopped first (or reuse it via `PW_REUSE_EXISTING_SERVER=true`).
- Also softened the "ships with Node 24" note (this VM shipped Node 22) and clarified that the startup update script selects Node 26 via nvm but interactive shells must switch again.

## Why

These are durable, non-obvious gotchas that cost real time during setup. Capturing them makes future agent runs faster and lets browser/e2e tests be brought up reliably.

## Testing

Environment fully verified: lint, typecheck, build, backend tests (203), browser-mode tests (14), and Playwright e2e (11 passed) all pass; dev server runs and login as the seed admin works end-to-end.

<a href="https://cursor.com/agents/bc-f32d2ae6-9463-4ca5-9d17-95210c0bd3c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello-world-login-demo.mp4"><img src="https://cursor.com/artifacts/c/art-727e41c6-5f38-4f3b-83e8-a1672e57f93c" alt="hello-world-login-demo.mp4" /></a>
![Authenticated account page after login](https://cursor.com/artifacts/c/art-6470761c-af7c-4f5d-9317-4281fb84ee69)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f32d2ae6-9463-4ca5-9d17-95210c0bd3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f32d2ae6-9463-4ca5-9d17-95210c0bd3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cloud/headless manual testing guidance with clearer Node version requirements.
  * Added steps for installing and using the required Node version in interactive shells.
  * Expanded browser setup instructions with a manual fallback for browser downloads and installation markers.
  * Clarified how to run end-to-end tests and what to do when a dev server is already using the port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->