### PR TITLE
Prewarm changed content after refresh

### DIFF
--- a/.github/workflows/refresh-content.yml
+++ b/.github/workflows/refresh-content.yml
@@ -21,7 +21,8 @@ jobs:
       group: refresh-content-${{ github.ref }}
       cancel-in-progress: true
     env:
-      SITE_URL: https://kentcdodds-com.kentcdodds.workers.dev
+      # Cache keys include the host, so compare and prewarm the public origin.
+      SITE_URL: https://kentcdodds.com
       WORKER_URL: https://kentcdodds-com.kentcdodds.workers.dev
     steps:
       # WORKER_URL is hardcoded to production: a manual dispatch from a

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -404,9 +404,13 @@ in the entry. On every `HIT`/`STALE`, the parent generates a fresh nonce,
 The parent in-memory generation cache is cleared on bump.
 After a content-only refresh completes its final generation bump, the refresh
 workflow sends cookieless requests for affected public URLs through
-`kentcdodds.com` and polls until `X-Edge-Cache: HIT`. This renders changed MDX
-before an end user arrives and verifies that the asynchronous KV fill completed.
-Blog changes also prewarm the homepage, blog index, feeds, and sitemap.
+`kentcdodds.com`. Each request carries the generation returned by the refresh;
+an isolate on an older generation returns `409` so the workflow retries. On a
+cache miss, the worker synchronously stores the response and confirms it with
+`X-Page-Cache-Stored: true`; an existing `HIT` for the requested generation is
+also accepted. This renders changed MDX before an end user arrives without
+depending on KV read-after-write visibility. Blog changes also prewarm the
+homepage, blog index, feeds, and sitemap.
 
 ### Observability
 

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -404,13 +404,13 @@ in the entry. On every `HIT`/`STALE`, the parent generates a fresh nonce,
 The parent in-memory generation cache is cleared on bump.
 After a content-only refresh completes its final generation bump, the refresh
 workflow sends cookieless requests for affected public URLs through
-`kentcdodds.com`. Each request carries the generation returned by the refresh;
-an isolate on an older generation returns `409` so the workflow retries. On a
-cache miss, the worker synchronously stores the response and confirms it with
-`X-Page-Cache-Stored: true`; an existing `HIT` for the requested generation is
-also accepted. This renders changed MDX before an end user arrives without
-depending on KV read-after-write visibility. Blog changes also prewarm the
-homepage, blog index, feeds, and sitemap.
+`kentcdodds.com`. Each request carries the cache generation and content version
+returned by the refresh; an isolate on an older value returns `409` so the
+workflow retries. Prewarm requests bypass existing page entries and parent
+manifest caches, then synchronously replace the entry and confirm it with
+`X-Page-Cache-Stored: true`. This prevents a fresh cache generation from being
+filled with stale MDX and does not depend on KV read-after-write visibility.
+Blog changes also prewarm the homepage, blog index, feeds, and sitemap.
 
 ### Observability
 

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -402,6 +402,11 @@ in the entry. On every `HIT`/`STALE`, the parent generates a fresh nonce,
 2. `POST /action/refresh-cache` (parent intercept before dynamic forward)
 
 The parent in-memory generation cache is cleared on bump.
+After a content-only refresh completes its final generation bump, the refresh
+workflow sends cookieless requests for affected public URLs through
+`kentcdodds.com` and polls until `X-Edge-Cache: HIT`. This renders changed MDX
+before an end user arrives and verifies that the asynchronous KV fill completed.
+Blog changes also prewarm the homepage, blog index, feeds, and sitemap.
 
 ### Observability
 

--- a/other/__tests__/content-prewarm-urls.test.ts
+++ b/other/__tests__/content-prewarm-urls.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "vitest";
+import { getContentPrewarmUrls } from "../content-prewarm-urls.ts";
+
+const blogSharedUrls = [
+  "/",
+  "/blog",
+  "/blog.json",
+  "/blog/rss.xml",
+  "/sitemap.xml",
+];
+
+test("maps flat and nested blog content to the public post URL", () => {
+  expect(
+    getContentPrewarmUrls([
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/flat-post.mdx",
+      },
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/nested-post/example.tsx",
+      },
+    ]),
+  ).toEqual([...blogSharedUrls, "/blog/flat-post", "/blog/nested-post"].sort());
+});
+
+test("maps pages and known data files to public URLs", () => {
+  expect(
+    getContentPrewarmUrls([
+      {
+        changeType: "modified",
+        filename: "services/site/content/pages/uses.md",
+      },
+      {
+        changeType: "modified",
+        filename: "services/site/content/data/resume.yml",
+      },
+    ]),
+  ).toEqual(["/resume", "/sitemap.xml", "/uses"]);
+});
+
+test("does not request deleted document URLs", () => {
+  expect(
+    getContentPrewarmUrls([
+      {
+        changeType: "deleted",
+        filename: "services/site/content/blog/retired-post.mdx",
+      },
+      {
+        changeType: "deleted",
+        filename: "services/site/content/pages/retired-page.mdx",
+      },
+    ]),
+  ).toEqual(blogSharedUrls);
+});
+
+test("warms the new URL and shared URLs from both sides of a move", () => {
+  expect(
+    getContentPrewarmUrls([
+      {
+        changeType: "moved",
+        filename: "services/site/content/pages/renamed.mdx",
+        previousFilename: "services/site/content/blog/original.mdx",
+      },
+    ]),
+  ).toEqual([...blogSharedUrls, "/renamed"].sort());
+});
+
+test("ignores content without a corresponding public route", () => {
+  expect(
+    getContentPrewarmUrls([
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/README.md",
+      },
+      {
+        changeType: "modified",
+        filename: "services/site/content/writing-blog/draft.mdx",
+      },
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/banner.png",
+      },
+    ]),
+  ).toEqual(blogSharedUrls);
+});

--- a/other/__tests__/get-changed-files.test.js
+++ b/other/__tests__/get-changed-files.test.js
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import { parseChangedFiles } from "../get-changed-files.js";
+
+test("parses added, modified, deleted, and renamed git paths", () => {
+  expect(
+    parseChangedFiles(
+      [
+        "A\tservices/site/content/blog/added.mdx",
+        "M\tservices/site/content/blog/modified.mdx",
+        "D\tservices/site/content/blog/deleted.mdx",
+        "R100\tservices/site/content/blog/old.mdx\tservices/site/content/blog/new.mdx",
+      ].join("\n"),
+    ),
+  ).toEqual([
+    {
+      changeType: "added",
+      filename: "services/site/content/blog/added.mdx",
+    },
+    {
+      changeType: "modified",
+      filename: "services/site/content/blog/modified.mdx",
+    },
+    {
+      changeType: "deleted",
+      filename: "services/site/content/blog/deleted.mdx",
+    },
+    {
+      changeType: "moved",
+      filename: "services/site/content/blog/new.mdx",
+      previousFilename: "services/site/content/blog/old.mdx",
+    },
+  ]);
+});

--- a/other/__tests__/prewarm-page-cache.test.ts
+++ b/other/__tests__/prewarm-page-cache.test.ts
@@ -91,6 +91,60 @@ test("reports a cache bypass without retrying", async () => {
   expect(log.warn).toHaveBeenCalledOnce();
 });
 
+test("waits for the refreshed generation and accepts a confirmed synchronous fill", async () => {
+  const fetchImpl = vi
+    .fn()
+    .mockResolvedValueOnce(
+      new Response(null, {
+        status: 409,
+        headers: {
+          "X-Edge-Cache": "BYPASS",
+          "X-Page-Cache-Generation": "old-generation",
+        },
+      }),
+    )
+    .mockResolvedValueOnce(
+      new Response("rendered", {
+        status: 200,
+        headers: {
+          "X-Edge-Cache": "MISS",
+          "X-Page-Cache-Generation": "new-generation",
+          "X-Page-Cache-Stored": "true",
+        },
+      }),
+    );
+  const sleepImpl = vi.fn(async () => undefined);
+
+  const result = await prewarmPageCache({
+    baseUrl: "https://example.com",
+    paths: ["/blog/example"],
+    expectedGeneration: "new-generation",
+    fetchImpl,
+    log: createLogger(),
+    maxAttempts: 2,
+    sleepImpl,
+  });
+
+  expect(result.results[0]).toEqual({
+    url: "https://example.com/blog/example",
+    ok: true,
+    attempts: 2,
+    status: 200,
+    edgeCache: "MISS",
+    generation: "new-generation",
+    stored: true,
+  });
+  expect(fetchImpl).toHaveBeenLastCalledWith(
+    "https://example.com/blog/example",
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        "x-page-cache-prewarm": "new-generation",
+      }),
+    }),
+  );
+  expect(sleepImpl).toHaveBeenCalledOnce();
+});
+
 test("retries transient failures and reports an exhausted prewarm", async () => {
   const fetchImpl = vi
     .fn()

--- a/other/__tests__/prewarm-page-cache.test.ts
+++ b/other/__tests__/prewarm-page-cache.test.ts
@@ -100,6 +100,7 @@ test("waits for the refreshed generation and accepts a confirmed synchronous fil
         headers: {
           "X-Edge-Cache": "BYPASS",
           "X-Page-Cache-Generation": "old-generation",
+          "X-Content-Version": "old-content",
         },
       }),
     )
@@ -109,6 +110,7 @@ test("waits for the refreshed generation and accepts a confirmed synchronous fil
         headers: {
           "X-Edge-Cache": "MISS",
           "X-Page-Cache-Generation": "new-generation",
+          "X-Content-Version": "new-content",
           "X-Page-Cache-Stored": "true",
         },
       }),
@@ -119,6 +121,7 @@ test("waits for the refreshed generation and accepts a confirmed synchronous fil
     baseUrl: "https://example.com",
     paths: ["/blog/example"],
     expectedGeneration: "new-generation",
+    expectedContentVersion: "new-content",
     fetchImpl,
     log: createLogger(),
     maxAttempts: 2,
@@ -132,6 +135,7 @@ test("waits for the refreshed generation and accepts a confirmed synchronous fil
     status: 200,
     edgeCache: "MISS",
     generation: "new-generation",
+    contentVersion: "new-content",
     stored: true,
   });
   expect(fetchImpl).toHaveBeenLastCalledWith(
@@ -139,10 +143,45 @@ test("waits for the refreshed generation and accepts a confirmed synchronous fil
     expect.objectContaining({
       headers: expect.objectContaining({
         "x-page-cache-prewarm": "new-generation",
+        "x-page-cache-prewarm-content-version": "new-content",
       }),
     }),
   );
   expect(sleepImpl).toHaveBeenCalledOnce();
+});
+
+test("fails immediately when the matching worker cannot store the page", async () => {
+  const fetchImpl = vi.fn(async () => {
+    return new Response("not cacheable", {
+      status: 200,
+      headers: {
+        "X-Edge-Cache": "MISS",
+        "X-Page-Cache-Generation": "new-generation",
+        "X-Content-Version": "new-content",
+        "X-Page-Cache-Stored": "false",
+      },
+    });
+  });
+  const sleepImpl = vi.fn(async () => undefined);
+
+  const result = await prewarmPageCache({
+    baseUrl: "https://example.com",
+    paths: ["/blog/example"],
+    expectedGeneration: "new-generation",
+    expectedContentVersion: "new-content",
+    fetchImpl,
+    log: createLogger(),
+    sleepImpl,
+  });
+
+  expect(result.results[0]).toMatchObject({
+    ok: false,
+    attempts: 1,
+    stored: false,
+    error: "Worker rendered the page but could not store it",
+  });
+  expect(fetchImpl).toHaveBeenCalledOnce();
+  expect(sleepImpl).not.toHaveBeenCalled();
 });
 
 test("retries transient failures and reports an exhausted prewarm", async () => {

--- a/other/__tests__/prewarm-page-cache.test.ts
+++ b/other/__tests__/prewarm-page-cache.test.ts
@@ -1,0 +1,124 @@
+import { expect, test, vi } from "vitest";
+import { prewarmPageCache } from "../prewarm-page-cache.ts";
+
+function createLogger() {
+  return { log: vi.fn(), warn: vi.fn() };
+}
+
+test("polls a cache miss until the asynchronous fill becomes a hit", async () => {
+  const fetchImpl = vi
+    .fn()
+    .mockResolvedValueOnce(
+      new Response("rendered", {
+        status: 200,
+        headers: { "X-Edge-Cache": "MISS" },
+      }),
+    )
+    .mockResolvedValueOnce(
+      new Response("cached", {
+        status: 200,
+        headers: { "X-Edge-Cache": "HIT" },
+      }),
+    );
+  const sleepImpl = vi.fn(async () => undefined);
+  const log = createLogger();
+
+  const result = await prewarmPageCache({
+    baseUrl: "https://example.com",
+    paths: ["/blog/example"],
+    fetchImpl,
+    log,
+    sleepImpl,
+  });
+
+  expect(result).toEqual({
+    attempted: 1,
+    warmed: 1,
+    failed: 0,
+    results: [
+      {
+        url: "https://example.com/blog/example",
+        ok: true,
+        attempts: 2,
+        status: 200,
+        edgeCache: "HIT",
+      },
+    ],
+  });
+  expect(fetchImpl).toHaveBeenCalledWith(
+    "https://example.com/blog/example",
+    expect.objectContaining({
+      headers: {
+        accept: "text/html",
+        "user-agent": "kcd-content-refresh-prewarm",
+      },
+      redirect: "manual",
+    }),
+  );
+  expect(sleepImpl).toHaveBeenCalledOnce();
+  expect(log.log).toHaveBeenCalledOnce();
+  expect(log.warn).not.toHaveBeenCalled();
+});
+
+test("reports a cache bypass without retrying", async () => {
+  const fetchImpl = vi.fn(async () => {
+    return new Response("private", {
+      status: 200,
+      headers: { "X-Edge-Cache": "BYPASS" },
+    });
+  });
+  const sleepImpl = vi.fn(async () => undefined);
+  const log = createLogger();
+
+  const result = await prewarmPageCache({
+    baseUrl: "https://example.com",
+    paths: ["/private"],
+    fetchImpl,
+    log,
+    sleepImpl,
+  });
+
+  expect(result.failed).toBe(1);
+  expect(result.results[0]).toMatchObject({
+    ok: false,
+    attempts: 1,
+    status: 200,
+    edgeCache: "BYPASS",
+    error: "Page is not cacheable (status 200, X-Edge-Cache BYPASS)",
+  });
+  expect(fetchImpl).toHaveBeenCalledOnce();
+  expect(sleepImpl).not.toHaveBeenCalled();
+  expect(log.warn).toHaveBeenCalledOnce();
+});
+
+test("retries transient failures and reports an exhausted prewarm", async () => {
+  const fetchImpl = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("network unavailable"))
+    .mockResolvedValueOnce(
+      new Response("unavailable", {
+        status: 503,
+        headers: { "X-Edge-Cache": "MISS" },
+      }),
+    );
+  const log = createLogger();
+
+  const result = await prewarmPageCache({
+    baseUrl: "https://example.com",
+    paths: ["/blog/example"],
+    fetchImpl,
+    log,
+    maxAttempts: 2,
+    sleepImpl: async () => undefined,
+  });
+
+  expect(result.failed).toBe(1);
+  expect(result.results[0]).toMatchObject({
+    ok: false,
+    attempts: 2,
+    status: 503,
+    edgeCache: "MISS",
+  });
+  expect(fetchImpl).toHaveBeenCalledTimes(2);
+  expect(log.warn).toHaveBeenCalledOnce();
+});

--- a/other/__tests__/refresh-changed-content.test.js
+++ b/other/__tests__/refresh-changed-content.test.js
@@ -56,7 +56,10 @@ describe("refreshChangedContent", () => {
         filename: "services/site/content/blog/some-post.mdx",
       },
     ]);
-    const postRefreshCacheImpl = vi.fn(async () => ({ ok: true }));
+    const postRefreshCacheImpl = vi.fn(async () => ({
+      ok: true,
+      pageCacheGeneration: "generation-2",
+    }));
     const log = createLogger();
 
     const result = await refreshChangedContent({
@@ -176,7 +179,10 @@ describe("refreshChangedContent", () => {
         filename: "services/site/content/blog/some-post/index.mdx",
       },
     ]);
-    const postRefreshCacheImpl = vi.fn(async () => ({ ok: true }));
+    const postRefreshCacheImpl = vi.fn(async () => ({
+      ok: true,
+      pageCacheGeneration: "generation-2",
+    }));
     const prewarmResult = {
       attempted: 6,
       warmed: 6,
@@ -209,6 +215,7 @@ describe("refreshChangedContent", () => {
         "/blog/some-post",
         "/sitemap.xml",
       ],
+      expectedGeneration: "generation-2",
       log,
     });
     expect(result).toEqual({

--- a/other/__tests__/refresh-changed-content.test.js
+++ b/other/__tests__/refresh-changed-content.test.js
@@ -73,6 +73,7 @@ describe("refreshChangedContent", () => {
       status: "refreshed",
       attempts: 1,
       contentPaths: ["blog/some-post.mdx"],
+      prewarm: { attempted: 0, warmed: 0, failed: 0, results: [] },
     });
     expect(getChangedFilesImpl).toHaveBeenCalledWith(
       "current-sha",
@@ -154,6 +155,7 @@ describe("refreshChangedContent", () => {
       status: "refreshed",
       attempts: 2,
       contentPaths: ["blog/some-post.mdx"],
+      prewarm: { attempted: 0, warmed: 0, failed: 0, results: [] },
     });
     expect(postRefreshCacheImpl).toHaveBeenCalledTimes(2);
     expect(postRefreshCacheImpl).toHaveBeenLastCalledWith({
@@ -164,6 +166,57 @@ describe("refreshChangedContent", () => {
       options: { hostname: "kentcdodds-com.kentcdodds.workers.dev" },
     });
     expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("prewarms affected public URLs after the final cache refresh", async () => {
+    const fetchJsonImpl = vi.fn(async () => ({ sha: "compare-sha" }));
+    const getChangedFilesImpl = vi.fn(async () => [
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/some-post/index.mdx",
+      },
+    ]);
+    const postRefreshCacheImpl = vi.fn(async () => ({ ok: true }));
+    const prewarmResult = {
+      attempted: 6,
+      warmed: 6,
+      failed: 0,
+      results: [],
+    };
+    const prewarmPageCacheImpl = vi.fn(async () => prewarmResult);
+    const log = createLogger();
+
+    const result = await refreshChangedContent({
+      currentCommitSha: "current-sha",
+      baseUrl: "https://example.test",
+      fetchJsonImpl,
+      getChangedFilesImpl,
+      postRefreshCacheImpl,
+      prewarmPageCacheImpl,
+      prewarmBaseUrl: "https://kentcdodds.com",
+      log,
+      skipPublish: true,
+      skipPrewarm: false,
+    });
+
+    expect(prewarmPageCacheImpl).toHaveBeenCalledWith({
+      baseUrl: "https://kentcdodds.com",
+      paths: [
+        "/",
+        "/blog",
+        "/blog.json",
+        "/blog/rss.xml",
+        "/blog/some-post",
+        "/sitemap.xml",
+      ],
+      log,
+    });
+    expect(result).toEqual({
+      status: "refreshed",
+      attempts: 1,
+      contentPaths: ["blog/some-post/index.mdx"],
+      prewarm: prewarmResult,
+    });
   });
 
   test("returns refresh-failed after exhausting retries without throwing", async () => {

--- a/other/__tests__/refresh-changed-content.test.js
+++ b/other/__tests__/refresh-changed-content.test.js
@@ -59,6 +59,7 @@ describe("refreshChangedContent", () => {
     const postRefreshCacheImpl = vi.fn(async () => ({
       ok: true,
       pageCacheGeneration: "generation-2",
+      contentVersion: "content-v2",
     }));
     const log = createLogger();
 
@@ -182,6 +183,7 @@ describe("refreshChangedContent", () => {
     const postRefreshCacheImpl = vi.fn(async () => ({
       ok: true,
       pageCacheGeneration: "generation-2",
+      contentVersion: "content-v2",
     }));
     const prewarmResult = {
       attempted: 6,
@@ -216,6 +218,7 @@ describe("refreshChangedContent", () => {
         "/sitemap.xml",
       ],
       expectedGeneration: "generation-2",
+      expectedContentVersion: "content-v2",
       log,
     });
     expect(result).toEqual({
@@ -224,6 +227,37 @@ describe("refreshChangedContent", () => {
       contentPaths: ["blog/some-post/index.mdx"],
       prewarm: prewarmResult,
     });
+  });
+
+  test("does not prewarm without generation and content version guarantees", async () => {
+    const prewarmPageCacheImpl = vi.fn();
+    const log = createLogger();
+
+    const result = await refreshChangedContent({
+      currentCommitSha: "current-sha",
+      fetchJsonImpl: vi.fn(async () => ({ sha: "compare-sha" })),
+      getChangedFilesImpl: vi.fn(async () => [
+        {
+          changeType: "modified",
+          filename: "services/site/content/blog/some-post.mdx",
+        },
+      ]),
+      postRefreshCacheImpl: vi.fn(async () => ({ ok: true })),
+      prewarmPageCacheImpl,
+      log,
+      skipPublish: true,
+      skipPrewarm: false,
+    });
+
+    expect(result).toMatchObject({
+      status: "refreshed",
+      prewarm: { attempted: 0, warmed: 0, failed: 0, results: [] },
+    });
+    expect(prewarmPageCacheImpl).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("did not identify"),
+      { pageCacheGeneration: undefined, contentVersion: undefined },
+    );
   });
 
   test("returns refresh-failed after exhausting retries without throwing", async () => {

--- a/other/__tests__/utils.test.js
+++ b/other/__tests__/utils.test.js
@@ -1,0 +1,46 @@
+import { EventEmitter } from "node:events";
+import { expect, test } from "vitest";
+import { postRefreshCache } from "../utils.js";
+
+test("returns cache generation and content version response headers", async () => {
+  const response = Object.assign(new EventEmitter(), {
+    statusCode: 200,
+    headers: {
+      "x-page-cache-generation": "generation-2",
+      "x-content-version": "content-v2",
+    },
+  });
+  let handleResponse;
+  const request = {
+    on() {
+      return request;
+    },
+    setTimeout() {},
+    write() {},
+    end() {
+      queueMicrotask(() => {
+        handleResponse(response);
+        response.emit("data", '{"message":"refreshed"}');
+        response.emit("end");
+      });
+    },
+  };
+  const http = {
+    request(_options, callback) {
+      handleResponse = callback;
+      return request;
+    },
+  };
+
+  await expect(
+    postRefreshCache({
+      http,
+      postData: { commitSha: "current-sha" },
+      options: { hostname: "example.test" },
+    }),
+  ).resolves.toEqual({
+    message: "refreshed",
+    pageCacheGeneration: "generation-2",
+    contentVersion: "content-v2",
+  });
+});

--- a/other/content-prewarm-urls.ts
+++ b/other/content-prewarm-urls.ts
@@ -1,0 +1,93 @@
+const contentRoot = "services/site/content/";
+
+const blogSharedUrls = [
+  "/",
+  "/blog",
+  "/blog.json",
+  "/blog/rss.xml",
+  "/sitemap.xml",
+] as const;
+
+const dataUrlsByFilename: Record<string, ReadonlyArray<string>> = {
+  "credits.yml": ["/credits"],
+  "resume.yml": ["/resume"],
+  "talks.yml": ["/talks"],
+  "testimonials.yml": ["/testimonials"],
+};
+
+export type ContentChange = {
+  changeType: "added" | "deleted" | "modified" | "moved";
+  filename: string;
+  previousFilename?: string;
+};
+
+function getContentPath(filename: string) {
+  const normalized = filename.replaceAll("\\", "/");
+  if (!normalized.startsWith(contentRoot)) return null;
+  return normalized.slice(contentRoot.length);
+}
+
+function getDocumentUrl(contentPath: string) {
+  const parts = contentPath.split("/");
+  const [contentDir, firstEntry] = parts;
+  if (!firstEntry) return null;
+
+  if (contentDir === "blog") {
+    if (/^readme\.mdx?$/i.test(firstEntry)) return null;
+    if (parts.length === 2 && !/\.(mdx|md)$/i.test(firstEntry)) return null;
+    const slug = firstEntry.replace(/\.(mdx|md)$/i, "");
+    return slug ? `/blog/${slug}` : null;
+  }
+
+  if (
+    contentDir === "pages" &&
+    parts.length === 2 &&
+    /\.(mdx|md)$/i.test(firstEntry) &&
+    !/^readme\.mdx?$/i.test(firstEntry)
+  ) {
+    const slug = firstEntry.replace(/\.(mdx|md)$/i, "");
+    return slug ? `/${slug}` : null;
+  }
+
+  return null;
+}
+
+function addSharedUrls(urls: Set<string>, contentPath: string) {
+  if (contentPath.startsWith("blog/")) {
+    for (const url of blogSharedUrls) urls.add(url);
+    return;
+  }
+
+  if (contentPath.startsWith("pages/")) {
+    urls.add("/sitemap.xml");
+    return;
+  }
+
+  if (contentPath.startsWith("data/")) {
+    urls.add("/sitemap.xml");
+    const filename = contentPath.slice("data/".length);
+    for (const url of dataUrlsByFilename[filename] ?? []) urls.add(url);
+  }
+}
+
+export function getContentPrewarmUrls(changes: ReadonlyArray<ContentChange>) {
+  const urls = new Set<string>();
+
+  for (const change of changes) {
+    const contentPath = getContentPath(change.filename);
+    if (contentPath) {
+      addSharedUrls(urls, contentPath);
+      if (change.changeType !== "deleted") {
+        const documentUrl = getDocumentUrl(contentPath);
+        if (documentUrl) urls.add(documentUrl);
+      }
+    }
+
+    if (change.changeType === "moved" && change.previousFilename) {
+      const previousContentPath = getContentPath(change.previousFilename);
+      if (previousContentPath) addSharedUrls(urls, previousContentPath);
+    }
+  }
+
+  return Array.from(urls).sort();
+}

--- a/other/get-changed-files.js
+++ b/other/get-changed-files.js
@@ -94,26 +94,38 @@ const changeTypes = {
   R: "moved",
 };
 
+export function parseChangedFiles(gitOutput) {
+  const changes = [];
+  for (const line of gitOutput.split("\n").filter(Boolean)) {
+    const [status, firstFilename, secondFilename] = line.split("\t");
+    const change = status?.[0];
+    const changeType = changeTypes[change];
+    const filename = changeType === "moved" ? secondFilename : firstFilename;
+    if (!filename) {
+      console.error(`Unable to parse changed file: ${line}`);
+      continue;
+    }
+    if (changeType) {
+      changes.push({
+        changeType,
+        filename,
+        ...(changeType === "moved" && firstFilename
+          ? { previousFilename: firstFilename }
+          : {}),
+      });
+    } else {
+      console.error(`Unknown change type: ${change} ${filename}`);
+    }
+  }
+  return changes;
+}
+
 export async function getChangedFiles(currentCommitSha, compareCommitSha) {
   try {
-    const lineParser = /^(?<change>\w).*?\s+(?<filename>.+$)/;
     const gitOutput = execSync(
       `git diff --name-status ${currentCommitSha} ${compareCommitSha}`,
     ).toString();
-    const changedFiles = gitOutput
-      .split("\n")
-      .map((line) => line.match(lineParser)?.groups)
-      .filter(Boolean);
-    const changes = [];
-    for (const { change, filename } of changedFiles) {
-      const changeType = changeTypes[change];
-      if (changeType) {
-        changes.push({ changeType: changeTypes[change], filename });
-      } else {
-        console.error(`Unknown change type: ${change} ${filename}`);
-      }
-    }
-    return changes;
+    return parseChangedFiles(gitOutput);
   } catch (error) {
     console.error(`Something went wrong trying to get changed files.`, error);
     return null;

--- a/other/prewarm-page-cache.ts
+++ b/other/prewarm-page-cache.ts
@@ -5,6 +5,7 @@ export type PageCachePrewarmResult = {
   status?: number;
   edgeCache?: string;
   generation?: string;
+  contentVersion?: string;
   stored?: boolean;
   error?: string;
 };
@@ -21,11 +22,13 @@ async function requestPage({
   url,
   fetchImpl,
   expectedGeneration,
+  expectedContentVersion,
   timeoutMs,
 }: {
   url: string;
   fetchImpl: typeof fetch;
   expectedGeneration?: string;
+  expectedContentVersion?: string;
   timeoutMs: number;
 }) {
   const controller = new AbortController();
@@ -37,6 +40,11 @@ async function requestPage({
         "user-agent": "kcd-content-refresh-prewarm",
         ...(expectedGeneration
           ? { "x-page-cache-prewarm": expectedGeneration }
+          : {}),
+        ...(expectedContentVersion
+          ? {
+              "x-page-cache-prewarm-content-version": expectedContentVersion,
+            }
           : {}),
       },
       redirect: "manual",
@@ -53,6 +61,7 @@ export async function prewarmPageCache({
   baseUrl,
   paths,
   expectedGeneration,
+  expectedContentVersion,
   fetchImpl = fetch,
   log = console,
   maxAttempts = 75,
@@ -63,6 +72,7 @@ export async function prewarmPageCache({
   baseUrl: string;
   paths: ReadonlyArray<string>;
   expectedGeneration?: string;
+  expectedContentVersion?: string;
   fetchImpl?: typeof fetch;
   log?: Pick<typeof console, "log" | "warn">;
   maxAttempts?: number;
@@ -86,34 +96,53 @@ export async function prewarmPageCache({
           url,
           fetchImpl,
           expectedGeneration,
+          expectedContentVersion,
           timeoutMs,
         });
         const edgeCache = response.headers.get("X-Edge-Cache") ?? undefined;
         const generation =
           response.headers.get("X-Page-Cache-Generation") ?? undefined;
+        const contentVersion =
+          response.headers.get("X-Content-Version") ?? undefined;
         const storedHeader = response.headers.get("X-Page-Cache-Stored");
         const stored =
           storedHeader === null ? undefined : storedHeader === "true";
         const generationMatches =
           !expectedGeneration || generation === expectedGeneration;
+        const contentVersionMatches =
+          !expectedContentVersion || contentVersion === expectedContentVersion;
         result = {
           url,
           ok:
             response.status === 200 &&
             generationMatches &&
+            contentVersionMatches &&
             (edgeCache === "HIT" || edgeCache === "STALE" || stored === true),
           attempts: attempt,
           status: response.status,
           edgeCache,
           ...(generation ? { generation } : {}),
+          ...(contentVersion ? { contentVersion } : {}),
           ...(stored !== undefined ? { stored } : {}),
         };
 
         if (result.ok) break;
         const waitingForGeneration =
           Boolean(expectedGeneration) && !generationMatches;
+        const waitingForContentVersion =
+          Boolean(expectedContentVersion) && !contentVersionMatches;
+        if (
+          generationMatches &&
+          contentVersionMatches &&
+          edgeCache === "MISS" &&
+          stored === false
+        ) {
+          result.error = "Worker rendered the page but could not store it";
+          break;
+        }
         if (
           !waitingForGeneration &&
+          !waitingForContentVersion &&
           response.status < 500 &&
           response.status !== 429 &&
           edgeCache !== "MISS"
@@ -139,6 +168,7 @@ export async function prewarmPageCache({
         attempts: result.attempts,
         edgeCache: result.edgeCache,
         generation: result.generation,
+        contentVersion: result.contentVersion,
         stored: result.stored,
       });
     } else {

--- a/other/prewarm-page-cache.ts
+++ b/other/prewarm-page-cache.ts
@@ -1,0 +1,127 @@
+export type PageCachePrewarmResult = {
+  url: string;
+  ok: boolean;
+  attempts: number;
+  status?: number;
+  edgeCache?: string;
+  error?: string;
+};
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sleep(durationMs: number) {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function requestPage({
+  url,
+  fetchImpl,
+  timeoutMs,
+}: {
+  url: string;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: "text/html",
+        "user-agent": "kcd-content-refresh-prewarm",
+      },
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    await response.arrayBuffer();
+    return response;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function prewarmPageCache({
+  baseUrl,
+  paths,
+  fetchImpl = fetch,
+  log = console,
+  maxAttempts = 6,
+  pollDelayMs = 1_000,
+  timeoutMs = 15_000,
+  sleepImpl = sleep,
+}: {
+  baseUrl: string;
+  paths: ReadonlyArray<string>;
+  fetchImpl?: typeof fetch;
+  log?: Pick<typeof console, "log" | "warn">;
+  maxAttempts?: number;
+  pollDelayMs?: number;
+  timeoutMs?: number;
+  sleepImpl?: (durationMs: number) => Promise<unknown>;
+}) {
+  const results: Array<PageCachePrewarmResult> = [];
+
+  for (const path of paths) {
+    const url = new URL(path, baseUrl).toString();
+    let result: PageCachePrewarmResult = {
+      url,
+      ok: false,
+      attempts: 0,
+    };
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const response = await requestPage({ url, fetchImpl, timeoutMs });
+        const edgeCache = response.headers.get("X-Edge-Cache") ?? undefined;
+        result = {
+          url,
+          ok:
+            response.status === 200 &&
+            (edgeCache === "HIT" || edgeCache === "STALE"),
+          attempts: attempt,
+          status: response.status,
+          edgeCache,
+        };
+
+        if (result.ok) break;
+        if (
+          response.status < 500 &&
+          response.status !== 429 &&
+          edgeCache !== "MISS"
+        ) {
+          result.error = `Page is not cacheable (status ${response.status}, X-Edge-Cache ${edgeCache ?? "missing"})`;
+          break;
+        }
+      } catch (error) {
+        result = {
+          url,
+          ok: false,
+          attempts: attempt,
+          error: getErrorMessage(error),
+        };
+      }
+
+      if (attempt < maxAttempts) await sleepImpl(pollDelayMs);
+    }
+
+    if (result.ok) {
+      log.log("Page cache prewarmed.", {
+        url: result.url,
+        attempts: result.attempts,
+        edgeCache: result.edgeCache,
+      });
+    } else {
+      log.warn("Page cache prewarm failed.", result);
+    }
+    results.push(result);
+  }
+
+  return {
+    attempted: results.length,
+    warmed: results.filter((result) => result.ok).length,
+    failed: results.filter((result) => !result.ok).length,
+    results,
+  };
+}

--- a/other/prewarm-page-cache.ts
+++ b/other/prewarm-page-cache.ts
@@ -4,6 +4,8 @@ export type PageCachePrewarmResult = {
   attempts: number;
   status?: number;
   edgeCache?: string;
+  generation?: string;
+  stored?: boolean;
   error?: string;
 };
 
@@ -18,10 +20,12 @@ function sleep(durationMs: number) {
 async function requestPage({
   url,
   fetchImpl,
+  expectedGeneration,
   timeoutMs,
 }: {
   url: string;
   fetchImpl: typeof fetch;
+  expectedGeneration?: string;
   timeoutMs: number;
 }) {
   const controller = new AbortController();
@@ -31,6 +35,9 @@ async function requestPage({
       headers: {
         accept: "text/html",
         "user-agent": "kcd-content-refresh-prewarm",
+        ...(expectedGeneration
+          ? { "x-page-cache-prewarm": expectedGeneration }
+          : {}),
       },
       redirect: "manual",
       signal: controller.signal,
@@ -45,15 +52,17 @@ async function requestPage({
 export async function prewarmPageCache({
   baseUrl,
   paths,
+  expectedGeneration,
   fetchImpl = fetch,
   log = console,
-  maxAttempts = 6,
+  maxAttempts = 75,
   pollDelayMs = 1_000,
   timeoutMs = 15_000,
   sleepImpl = sleep,
 }: {
   baseUrl: string;
   paths: ReadonlyArray<string>;
+  expectedGeneration?: string;
   fetchImpl?: typeof fetch;
   log?: Pick<typeof console, "log" | "warn">;
   maxAttempts?: number;
@@ -73,20 +82,38 @@ export async function prewarmPageCache({
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        const response = await requestPage({ url, fetchImpl, timeoutMs });
+        const response = await requestPage({
+          url,
+          fetchImpl,
+          expectedGeneration,
+          timeoutMs,
+        });
         const edgeCache = response.headers.get("X-Edge-Cache") ?? undefined;
+        const generation =
+          response.headers.get("X-Page-Cache-Generation") ?? undefined;
+        const storedHeader = response.headers.get("X-Page-Cache-Stored");
+        const stored =
+          storedHeader === null ? undefined : storedHeader === "true";
+        const generationMatches =
+          !expectedGeneration || generation === expectedGeneration;
         result = {
           url,
           ok:
             response.status === 200 &&
-            (edgeCache === "HIT" || edgeCache === "STALE"),
+            generationMatches &&
+            (edgeCache === "HIT" || edgeCache === "STALE" || stored === true),
           attempts: attempt,
           status: response.status,
           edgeCache,
+          ...(generation ? { generation } : {}),
+          ...(stored !== undefined ? { stored } : {}),
         };
 
         if (result.ok) break;
+        const waitingForGeneration =
+          Boolean(expectedGeneration) && !generationMatches;
         if (
+          !waitingForGeneration &&
           response.status < 500 &&
           response.status !== 429 &&
           edgeCache !== "MISS"
@@ -111,6 +138,8 @@ export async function prewarmPageCache({
         url: result.url,
         attempts: result.attempts,
         edgeCache: result.edgeCache,
+        generation: result.generation,
+        stored: result.stored,
       });
     } else {
       log.warn("Page cache prewarm failed.", result);

--- a/other/refresh-changed-content.ts
+++ b/other/refresh-changed-content.ts
@@ -2,7 +2,9 @@
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { publishViaEndpoint as publishViaEndpointImpl } from "../services/site-worker/scripts/publish-artifacts-lib.mjs";
+import { getContentPrewarmUrls } from "./content-prewarm-urls.ts";
 import { getChangedFiles, fetchJson } from "./get-changed-files.js";
+import { prewarmPageCache } from "./prewarm-page-cache.ts";
 import { resolveCompareCommitSha } from "./resolve-compare-commit-sha.ts";
 import { postRefreshCache } from "./utils.js";
 
@@ -133,10 +135,13 @@ export async function refreshChangedContent({
   getChangedFilesImpl = getChangedFiles,
   postRefreshCacheImpl = postRefreshCache,
   publishArtifactsImpl = publishArtifacts,
+  prewarmPageCacheImpl = prewarmPageCache,
+  prewarmBaseUrl = baseUrl,
   log = console,
   maxRefreshAttempts = defaultRefreshRetryOptions.maxAttempts,
   retryDelayMs = defaultRefreshRetryOptions.baseDelayMs,
   skipPublish = process.env.SKIP_ARTIFACT_PUBLISH === "true",
+  skipPrewarm = skipPublish || process.env.SKIP_PAGE_CACHE_PREWARM === "true",
 }: {
   currentCommitSha?: string;
   baseUrl?: string;
@@ -146,10 +151,13 @@ export async function refreshChangedContent({
   getChangedFilesImpl?: typeof getChangedFiles;
   postRefreshCacheImpl?: typeof postRefreshCache;
   publishArtifactsImpl?: typeof publishArtifacts;
+  prewarmPageCacheImpl?: typeof prewarmPageCache;
+  prewarmBaseUrl?: string;
   log?: Pick<typeof console, "log" | "warn" | "error">;
   maxRefreshAttempts?: number;
   retryDelayMs?: number;
   skipPublish?: boolean;
+  skipPrewarm?: boolean;
 } = {}) {
   if (!currentCommitSha) {
     throw new Error("currentCommitSha is required");
@@ -167,9 +175,12 @@ export async function refreshChangedContent({
 
   const changedFiles =
     (await getChangedFilesImpl(currentCommitSha, compareSha)) ?? [];
-  const contentPaths = changedFiles
-    .filter((f) => f.filename.startsWith("services/site/content/"))
-    .map((f) => f.filename.replace(/^services\/site\/content\//, ""));
+  const contentChanges = changedFiles.filter((file) =>
+    file.filename.startsWith("services/site/content/"),
+  );
+  const contentPaths = contentChanges.map((f) =>
+    f.filename.replace(/^services\/site\/content\//, ""),
+  );
   if (!contentPaths.length) {
     log.log("🆗 Not refreshing changed content because no content changed.");
     return { status: "no-content-changes" as const };
@@ -201,14 +212,25 @@ export async function refreshChangedContent({
   });
 
   if (refreshResult.ok) {
+    const prewarmPaths = getContentPrewarmUrls(contentChanges);
+    const prewarm =
+      skipPrewarm || prewarmPaths.length === 0
+        ? { attempted: 0, warmed: 0, failed: 0, results: [] }
+        : await prewarmPageCacheImpl({
+            baseUrl: prewarmBaseUrl,
+            paths: prewarmPaths,
+            log,
+          });
     log.log(`Content refresh finished.`, {
       response: refreshResult.response,
       attempts: refreshResult.attempts,
+      prewarm,
     });
     return {
       status: "refreshed" as const,
       attempts: refreshResult.attempts,
       contentPaths,
+      prewarm,
     };
   }
 

--- a/other/refresh-changed-content.ts
+++ b/other/refresh-changed-content.ts
@@ -212,6 +212,10 @@ export async function refreshChangedContent({
   });
 
   if (refreshResult.ok) {
+    const pageCacheGeneration =
+      typeof refreshResult.response?.pageCacheGeneration === "string"
+        ? refreshResult.response.pageCacheGeneration
+        : undefined;
     const prewarmPaths = getContentPrewarmUrls(contentChanges);
     const prewarm =
       skipPrewarm || prewarmPaths.length === 0
@@ -219,6 +223,9 @@ export async function refreshChangedContent({
         : await prewarmPageCacheImpl({
             baseUrl: prewarmBaseUrl,
             paths: prewarmPaths,
+            ...(pageCacheGeneration
+              ? { expectedGeneration: pageCacheGeneration }
+              : {}),
             log,
           });
     log.log(`Content refresh finished.`, {

--- a/other/refresh-changed-content.ts
+++ b/other/refresh-changed-content.ts
@@ -216,18 +216,33 @@ export async function refreshChangedContent({
       typeof refreshResult.response?.pageCacheGeneration === "string"
         ? refreshResult.response.pageCacheGeneration
         : undefined;
+    const contentVersion =
+      typeof refreshResult.response?.contentVersion === "string"
+        ? refreshResult.response.contentVersion
+        : undefined;
     const prewarmPaths = getContentPrewarmUrls(contentChanges);
-    const prewarm =
-      skipPrewarm || prewarmPaths.length === 0
-        ? { attempted: 0, warmed: 0, failed: 0, results: [] }
-        : await prewarmPageCacheImpl({
-            baseUrl: prewarmBaseUrl,
-            paths: prewarmPaths,
-            ...(pageCacheGeneration
-              ? { expectedGeneration: pageCacheGeneration }
-              : {}),
-            log,
-          });
+    let prewarm: Awaited<ReturnType<typeof prewarmPageCache>> = {
+      attempted: 0,
+      warmed: 0,
+      failed: 0,
+      results: [],
+    };
+    if (!skipPrewarm && prewarmPaths.length > 0) {
+      if (!pageCacheGeneration || !contentVersion) {
+        log.warn(
+          "Skipping page cache prewarm because the refresh response did not identify its cache generation and content version.",
+          { pageCacheGeneration, contentVersion },
+        );
+      } else {
+        prewarm = await prewarmPageCacheImpl({
+          baseUrl: prewarmBaseUrl,
+          paths: prewarmPaths,
+          expectedGeneration: pageCacheGeneration,
+          expectedContentVersion: contentVersion,
+          log,
+        });
+      }
+    }
     log.log(`Content refresh finished.`, {
       response: refreshResult.response,
       attempts: refreshResult.attempts,

--- a/other/utils.js
+++ b/other/utils.js
@@ -72,10 +72,14 @@ export async function postRefreshCache({
               }
               const pageCacheGeneration =
                 res.headers["x-page-cache-generation"];
+              const contentVersion = res.headers["x-content-version"];
               resolve({
                 ...parsed,
                 ...(typeof pageCacheGeneration === "string"
                   ? { pageCacheGeneration }
+                  : {}),
+                ...(typeof contentVersion === "string"
+                  ? { contentVersion }
                   : {}),
               });
             } catch {

--- a/other/utils.js
+++ b/other/utils.js
@@ -1,101 +1,110 @@
-const defaultTimeoutMs = 30_000
+const defaultTimeoutMs = 30_000;
 
 function getSiteHostname() {
-	if (process.env.WORKER_URL) {
-		return new URL(process.env.WORKER_URL).hostname
-	}
-	if (process.env.SITE_URL) {
-		return new URL(process.env.SITE_URL).hostname
-	}
-	return 'kentcdodds-com.kentcdodds.workers.dev'
+  if (process.env.WORKER_URL) {
+    return new URL(process.env.WORKER_URL).hostname;
+  }
+  if (process.env.SITE_URL) {
+    return new URL(process.env.SITE_URL).hostname;
+  }
+  return "kentcdodds-com.kentcdodds.workers.dev";
 }
 
 function withStatusMessage(statusCode, body) {
-	const message =
-		typeof body === 'string' && body.trim()
-			? body.trim()
-			: '<empty response body>'
-	return new Error(
-		`refresh-cache request failed with status ${statusCode}: ${message}`,
-	)
+  const message =
+    typeof body === "string" && body.trim()
+      ? body.trim()
+      : "<empty response body>";
+  return new Error(
+    `refresh-cache request failed with status ${statusCode}: ${message}`,
+  );
 }
 
 // try to keep this dep-free so we don't have to install deps
 export async function postRefreshCache({
-	http,
-	postData,
-	options: {
-		headers: headersOverrides,
-		timeout: timeoutOverride,
-		...optionsOverrides
-	} = {},
+  http,
+  postData,
+  options: {
+    headers: headersOverrides,
+    timeout: timeoutOverride,
+    ...optionsOverrides
+  } = {},
 }) {
-	if (!http) {
-		http = await import('https')
-	}
-	return new Promise((resolve, reject) => {
-		try {
-			const postDataString = JSON.stringify(postData)
-			const options = {
-				hostname: getSiteHostname(),
-				port: 443,
-				path: `/action/refresh-cache`,
-				method: 'POST',
-				headers: {
-					auth: process.env.REFRESH_CACHE_SECRET,
-					'Content-Type': 'application/json',
-					'Content-Length': Buffer.byteLength(postDataString),
-					...headersOverrides,
-				},
-				...optionsOverrides,
-			}
+  if (!http) {
+    http = await import("https");
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      const postDataString = JSON.stringify(postData);
+      const options = {
+        hostname: getSiteHostname(),
+        port: 443,
+        path: `/action/refresh-cache`,
+        method: "POST",
+        headers: {
+          auth: process.env.REFRESH_CACHE_SECRET,
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postDataString),
+          ...headersOverrides,
+        },
+        ...optionsOverrides,
+      };
 
-			const req = http
-				.request(options, (res) => {
-					let data = ''
-					res.on('data', (d) => {
-						data += d
-					})
+      const req = http
+        .request(options, (res) => {
+          let data = "";
+          res.on("data", (d) => {
+            data += d;
+          });
 
-					res.on('end', () => {
-						const statusCode = Number(res.statusCode ?? 500)
-						const isOk = statusCode >= 200 && statusCode < 300
-						try {
-							const parsed = JSON.parse(data)
-							if (!isOk) {
-								reject(
-									new Error(
-										`refresh-cache request failed with status ${statusCode}: ${JSON.stringify(parsed)}`,
-									),
-								)
-								return
-							}
-							resolve(parsed)
-						} catch {
-							if (!isOk) {
-								reject(withStatusMessage(statusCode, data))
-								return
-							}
-							reject(
-								new Error(
-									`refresh-cache request returned non-JSON success response: ${data}`,
-								),
-							)
-						}
-					})
-				})
-				.on('error', reject)
-			const timeoutMs =
-				typeof timeoutOverride === 'number' ? timeoutOverride : defaultTimeoutMs
-			req.setTimeout(timeoutMs, () => {
-				req.destroy(
-					new Error(`refresh-cache request timed out after ${timeoutMs}ms`),
-				)
-			})
-			req.write(postDataString)
-			req.end()
-		} catch (error) {
-			reject(error)
-		}
-	})
+          res.on("end", () => {
+            const statusCode = Number(res.statusCode ?? 500);
+            const isOk = statusCode >= 200 && statusCode < 300;
+            try {
+              const parsed = JSON.parse(data);
+              if (!isOk) {
+                reject(
+                  new Error(
+                    `refresh-cache request failed with status ${statusCode}: ${JSON.stringify(parsed)}`,
+                  ),
+                );
+                return;
+              }
+              const pageCacheGeneration =
+                res.headers["x-page-cache-generation"];
+              resolve({
+                ...parsed,
+                ...(typeof pageCacheGeneration === "string"
+                  ? { pageCacheGeneration }
+                  : {}),
+              });
+            } catch {
+              if (!isOk) {
+                reject(withStatusMessage(statusCode, data));
+                return;
+              }
+              reject(
+                new Error(
+                  `refresh-cache request returned non-JSON success response: ${data}`,
+                ),
+              );
+            }
+          });
+        })
+        .on("error", reject);
+      const timeoutMs =
+        typeof timeoutOverride === "number"
+          ? timeoutOverride
+          : defaultTimeoutMs;
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(
+          new Error(`refresh-cache request timed out after ${timeoutMs}ms`),
+        );
+      });
+      req.write(postDataString);
+      req.end();
+    } catch (error) {
+      reject(error);
+    }
+  });
 }

--- a/services/site-worker/src/index.ts
+++ b/services/site-worker/src/index.ts
@@ -32,6 +32,7 @@ import {
 	clearPageCacheGenerationCache,
 	handlePageCacheRequest,
 	PAGE_CACHE_GENERATION_HEADER,
+	PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER,
 } from './page-cache.ts'
 import { serveStaticAsset } from './static-assets.ts'
 import { handleMediaRequest } from './media.ts'
@@ -66,6 +67,7 @@ function getStringEnvBindings(env: ParentWorkerEnv) {
 }
 
 const ARTIFACT_PUBLISH_PATH = '/resources/mdx-artifacts'
+const CONTENT_VERSION_HEADER = 'X-Content-Version'
 
 async function handlePublishArtifacts(request: Request, env: ParentWorkerEnv) {
 	// Publishing MDX artifacts is effectively a code deploy (the bundles run
@@ -182,7 +184,11 @@ async function handleDynamicRequest(
 	ctx: ParentExecutionContext,
 ) {
 	const parentStartedAt = performance.now()
-	const bypassManifestCache = shouldBypassManifestCache(request)
+	const expectedContentVersion = request.headers.get(
+		PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER,
+	)
+	const bypassManifestCache =
+		shouldBypassManifestCache(request) || Boolean(expectedContentVersion)
 	if (bypassManifestCache) {
 		clearManifestCache()
 		clearArtifactBundleCache()
@@ -195,6 +201,12 @@ async function handleDynamicRequest(
 	if (!manifest) {
 		return unprovisionedResponse({
 			missing: 'CONTENT_KV mdx-manifest:current',
+		})
+	}
+	if (expectedContentVersion && manifest.version !== expectedContentVersion) {
+		return new Response(null, {
+			status: 409,
+			headers: { [CONTENT_VERSION_HEADER]: manifest.version },
 		})
 	}
 
@@ -272,6 +284,7 @@ async function handleDynamicRequest(
 		moduleMapCache: hadModuleMapCache ? 1 : 0,
 	})
 	const headers = new Headers(response.headers)
+	headers.set(CONTENT_VERSION_HEADER, manifest.version)
 	headers.set(
 		'X-Cold-Start-Timing',
 		mergeColdStartTimingHeaders(

--- a/services/site-worker/src/index.ts
+++ b/services/site-worker/src/index.ts
@@ -31,6 +31,7 @@ import {
 	bumpPageCacheGeneration,
 	clearPageCacheGenerationCache,
 	handlePageCacheRequest,
+	PAGE_CACHE_GENERATION_HEADER,
 } from './page-cache.ts'
 import { serveStaticAsset } from './static-assets.ts'
 import { handleMediaRequest } from './media.ts'
@@ -124,9 +125,14 @@ async function handlePublishArtifacts(request: Request, env: ParentWorkerEnv) {
 	await env.CONTENT_KV.put('mdx-manifest:current', manifest)
 	clearManifestCache()
 	clearArtifactBundleCache()
-	await bumpPageCacheGeneration(env.CONTENT_KV)
+	const pageCacheGeneration = await bumpPageCacheGeneration(env.CONTENT_KV)
 
-	return Response.json({ ok: true, version: bundle.version, r2Key })
+	return Response.json({
+		ok: true,
+		version: bundle.version,
+		r2Key,
+		pageCacheGeneration,
+	})
 }
 
 async function handleMetaRequest(env: ParentWorkerEnv) {
@@ -338,6 +344,7 @@ export default {
 			if (assetResponse) return assetResponse
 		}
 
+		let pageCacheGeneration: string | undefined
 		if (
 			url.pathname === '/action/refresh-cache' &&
 			request.method === 'POST' &&
@@ -348,13 +355,29 @@ export default {
 				env.REFRESH_CACHE_SECRET,
 			)
 		) {
-			await bumpPageCacheGeneration(env.CONTENT_KV)
+			pageCacheGeneration = await bumpPageCacheGeneration(env.CONTENT_KV)
 			clearPageCacheGenerationCache()
 		}
 
-		return handlePageCacheRequest(request, env, ctx, (dynamicRequest) =>
-			handleDynamicRequest(dynamicRequest, env, ctx as ParentExecutionContext),
+		const response = await handlePageCacheRequest(
+			request,
+			env,
+			ctx,
+			(dynamicRequest) =>
+				handleDynamicRequest(
+					dynamicRequest,
+					env,
+					ctx as ParentExecutionContext,
+				),
 		)
+		if (!pageCacheGeneration) return response
+		const headers = new Headers(response.headers)
+		headers.set(PAGE_CACHE_GENERATION_HEADER, pageCacheGeneration)
+		return new Response(response.body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		})
 	},
 
 	async scheduled(

--- a/services/site-worker/src/page-cache.test.ts
+++ b/services/site-worker/src/page-cache.test.ts
@@ -13,7 +13,10 @@ import {
 	isPageCacheServeEligible,
 	isPageCacheStoreEligible,
 	PAGE_CACHE_FRESH_TTL_SEC,
+	PAGE_CACHE_GENERATION_HEADER,
 	PAGE_CACHE_GENERATION_MEMORY_TTL_MS,
+	PAGE_CACHE_PREWARM_HEADER,
+	PAGE_CACHE_STORED_HEADER,
 	readPageCacheEntry,
 	requestPrefersMarkdown,
 	rewriteCachedEntryNonce,
@@ -211,7 +214,9 @@ describe('generation cache', () => {
 		await expect(getPageCacheGeneration(contentKv)).resolves.toBe('7')
 		expect(get).toHaveBeenCalledTimes(1)
 
-		vi.setSystemTime(new Date(now.getTime() + PAGE_CACHE_GENERATION_MEMORY_TTL_MS + 1))
+		vi.setSystemTime(
+			new Date(now.getTime() + PAGE_CACHE_GENERATION_MEMORY_TTL_MS + 1),
+		)
 		await expect(getPageCacheGeneration(contentKv)).resolves.toBe('7')
 		expect(get).toHaveBeenCalledTimes(2)
 	})
@@ -219,7 +224,8 @@ describe('generation cache', () => {
 	test('bump updates memory cache immediately', async () => {
 		const put = vi.fn().mockResolvedValue(undefined)
 		const contentKv = { put }
-		await bumpPageCacheGeneration(contentKv)
+		const generation = await bumpPageCacheGeneration(contentKv)
+		expect(generation).toMatch(/^\d+$/)
 		const get = vi.fn()
 		await expect(getPageCacheGeneration({ get })).resolves.toMatch(/^\d+$/)
 		expect(get).not.toHaveBeenCalled()
@@ -251,8 +257,14 @@ describe('SWR state machine', () => {
 			.mockResolvedValue(null)
 		const kvPut = vi.fn().mockResolvedValue(undefined)
 		const env = makeEnv({
-			SITE_CACHE_KV: { get: kvGet, put: kvPut } as unknown as ParentWorkerEnv['SITE_CACHE_KV'],
-			CONTENT_KV: { get: vi.fn().mockResolvedValue('1'), put: vi.fn() } as unknown as ParentWorkerEnv['CONTENT_KV'],
+			SITE_CACHE_KV: {
+				get: kvGet,
+				put: kvPut,
+			} as unknown as ParentWorkerEnv['SITE_CACHE_KV'],
+			CONTENT_KV: {
+				get: vi.fn().mockResolvedValue('1'),
+				put: vi.fn(),
+			} as unknown as ParentWorkerEnv['CONTENT_KV'],
 		})
 
 		const fetchDynamic = vi.fn().mockResolvedValue(
@@ -270,6 +282,7 @@ describe('SWR state machine', () => {
 			fetchDynamic,
 		)
 		expect(hit.headers.get('X-Edge-Cache')).toBe('HIT')
+		expect(hit.headers.get(PAGE_CACHE_GENERATION_HEADER)).toBe('1')
 		expect(await hit.text()).toBe('<html>fresh</html>')
 		expect(fetchDynamic).not.toHaveBeenCalled()
 
@@ -290,6 +303,62 @@ describe('SWR state machine', () => {
 		)
 		expect(miss.headers.get('X-Edge-Cache')).toBe('MISS')
 		expect(fetchDynamic).toHaveBeenCalled()
+	})
+
+	test('prewarm waits for its generation and confirms the cache write', async () => {
+		const kvPut = vi.fn().mockResolvedValue(undefined)
+		const generationGet = vi.fn().mockResolvedValue('current-generation')
+		const env = makeEnv({
+			SITE_CACHE_KV: {
+				get: vi.fn().mockResolvedValue(null),
+				put: kvPut,
+			} as unknown as ParentWorkerEnv['SITE_CACHE_KV'],
+			CONTENT_KV: {
+				get: generationGet,
+				put: vi.fn(),
+			} as unknown as ParentWorkerEnv['CONTENT_KV'],
+		})
+		const fetchDynamic = vi.fn().mockResolvedValue(
+			new Response('<html>current</html>', {
+				status: 200,
+				headers: { 'content-type': 'text/html' },
+			}),
+		)
+		const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext
+
+		const staleGeneration = await handlePageCacheRequest(
+			new Request('https://example.com/blog/example', {
+				headers: { [PAGE_CACHE_PREWARM_HEADER]: 'next-generation' },
+			}),
+			env,
+			ctx,
+			fetchDynamic,
+		)
+		expect(staleGeneration.status).toBe(409)
+		expect(staleGeneration.headers.get(PAGE_CACHE_GENERATION_HEADER)).toBe(
+			'current-generation',
+		)
+		expect(fetchDynamic).not.toHaveBeenCalled()
+		expect(kvPut).not.toHaveBeenCalled()
+
+		clearPageCacheGenerationCache()
+		generationGet.mockResolvedValue('next-generation')
+		const warmed = await handlePageCacheRequest(
+			new Request('https://example.com/blog/example', {
+				headers: { [PAGE_CACHE_PREWARM_HEADER]: 'next-generation' },
+			}),
+			env,
+			ctx,
+			fetchDynamic,
+		)
+		expect(warmed.status).toBe(200)
+		expect(warmed.headers.get('X-Edge-Cache')).toBe('MISS')
+		expect(warmed.headers.get(PAGE_CACHE_GENERATION_HEADER)).toBe(
+			'next-generation',
+		)
+		expect(warmed.headers.get(PAGE_CACHE_STORED_HEADER)).toBe('true')
+		expect(kvPut).toHaveBeenCalledTimes(1)
+		expect(ctx.waitUntil).not.toHaveBeenCalled()
 	})
 
 	test('client-id request on /blog bypasses the shared cache entirely', async () => {
@@ -414,7 +483,8 @@ describe('SWR state machine', () => {
 	test('fill request strips cookies except theme', async () => {
 		const request = new Request('https://example.com/blog', {
 			headers: {
-				cookie: 'KCD_client_id=abc; en_theme=dark; kcd_d1_bookmark=v1-abc; other=1',
+				cookie:
+					'KCD_client_id=abc; en_theme=dark; kcd_d1_bookmark=v1-abc; other=1',
 			},
 		})
 		const fill = buildPageCacheFillRequest(request)
@@ -533,7 +603,9 @@ describe('SWR state machine', () => {
 		await Promise.all(waitUntilPromises)
 
 		expect(kvPut).toHaveBeenCalledTimes(1)
-		const stored = JSON.parse(String(kvPut.mock.calls[0]?.[1])) as PageCacheEntry
+		const stored = JSON.parse(
+			String(kvPut.mock.calls[0]?.[1]),
+		) as PageCacheEntry
 		const storedHeaderNames = stored.headers.map(([name]) => name.toLowerCase())
 		expect(storedHeaderNames).not.toContain('x-cache-stats')
 		expect(storedHeaderNames).not.toContain('x-d1-stats')

--- a/services/site-worker/src/page-cache.test.ts
+++ b/services/site-worker/src/page-cache.test.ts
@@ -331,10 +331,27 @@ describe('SWR state machine', () => {
 		const fetchDynamic = vi.fn().mockResolvedValue(
 			new Response('<html>current</html>', {
 				status: 200,
-				headers: { 'content-type': 'text/html' },
+				headers: {
+					'content-type': 'text/html',
+					'X-Content-Version': 'content-v2',
+				},
 			}),
 		)
 		const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext
+
+		const incompletePrewarm = await handlePageCacheRequest(
+			new Request('https://example.com/blog/example', {
+				headers: {
+					[PAGE_CACHE_PREWARM_HEADER]: 'current-generation',
+				},
+			}),
+			env,
+			ctx,
+			fetchDynamic,
+		)
+		expect(incompletePrewarm.status).toBe(400)
+		expect(fetchDynamic).not.toHaveBeenCalled()
+		expect(kvPut).not.toHaveBeenCalled()
 
 		const staleGeneration = await handlePageCacheRequest(
 			new Request('https://example.com/blog/example', {

--- a/services/site-worker/src/page-cache.test.ts
+++ b/services/site-worker/src/page-cache.test.ts
@@ -15,6 +15,7 @@ import {
 	PAGE_CACHE_FRESH_TTL_SEC,
 	PAGE_CACHE_GENERATION_HEADER,
 	PAGE_CACHE_GENERATION_MEMORY_TTL_MS,
+	PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER,
 	PAGE_CACHE_PREWARM_HEADER,
 	PAGE_CACHE_STORED_HEADER,
 	readPageCacheEntry,
@@ -307,10 +308,19 @@ describe('SWR state machine', () => {
 
 	test('prewarm waits for its generation and confirms the cache write', async () => {
 		const kvPut = vi.fn().mockResolvedValue(undefined)
+		const kvGet = vi.fn().mockResolvedValue(
+			JSON.stringify({
+				body: '<html>stale content</html>',
+				status: 200,
+				headers: [['content-type', 'text/html']],
+				nonce: '',
+				storedAt: Date.now(),
+			} satisfies PageCacheEntry),
+		)
 		const generationGet = vi.fn().mockResolvedValue('current-generation')
 		const env = makeEnv({
 			SITE_CACHE_KV: {
-				get: vi.fn().mockResolvedValue(null),
+				get: kvGet,
 				put: kvPut,
 			} as unknown as ParentWorkerEnv['SITE_CACHE_KV'],
 			CONTENT_KV: {
@@ -328,7 +338,10 @@ describe('SWR state machine', () => {
 
 		const staleGeneration = await handlePageCacheRequest(
 			new Request('https://example.com/blog/example', {
-				headers: { [PAGE_CACHE_PREWARM_HEADER]: 'next-generation' },
+				headers: {
+					[PAGE_CACHE_PREWARM_HEADER]: 'next-generation',
+					[PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER]: 'content-v2',
+				},
 			}),
 			env,
 			ctx,
@@ -345,7 +358,10 @@ describe('SWR state machine', () => {
 		generationGet.mockResolvedValue('next-generation')
 		const warmed = await handlePageCacheRequest(
 			new Request('https://example.com/blog/example', {
-				headers: { [PAGE_CACHE_PREWARM_HEADER]: 'next-generation' },
+				headers: {
+					[PAGE_CACHE_PREWARM_HEADER]: 'next-generation',
+					[PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER]: 'content-v2',
+				},
 			}),
 			env,
 			ctx,
@@ -357,6 +373,7 @@ describe('SWR state machine', () => {
 			'next-generation',
 		)
 		expect(warmed.headers.get(PAGE_CACHE_STORED_HEADER)).toBe('true')
+		expect(kvGet).not.toHaveBeenCalled()
 		expect(kvPut).toHaveBeenCalledTimes(1)
 		expect(ctx.waitUntil).not.toHaveBeenCalled()
 	})

--- a/services/site-worker/src/page-cache.ts
+++ b/services/site-worker/src/page-cache.ts
@@ -6,6 +6,9 @@ export const PAGE_CACHE_FRESH_TTL_SEC = 300
 export const PAGE_CACHE_EXPIRATION_TTL_SEC = 26 * 60 * 60
 export const PAGE_CACHE_GENERATION_MEMORY_TTL_MS = 15_000
 export const PAGE_CACHE_KV_READ_CACHE_TTL_SEC = 30
+export const PAGE_CACHE_GENERATION_HEADER = 'X-Page-Cache-Generation'
+export const PAGE_CACHE_PREWARM_HEADER = 'X-Page-Cache-Prewarm'
+export const PAGE_CACHE_STORED_HEADER = 'X-Page-Cache-Stored'
 
 const THEME_COOKIE_NAME = 'en_theme'
 const SESSION_COOKIE_NAME = 'KCD_root_session'
@@ -302,6 +305,7 @@ export async function bumpPageCacheGeneration(contentKv: {
 	const value = Date.now().toString()
 	await contentKv.put(PAGE_CACHE_GENERATION_KEY, value)
 	generationCache = { value, fetchedAt: Date.now() }
+	return value
 }
 
 export function generatePageCacheNonce() {
@@ -450,6 +454,7 @@ function buildCachedResponse(
 	request: Request,
 	entry: PageCacheEntry,
 	cacheStatus: 'HIT' | 'STALE',
+	generation: string,
 ) {
 	const ageSec = Math.max(0, Math.floor((Date.now() - entry.storedAt) / 1000))
 	const freshNonce = entry.nonce ? generatePageCacheNonce() : ''
@@ -458,6 +463,7 @@ function buildCachedResponse(
 		: entry
 	const headers = new Headers(rewritten.headers)
 	headers.set('X-Edge-Cache', cacheStatus)
+	headers.set(PAGE_CACHE_GENERATION_HEADER, generation)
 	headers.set('Age', String(ageSec))
 
 	if (request.method === 'HEAD') {
@@ -473,9 +479,23 @@ function buildCachedResponse(
 	})
 }
 
-function withEdgeCacheHeader(response: Response, status: 'MISS' | 'BYPASS') {
+function withEdgeCacheHeader(
+	response: Response,
+	status: 'MISS' | 'BYPASS',
+	{
+		generation,
+		stored,
+	}: {
+		generation?: string
+		stored?: boolean
+	} = {},
+) {
 	const headers = new Headers(response.headers)
 	headers.set('X-Edge-Cache', status)
+	if (generation) headers.set(PAGE_CACHE_GENERATION_HEADER, generation)
+	if (stored !== undefined) {
+		headers.set(PAGE_CACHE_STORED_HEADER, stored ? 'true' : 'false')
+	}
 	return new Response(response.body, {
 		status: response.status,
 		statusText: response.statusText,
@@ -497,11 +517,12 @@ async function storePageCacheFromFillResponse(
 		statusText: fillResponse.statusText,
 		headers,
 	})
-	if (!isPageCacheStoreEligible(stripped, pathname)) return
+	if (!isPageCacheStoreEligible(stripped, pathname)) return false
 
 	const entry = encodePageCacheEntry(stripped, body)
-	if (!entry) return
+	if (!entry) return false
 	await writePageCacheEntry(kv, key, entry)
+	return true
 }
 
 async function revalidatePageCacheEntry(
@@ -543,6 +564,16 @@ export async function handlePageCacheRequest(
 	}
 
 	const generation = await getPageCacheGeneration(env.CONTENT_KV)
+	const prewarmGeneration = request.headers.get(PAGE_CACHE_PREWARM_HEADER)
+	if (prewarmGeneration && prewarmGeneration !== generation) {
+		return new Response(null, {
+			status: 409,
+			headers: {
+				'X-Edge-Cache': 'BYPASS',
+				[PAGE_CACHE_GENERATION_HEADER]: generation,
+			},
+		})
+	}
 	const key = buildPageCacheKey(request, generation)
 	const entry = await readPageCacheEntry(env.SITE_CACHE_KV, key)
 	const pathname = new URL(request.url).pathname
@@ -550,7 +581,7 @@ export async function handlePageCacheRequest(
 	if (entry) {
 		const ageSec = Math.floor((Date.now() - entry.storedAt) / 1000)
 		if (ageSec < PAGE_CACHE_FRESH_TTL_SEC) {
-			return buildCachedResponse(request, entry, 'HIT')
+			return buildCachedResponse(request, entry, 'HIT', generation)
 		}
 
 		ctx.waitUntil(
@@ -560,7 +591,7 @@ export async function handlePageCacheRequest(
 				},
 			),
 		)
-		return buildCachedResponse(request, entry, 'STALE')
+		return buildCachedResponse(request, entry, 'STALE', generation)
 	}
 
 	// On a miss, fill the cache. When the request carried no cookies beyond
@@ -574,6 +605,20 @@ export async function handlePageCacheRequest(
 	if (request.method === 'GET') {
 		if (canStoreOwnResponse(request)) {
 			const responseForStore = response.clone()
+			if (prewarmGeneration) {
+				let stored = false
+				try {
+					stored = await storePageCacheFromFillResponse(
+						key,
+						responseForStore,
+						env.SITE_CACHE_KV,
+						pathname,
+					)
+				} catch (error: unknown) {
+					console.warn('page-cache prewarm fill failed', key, error)
+				}
+				return withEdgeCacheHeader(response, 'MISS', { generation, stored })
+			}
 			ctx.waitUntil(
 				storePageCacheFromFillResponse(
 					key,
@@ -595,5 +640,5 @@ export async function handlePageCacheRequest(
 		}
 	}
 
-	return withEdgeCacheHeader(response, 'MISS')
+	return withEdgeCacheHeader(response, 'MISS', { generation })
 }

--- a/services/site-worker/src/page-cache.ts
+++ b/services/site-worker/src/page-cache.ts
@@ -567,7 +567,17 @@ export async function handlePageCacheRequest(
 
 	const generation = await getPageCacheGeneration(env.CONTENT_KV)
 	const prewarmGeneration = request.headers.get(PAGE_CACHE_PREWARM_HEADER)
-	if (prewarmGeneration && prewarmGeneration !== generation) {
+	const prewarmContentVersion = request.headers.get(
+		PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER,
+	)
+	if (Boolean(prewarmGeneration) !== Boolean(prewarmContentVersion)) {
+		return new Response(null, {
+			status: 400,
+			headers: { [PAGE_CACHE_GENERATION_HEADER]: generation },
+		})
+	}
+	const isPrewarm = Boolean(prewarmGeneration && prewarmContentVersion)
+	if (isPrewarm && prewarmGeneration !== generation) {
 		return new Response(null, {
 			status: 409,
 			headers: {
@@ -579,7 +589,7 @@ export async function handlePageCacheRequest(
 	const key = buildPageCacheKey(request, generation)
 	// A prewarm must render the requested content version even if another
 	// request filled this generation before the manifest propagated.
-	const entry = prewarmGeneration
+	const entry = isPrewarm
 		? null
 		: await readPageCacheEntry(env.SITE_CACHE_KV, key)
 	const pathname = new URL(request.url).pathname
@@ -611,7 +621,20 @@ export async function handlePageCacheRequest(
 	if (request.method === 'GET') {
 		if (canStoreOwnResponse(request)) {
 			const responseForStore = response.clone()
-			if (prewarmGeneration) {
+			if (isPrewarm) {
+				if (
+					responseForStore.headers.get('X-Content-Version') !==
+					prewarmContentVersion
+				) {
+					return new Response(null, {
+						status: 409,
+						headers: {
+							[PAGE_CACHE_GENERATION_HEADER]: generation,
+							'X-Content-Version':
+								responseForStore.headers.get('X-Content-Version') ?? '',
+						},
+					})
+				}
 				let stored = false
 				try {
 					stored = await storePageCacheFromFillResponse(

--- a/services/site-worker/src/page-cache.ts
+++ b/services/site-worker/src/page-cache.ts
@@ -8,6 +8,8 @@ export const PAGE_CACHE_GENERATION_MEMORY_TTL_MS = 15_000
 export const PAGE_CACHE_KV_READ_CACHE_TTL_SEC = 30
 export const PAGE_CACHE_GENERATION_HEADER = 'X-Page-Cache-Generation'
 export const PAGE_CACHE_PREWARM_HEADER = 'X-Page-Cache-Prewarm'
+export const PAGE_CACHE_PREWARM_CONTENT_VERSION_HEADER =
+	'X-Page-Cache-Prewarm-Content-Version'
 export const PAGE_CACHE_STORED_HEADER = 'X-Page-Cache-Stored'
 
 const THEME_COOKIE_NAME = 'en_theme'
@@ -575,7 +577,11 @@ export async function handlePageCacheRequest(
 		})
 	}
 	const key = buildPageCacheKey(request, generation)
-	const entry = await readPageCacheEntry(env.SITE_CACHE_KV, key)
+	// A prewarm must render the requested content version even if another
+	// request filled this generation before the manifest propagated.
+	const entry = prewarmGeneration
+		? null
+		: await readPageCacheEntry(env.SITE_CACHE_KV, key)
 	const pathname = new URL(request.url).pathname
 
 	if (entry) {

--- a/services/site/vitest.config.ts
+++ b/services/site/vitest.config.ts
@@ -8,7 +8,10 @@ import { configDefaults, defineConfig } from 'vitest/config'
 export default defineConfig({
 	plugins: [react(), tsconfigPaths()],
 	test: {
-		include: ['**/__tests__/**.{js,jsx,ts,tsx}'],
+		include: [
+			'**/__tests__/**.{js,jsx,ts,tsx}',
+			'../../other/__tests__/**.{js,jsx,ts,tsx}',
+		],
 		exclude: [...configDefaults.exclude, '**/*.test.browser.{js,jsx,ts,tsx}'],
 		environment: 'node',
 		setupFiles: ['./tests/setup-backend.ts'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- derive affected public URLs from changed content, including nested posts, moves, deletions, pages, and shared indexes
- bind prewarming to the exact cache generation and content version returned by refresh
- require complete protocol metadata, reject stale isolates, bypass existing page/manifest caches, and synchronously confirm replacement KV writes
- fix rename parsing and add refresh, URL mapping, protocol, retry, header-bridge, and cache-write coverage
- use the canonical `kentcdodds.com` host and document the refresh-time cache behavior

## Validation
- pre-commit verification: formatting, lint, typecheck, and builds
- pre-push verification: all workspace tests
- focused content-prewarm and site-worker cache suites
- local HTTP integration exercising stale-generation retry and verified content-version warming
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-221d1b1e-571c-49d8-bce0-ac17857c0f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-221d1b1e-571c-49d8-bce0-ac17857c0f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved content refreshes with automatic cache prewarming for updated pages and related site routes.
  * Added clearer cache/version signaling so refreshed content is served more consistently.

* **Bug Fixes**
  * Reduced the chance of serving stale content after updates.
  * Improved handling of cache refresh retries and mismatched content versions.
  * Added more reliable cache warming behavior for moved, deleted, and nested content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->