### PR TITLE
Include Better with Kent playlist on /better YouTube links

### DIFF
--- a/services/site/app/external-links.tsx
+++ b/services/site/app/external-links.tsx
@@ -1,3 +1,7 @@
+// The "Better with Kent" playlist on Kent's YouTube channel. Episode watch
+// links and embeds include this so viewers land in the full show playlist.
+const betterWithKentPlaylistId = 'PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY'
+
 const externalLinks = {
 	applePodcast:
 		'https://podcasts.apple.com/us/podcast/chats-with-kent-c-dodds/id1475543959',
@@ -11,8 +15,7 @@ const externalLinks = {
 	callKentRSS: 'https://feeds.transistor.fm/call-kent',
 	betterWithKentYouTube:
 		'https://www.youtube.com/@KentCDodds-vids?sub_confirmation=1',
-	betterWithKentPlaylist:
-		'https://www.youtube.com/playlist?list=PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY',
+	betterWithKentPlaylist: `https://www.youtube.com/playlist?list=${betterWithKentPlaylistId}`,
 	betterWithKentApple:
 		'https://podcasts.apple.com/us/podcast/better-with-kent/id1896798447',
 	betterWithKentPocketCasts: 'https://pca.st/itunes/1896798447',
@@ -29,4 +32,4 @@ const externalLinks = {
 	rss: 'https://kentcdodds.com/blog/rss.xml',
 }
 
-export { externalLinks }
+export { betterWithKentPlaylistId, externalLinks }

--- a/services/site/app/routes/better.tsx
+++ b/services/site/app/routes/better.tsx
@@ -17,19 +17,16 @@ import { PodcastSubs } from '#app/components/podcast-subs.tsx'
 import { HeaderSection } from '#app/components/sections/header-section.tsx'
 import { HeroSection } from '#app/components/sections/hero-section.tsx'
 import { H2, H3, H6, Paragraph } from '#app/components/typography.tsx'
-import { externalLinks } from '#app/external-links.tsx'
 import {
-	getImgProps,
-	images,
-} from '#app/images.tsx'
+	betterWithKentPlaylistId,
+	externalLinks,
+} from '#app/external-links.tsx'
+import { getImgProps, images } from '#app/images.tsx'
 import {
 	type BetterWithKentEpisode,
 	getBetterWithKentEpisodes,
 } from '#app/utils/better-with-kent.server.ts'
-import {
-	formatDate,
-	reuseUsefulLoaderHeaders,
-} from '#app/utils/misc-react.tsx'
+import { formatDate, reuseUsefulLoaderHeaders } from '#app/utils/misc-react.tsx'
 import { getServerTimeHeader, type Timings } from '#app/utils/timing.server.ts'
 import { type Route } from './+types/better'
 
@@ -77,7 +74,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) =>
 	data?.socialMetas ?? []
 
 function getWatchUrl(videoId: string) {
-	return `https://www.youtube.com/watch?v=${videoId}`
+	return `https://www.youtube.com/watch?v=${videoId}&list=${betterWithKentPlaylistId}`
 }
 
 function SubscribeButton({
@@ -164,7 +161,10 @@ export default function BetterRoute({
 									// img.youtube.com which our CSP img-src does not allow, so we
 									// point straight at the i.ytimg.com thumbnail instead.
 									thumbnail={`https://i.ytimg.com/vi/${latestEpisode.videoId}/maxresdefault.jpg`}
-									params="rel=0"
+									params={new URLSearchParams({
+										rel: '0',
+										list: betterWithKentPlaylistId,
+									}).toString()}
 								/>
 							</div>
 						</div>

--- a/services/site/app/utils/better-with-kent.server.ts
+++ b/services/site/app/utils/better-with-kent.server.ts
@@ -1,10 +1,7 @@
 import { z } from 'zod'
+import { betterWithKentPlaylistId } from '#app/external-links.tsx'
 import { cache, cachified } from './cache.server.ts'
 import { type Timings } from './timing.server.ts'
-
-// The "Better with Kent" playlist on Kent's YouTube channel. Episodes are
-// added here by the publishing pipeline in the kcd-youtube repo.
-export const betterWithKentPlaylistId = 'PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY'
 
 const betterWithKentEpisodeSchema = z.object({
 	videoId: z.string().regex(/^[A-Za-z0-9_-]{11}$/),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Episode watch links on `/better` now include `&list=PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY` so opening a video lands viewers in the full show playlist.
- The latest-episode Lite YouTube embed also passes that playlist id, so related playback stays in the series.
- Centralized the playlist id in `external-links.tsx` and reused it from the episode feed helper.

## Test plan
- [ ] Open `/better` and confirm the latest episode "Watch on YouTube" link includes `list=PLV5CVI1eNcJhP4nrJt85L7PxHjebFpDfY`
- [ ] Confirm earlier episode cards link with the same playlist param
- [ ] Play the latest-episode embed and confirm the player is associated with the Better with Kent playlist

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27e8596a-8518-4972-899f-efb67a5a4804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27e8596a-8518-4972-899f-efb67a5a4804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Better with Kent” video links now preserve the playlist context when opened.
  * The embedded player now stays tied to the same playlist, improving navigation between episodes.
  * The playlist identifier is now managed consistently across the site for more reliable linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->