### PR TITLE
Filter ChatGPT Module load timeout noise in Sentry

### DIFF
--- a/services/site/app/utils/monitoring.client.tsx
+++ b/services/site/app/utils/monitoring.client.tsx
@@ -13,6 +13,8 @@ export function init() {
 			'Request to /lookout failed',
 			"Can't find variable: CONFIG",
 			'CONFIG is not defined',
+			// Injected/third-party module loaders (seen from chatgpt.com referrers).
+			/^Module load timeout: m_\d+$/,
 		],
 		beforeSend(event, hint) {
 			if (isBrowserExtensionError(hint.originalException)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Ignore opaque client `Module load timeout: m_*` errors in Sentry (`ignoreErrors`).
- These are ChatGPT-injected browser noise (Firefox + `chatgpt.com` referer), seen on both Fly and Workers — not a migration regression.

## Test plan
- [x] Confirm Sentry events match `/^Module load timeout: m_\d+$/`
- [ ] After deploy, verify new events of this shape stop appearing in `kcd-node`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27d908a5-bc77-4fee-8989-c22755eadbce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27d908a5-bc77-4fee-8989-c22755eadbce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from error monitoring by filtering out an additional timeout-related error pattern.
  * This helps prevent expected module loading timeouts from appearing in reports, making real issues easier to spot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->