### PR TITLE
Fix semantic-search JSX indexer dev-server readiness across IPv4/IPv6

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -101,6 +101,13 @@ reference:
 - Oxlint config caveat: prefer package-export extends
   (`"@epic-web/config/oxlint"`) in `.oxlintrc.json`. In this repo, path-based
   extends into `node_modules` can fail to inherit the shared env/rules.
+- Semantic search caveat: the JSX-page indexer
+  (`other/semantic-search/jsx-page-content.ts`) boots `npm run dev` and waits for
+  `/sitemap.xml`. Vite binds to `localhost`, which resolves to IPv6 (`::1`) or
+  IPv4 (`127.0.0.1`) depending on the runner, so the readiness probe checks both
+  loopback families (`resolveReachableSitemapOrigin`) and uses whichever the dev
+  server actually bound to. Probing a single hard-coded address caused CI
+  "Timed out waiting for local dev server" failures even though the server was up.
 - Semantic search caveat: YouTube auto-captions can include cue-only chunks like
   `[Music]`. The YouTube indexer filters these low-signal caption lines and
   merges tiny trailing transcript chunks at ingest time, but old vectors can

--- a/other/semantic-search/jsx-page-content.ts
+++ b/other/semantic-search/jsx-page-content.ts
@@ -354,30 +354,41 @@ async function requestTextDocument({
 	})
 }
 
-async function waitForSitemap({
-	origin,
+// The dev server (Vite) binds to `localhost`, which can resolve to IPv4
+// (127.0.0.1) or IPv6 (::1) depending on the runner. If we probe only one
+// address family and the server bound to the other, every request is refused
+// and startup "times out" even though the server is up. Probe both loopback
+// families and use whichever one actually answers.
+export function getLoopbackOriginsForPort(port: number) {
+	return [`http://127.0.0.1:${port}`, `http://[::1]:${port}`]
+}
+
+export async function resolveReachableSitemapOrigin({
+	candidateOrigins,
 	logs,
 	timeoutMs,
 }: {
-	origin: string
+	candidateOrigins: string[]
 	logs: () => string
 	timeoutMs: number
-}) {
+}): Promise<string> {
 	const start = Date.now()
 	while (Date.now() - start < timeoutMs) {
-		try {
-			const res = await requestTextDocument({
-				url: `${origin}/sitemap.xml`,
-				accept: 'application/xml',
-			})
-			if (res.statusCode >= 200 && res.statusCode < 300) return
-		} catch {
-			// still starting
+		for (const origin of candidateOrigins) {
+			try {
+				const res = await requestTextDocument({
+					url: `${origin}/sitemap.xml`,
+					accept: 'application/xml',
+				})
+				if (res.statusCode >= 200 && res.statusCode < 300) return origin
+			} catch {
+				// still starting, or this address family isn't bound yet
+			}
 		}
 		await sleep(750)
 	}
 	throw new Error(
-		`Timed out waiting for local dev server at ${origin}. Recent logs:\n${logs()}`,
+		`Timed out waiting for local dev server on ${candidateOrigins.join(', ')}. Recent logs:\n${logs()}`,
 	)
 }
 
@@ -387,7 +398,7 @@ export async function startLocalDevServerForSitemap({
 	startupTimeoutMs?: number
 } = {}): Promise<RunningDevServer> {
 	const port = await getPort({ port: portNumbers(3200, 3999) })
-	const origin = `http://127.0.0.1:${port}`
+	const candidateOrigins = getLoopbackOriginsForPort(port)
 	const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 	const child = spawn(npmExecutable, ['run', 'dev'], {
 		cwd: path.join(process.cwd(), 'services', 'site'),
@@ -454,8 +465,8 @@ export async function startLocalDevServerForSitemap({
 	}
 
 	try {
-		await waitForSitemap({
-			origin,
+		const origin = await resolveReachableSitemapOrigin({
+			candidateOrigins,
 			logs: () => outputLog,
 			timeoutMs: startupTimeoutMs,
 		})

--- a/services/site/tests/__tests__/semantic-search-jsx-page-origin.test.ts
+++ b/services/site/tests/__tests__/semantic-search-jsx-page-origin.test.ts
@@ -58,9 +58,12 @@ describe('jsx page dev server origin resolution', () => {
 		let server: Awaited<ReturnType<typeof startSitemapServer>>
 		try {
 			server = await startSitemapServer('::1')
-		} catch {
-			// Skip when the runner has no IPv6 loopback available.
-			return
+		} catch (error) {
+			// Skip only when the runner genuinely lacks an IPv6 loopback; surface
+			// any other failure so it can't silently hide a real regression.
+			const code = (error as NodeJS.ErrnoException | null)?.code
+			if (code === 'EADDRNOTAVAIL' || code === 'EAFNOSUPPORT') return
+			throw error
 		}
 		try {
 			const origin = await resolveReachableSitemapOrigin({

--- a/services/site/tests/__tests__/semantic-search-jsx-page-origin.test.ts
+++ b/services/site/tests/__tests__/semantic-search-jsx-page-origin.test.ts
@@ -1,0 +1,86 @@
+import http from 'node:http'
+import { describe, expect, test } from 'vitest'
+import {
+	getLoopbackOriginsForPort,
+	resolveReachableSitemapOrigin,
+} from '../../../../other/semantic-search/jsx-page-content.ts'
+
+async function startSitemapServer(host: string) {
+	const server = http.createServer((req, res) => {
+		if (req.url === '/sitemap.xml') {
+			res.writeHead(200, { 'Content-Type': 'application/xml' })
+			res.end(`<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>`)
+			return
+		}
+		res.writeHead(404)
+		res.end('not found')
+	})
+	await new Promise<void>((resolve, reject) => {
+		server.once('error', reject)
+		server.listen(0, host, () => resolve())
+	})
+	const address = server.address()
+	if (!address || typeof address === 'string') {
+		throw new Error('Unexpected server address')
+	}
+	return {
+		port: address.port,
+		close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+	}
+}
+
+describe('jsx page dev server origin resolution', () => {
+	test('getLoopbackOriginsForPort probes both IPv4 and IPv6 loopback', () => {
+		expect(getLoopbackOriginsForPort(3200)).toEqual([
+			'http://127.0.0.1:3200',
+			'http://[::1]:3200',
+		])
+	})
+
+	test('resolveReachableSitemapOrigin resolves an IPv4-only dev server', async () => {
+		const server = await startSitemapServer('127.0.0.1')
+		try {
+			const origin = await resolveReachableSitemapOrigin({
+				candidateOrigins: getLoopbackOriginsForPort(server.port),
+				logs: () => '',
+				timeoutMs: 5_000,
+			})
+			expect(origin).toBe(`http://127.0.0.1:${server.port}`)
+		} finally {
+			await server.close()
+		}
+	}, 10_000)
+
+	// Regression for the CI failure where Vite bound to IPv6 (::1) while the
+	// indexer only probed 127.0.0.1, so startup "timed out" even though the dev
+	// server was already serving requests.
+	test('resolveReachableSitemapOrigin resolves an IPv6-only dev server', async () => {
+		let server: Awaited<ReturnType<typeof startSitemapServer>>
+		try {
+			server = await startSitemapServer('::1')
+		} catch {
+			// Skip when the runner has no IPv6 loopback available.
+			return
+		}
+		try {
+			const origin = await resolveReachableSitemapOrigin({
+				candidateOrigins: getLoopbackOriginsForPort(server.port),
+				logs: () => '',
+				timeoutMs: 5_000,
+			})
+			expect(origin).toBe(`http://[::1]:${server.port}`)
+		} finally {
+			await server.close()
+		}
+	}, 10_000)
+
+	test('resolveReachableSitemapOrigin throws with candidates and logs when unreachable', async () => {
+		await expect(
+			resolveReachableSitemapOrigin({
+				candidateOrigins: ['http://127.0.0.1:1', 'http://[::1]:1'],
+				logs: () => 'recent dev server output',
+				timeoutMs: 500,
+			}),
+		).rejects.toThrow(/http:\/\/127\.0\.0\.1:1.*recent dev server output/s)
+	}, 10_000)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `🔎 Index Semantic Search (content)` job failed after PR #841 with:

```
Error: Timed out waiting for local dev server at http://127.0.0.1:3200. Recent logs:
...
[mdx] mdx-dev: compiled 227 documents, reused 0 cached documents (28 embed fallbacks)
[mdx] mdx-dev: ready in 56550ms
    at waitForSitemap (other/semantic-search/jsx-page-content.ts:379:8)
    at async startLocalDevServerForSitemap (other/semantic-search/jsx-page-content.ts:457:3)
```

The site worker deploy itself succeeded — production is healthy — so this was purely a reliability bug in the JSX-page indexer, not a content/deploy problem. PR #841 only *triggered* the job (it changed `services/site/app/**`, which makes the indexer reindex JSX pages by booting a local dev server).

## Root cause

The JSX-page indexer boots `npm run dev` and polls `/sitemap.xml` to detect readiness. It hard-coded the origin to `http://127.0.0.1:${port}` (IPv4), but Vite binds to `localhost`, which on the CI runner (and this environment) resolves to **IPv6 `::1`**. Every probe to `127.0.0.1` was refused, so the poll loop ran the full `startupTimeoutMs` (180s) and threw — even though the dev server was up and serving requests within seconds. This was a latent bug present since #620; the ~56s cold MDX compile is a red herring (the sitemap does not depend on MDX compilation).

### Evidence (reproduced locally)

`localhost` resolution vs. what Vite bound to:

```
curl http://127.0.0.1:3200/sitemap.xml  -> 000 (connection refused)
curl http://localhost:3200/sitemap.xml  -> 200
curl http://[::1]:3200/sitemap.xml      -> 200
```

Node `http.request` behaves the same way (`ECONNREFUSED` on `127.0.0.1`, `200` on `[::1]`), confirming Vite was IPv6-only.

## Fix

Probe **both** loopback families (`127.0.0.1` and `[::1]`) during readiness and use whichever origin the dev server actually bound to (`resolveReachableSitemapOrigin`). The resolved origin flows through to all subsequent page fetches. This is durable regardless of which address family Vite binds to; the timeout is left unchanged because it was never the real issue.

## Test plan

- Added `services/site/tests/__tests__/semantic-search-jsx-page-origin.test.ts` (placed where the CI-collected semantic-search tests live, not the orphaned `other/semantic-search/__tests__` dir): covers IPv4-only, IPv6-only (the exact regression), and unreachable/timeout cases. All pass.
- End-to-end: booted the real `startLocalDevServerForSitemap` + `loadJsxPageItemsFromRunningSite` path. Before: 180s timeout. After: dev server detected at `http://[::1]:3200` in ~9s and all 27 JSX pages indexed in ~15s total:

```
[+0.0s] booting local dev server for sitemap...
[+9.2s] dev server reachable at http://[::1]:3200
[+14.7s] loaded 27 jsx page items
  - / (Kent C. Dodds) [2245 chars]
  - /talks (86 talks by Kent all about software development) [58180 chars]
  - /about (About Kent C. Dodds) [5887 chars]
  ...
```

- `npm run typecheck` (site workspace) and `oxlint` on the changed files: clean.

## Notes

- No unrelated migration/cleanup work from #841 was touched.
- Added a caveat to `docs/agents/project-context.md` documenting the IPv4/IPv6 dev-server binding sharp edge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff2c3b5b-8fec-40d7-925b-c0b132297727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff2c3b5b-8fec-40d7-925b-c0b132297727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local preview sitemap readiness checks to support both IPv4 and IPv6 loopback bindings.
  * Reduced “Timed out waiting for local dev server” issues by probing multiple loopback origins before failing.
  * Enhanced failure messages with recent dev-server output to aid troubleshooting.

* **Documentation**
  * Added a new “Non-obvious caveats” note describing the loopback probing behavior and why it matters in CI.

* **Tests**
  * Added tests for IPv4-only, IPv6-only, and unreachable local server scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->