### PR TITLE
Extract shared worker request pipeline from dev-entry and dynamic bootstrap

### DIFF
--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -144,9 +144,13 @@ the commit via `POST /action/refresh-cache`. Compare SHA resolution prefers
 
 The dynamic worker's main module (`app-worker.js`) is an esbuild bundle of
 `services/site-worker/src/dynamic/bootstrap.ts` which imports the site server
-build. Before handling any request it sets these globals so app code (bundled
-from `services/site`) can reach worker-provided content without static imports
-that would break the Node/dev build:
+build. Request handling (pre-router, CSP, rate limits, markdown negotiation,
+logging) lives in the shared factory
+`services/site/app/utils/worker-request-pipeline.server.ts`; bootstrap only
+supplies prod bridges, cold-start headers, and the cached server build. Before
+handling any request it sets these globals so app code (bundled from
+`services/site`) can reach worker-provided content without static imports that
+would break the Node/dev build:
 
 - `globalThis[Symbol.for('kentcdodds.contentData')]` — the artifact bundle
   JSON with per-document `code` and `esm` **stripped** (metadata, blogList,
@@ -459,10 +463,12 @@ split; production smoke tests cover the full topology.
 
 ### Dev worker entry
 
-`services/site/workers/dev-entry.ts` — `createRequestHandler` +
-`virtual:react-router/server-build`, runtime env/binding bridges, pre-router
-pipeline (rate limiting, CSP), outbound fetch mocks when `MOCKS=true`, and MDX
-content from `virtual:mdx-dev-manifest` + `/@fs` module imports.
+`services/site/workers/dev-entry.ts` is a thin entry over
+`createWorkerFetchHandler` from
+`services/site/app/utils/worker-request-pipeline.server.ts`. It supplies
+dev-only early routes (`/media/*`, `/resources/og-image`), outbound fetch mocks
+when `MOCKS=true`, MDX from `virtual:mdx-dev-manifest` + `/@fs`, and a lazy
+`virtual:react-router/server-build` handler.
 
 ### MDX in dev (no eval in workerd)
 

--- a/services/site-worker/src/dynamic/bootstrap.test.ts
+++ b/services/site-worker/src/dynamic/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { isBogusCrawlerPath } from './bootstrap.ts'
+import { isBogusCrawlerPath } from '../../../site/app/utils/worker-request-pipeline.server.ts'
 
 const scannerPostPaths = ['/RSC/abc.txt', '/session/root/shell', '/session']
 

--- a/services/site-worker/src/dynamic/bootstrap.ts
+++ b/services/site-worker/src/dynamic/bootstrap.ts
@@ -1,64 +1,13 @@
-import * as sharedReact from 'react'
-import * as sharedJsxRuntime from 'react/jsx-runtime'
-import {
-	createRequestHandler,
-	type AppLoadContext,
-	type ServerBuild,
-} from 'react-router'
-
-const sharedReactGlobalKey = Symbol.for('kentcdodds.sharedReact')
-const sharedJsxRuntimeGlobalKey = Symbol.for('kentcdodds.sharedJsxRuntime')
-
-function publishSharedReactGlobals() {
-	;(globalThis as Record<symbol, unknown>)[sharedReactGlobalKey] = sharedReact
-	;(globalThis as Record<symbol, unknown>)[sharedJsxRuntimeGlobalKey] =
-		sharedJsxRuntime
-}
-
-publishSharedReactGlobals()
-import { setRequestWaitUntil } from '../../../site/app/utils/background-task.server.ts'
-import {
-	beginCacheRequestStats,
-	formatCacheRequestStatsHeader,
-} from '../../../site/app/utils/cache-request-stats.server.ts'
-import {
-	beginD1RequestStats,
-	formatD1RequestStatsHeader,
-} from '../../../site/app/utils/db/d1-request-stats.server.ts'
-import {
-	appendD1BookmarkCookie,
-	getD1BookmarkFromRequest,
-} from '../../../site/app/utils/db/d1-bookmark-cookie.server.ts'
-import {
-	getOutboundD1Bookmark,
-	runWithD1RequestContext,
-} from '../../../site/app/utils/db/d1-session-request.server.ts'
-import { runWithRequestContext } from '../../../site/app/utils/request-context.server.ts'
-import {
-	setRuntimeEnvSource,
-	getEnv,
-} from '../../../site/app/utils/env.server.ts'
-import {
-	setRuntimeBindingSource,
-	type RuntimeBindingSource,
-} from '../../../site/app/utils/runtime-bindings.server.ts'
-import { applySecurityHeaders as applyHelmetSecurityHeaders } from '../../../site/app/utils/security-headers.server.ts'
-import { applySecurityHeaders as applyCspHeaders } from './csp.ts'
+import { type ServerBuild } from 'react-router'
+import { setRuntimeEnvSource } from '../../../site/app/utils/env.server.ts'
+import { setRuntimeBindingSource } from '../../../site/app/utils/runtime-bindings.server.ts'
 import { formatColdStartTiming } from '../cold-start-timing.ts'
-import {
-	type RateLimitResult,
-	applyRateLimitHeaders,
-	checkRateLimit,
-	createRateLimitedResponse,
-	getAgentSearchHintHeaders,
-} from './rate-limiting.ts'
-import { getLegacyGenericSocialImageUrl } from '../../../site/app/og/meta.server.ts'
-import {
-	getRickRollHtml,
-	matchRedirect,
-	parseRedirectsString,
-} from '../../../site/app/utils/redirects-core.server.ts'
 import redirectsText from '../../../site/other/_redirects.txt'
+import {
+	createWorkerFetchHandler,
+	getStringEnvBindings,
+	type WorkerEnv,
+} from '../../../site/app/utils/worker-request-pipeline.server.ts'
 
 let isolateId: string | undefined
 
@@ -67,96 +16,10 @@ function getIsolateId() {
 	return isolateId
 }
 
-const markdownMediaType = 'text/markdown'
-
-function requestPrefersMarkdown(acceptHeader: string | null): boolean {
-	if (!acceptHeader) return false
-	const entries = acceptHeader
-		.split(',')
-		.map((part) => part.trim())
-		.filter(Boolean)
-	let htmlQ = -1
-	let markdownQ = -1
-	for (const entry of entries) {
-		const segments = entry.split(';').map((segment) => segment.trim())
-		const type = segments[0]
-		if (!type) continue
-		const qParam = segments.find((segment) => segment.startsWith('q='))
-		const q = qParam ? Number.parseFloat(qParam.slice(2)) : 1
-		if (type === 'text/html') htmlQ = q
-		if (type === markdownMediaType) markdownQ = q
-	}
-	if (markdownQ < 0) return false
-	if (htmlQ < 0) return true
-	return markdownQ >= htmlQ
-}
-
-type MarkdownNegotiation =
-	typeof import('../../../site/app/utils/markdown-negotiation.server.ts')
-let markdownNegotiationPromise: Promise<MarkdownNegotiation> | undefined
-
-function getMarkdownNegotiation() {
-	if (!markdownNegotiationPromise) {
-		markdownNegotiationPromise = import(
-			'../../../site/app/utils/markdown-negotiation.server.ts'
-		)
-	}
-	return markdownNegotiationPromise
-}
-
-type WorkerEnv = RuntimeBindingSource & Record<string, unknown>
-
-type SiteRequestHandler = (
-	request: Request,
-	loadContext?: AppLoadContext,
-) => Promise<Response>
-
-const parsedRedirects = parseRedirectsString(redirectsText)
-
-const bogusCrawlerCallPathEndings = new Set([
-	'Express.js',
-	'Next.js',
-	'React.js',
-	'index.js',
-	'meta.json',
-	'u003e',
-])
-
 let contentDataPromise: Promise<unknown> | null = null
 let bridgesInitialized = false
 let firstRequestTimings: Record<string, number> | null = null
-
-function getHost(request: Request) {
-	const url = new URL(request.url)
-	return (
-		request.headers.get('X-Forwarded-Host') ??
-		request.headers.get('host') ??
-		url.host
-	)
-}
-
-export function isBogusCrawlerPath(pathname: string) {
-	if (pathname.includes('/node_modules/')) return true
-	if (!pathname.startsWith('/calls/')) return false
-	const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1)
-	return bogusCrawlerCallPathEndings.has(lastSegment)
-}
-
-function createCspNonce() {
-	const bytes = new Uint8Array(16)
-	crypto.getRandomValues(bytes)
-	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
-		'',
-	)
-}
-
-function getStringEnvBindings(env: WorkerEnv) {
-	return Object.fromEntries(
-		Object.entries(env).filter((entry): entry is [string, string] => {
-			return typeof entry[1] === 'string'
-		}),
-	)
-}
+let cachedServerBuild: ServerBuild | null = null
 
 async function ensureRuntimeBridges(env: WorkerEnv) {
 	if (bridgesInitialized) return
@@ -199,373 +62,52 @@ async function ensureRuntimeBridges(env: WorkerEnv) {
 	}
 }
 
-function getWorkerAllowedActionOrigins(request: Request) {
-	const requestHost = new URL(request.url).host
-	return Array.from(new Set([...getEnv().allowedActionOrigins, requestHost]))
-}
-
-// Handlers are cached per request host: allowedActionOrigins includes the
-// request host, so a single cached handler would pin action origin checks to
-// whichever host happened to arrive first (e.g. the warmup cron's internal
-// host), breaking POSTs from the real public host on that isolate.
-const requestHandlersByHost = new Map<string, SiteRequestHandler>()
-const MAX_CACHED_REQUEST_HANDLERS = 10
-let cachedServerBuild: ServerBuild | null = null
-
-async function getSiteRequestHandler(
-	request: Request,
-): Promise<SiteRequestHandler> {
-	const host = new URL(request.url).host
-	const cached = requestHandlersByHost.get(host)
-	if (cached) return cached
-
-	if (!cachedServerBuild) {
-		const handlerImportStartedAt = performance.now()
-		cachedServerBuild = (await import(
-			// @ts-ignore -- generated by `npm run build:site --workspace site-worker`;
-			// absent in environments (like CI validate) that typecheck without building.
-			'../../../site/build/server/index.js'
-		)) as unknown as ServerBuild
-		if (firstRequestTimings) {
-			firstRequestTimings.handlerImport =
-				performance.now() - handlerImportStartedAt
-		}
-	}
-
-	const handler = createRequestHandler(
-		{
-			...cachedServerBuild,
-			allowedActionOrigins: getWorkerAllowedActionOrigins(request),
-		},
-		'production',
-	) as SiteRequestHandler
-	requestHandlersByHost.set(host, handler)
-	for (const key of requestHandlersByHost.keys()) {
-		if (requestHandlersByHost.size <= MAX_CACHED_REQUEST_HANDLERS) break
-		if (key !== host) requestHandlersByHost.delete(key)
-	}
-	return handler
-}
-
-function shouldSkipRequestLog(request: Request, response: Response) {
-	if (response.status !== 200) return false
-	const url = new URL(request.url)
-	const headToRoot = request.method === 'HEAD' && url.pathname === '/'
-	const getToHealthcheck =
-		request.method === 'GET' && url.pathname === '/healthcheck'
-	return headToRoot || getToHealthcheck
-}
-
-function logRequest(request: Request, response: Response, startedAt: number) {
-	if (shouldSkipRequestLog(request, response)) return
-	const url = new URL(request.url)
-	const host = getHost(request)
-	const duration = Date.now() - startedAt
-	const contentLength = response.headers.get('content-length') ?? '-'
-	console.log(
-		[
-			request.method,
-			`${host}${decodeURIComponent(url.pathname + url.search)}`,
-			String(response.status),
-			contentLength,
-			'-',
-			String(duration),
-			'ms',
-		].join(' '),
-	)
-}
-
-function redirectResponse(destination: string, status = 301) {
-	return new Response(null, {
-		status,
-		headers: { Location: destination },
-	})
-}
-
-type PreRouterResult = {
-	response: Response | null
-	rateLimit: RateLimitResult | null
-}
-
-async function runPreRouterPipeline(
-	request: Request,
-	env: WorkerEnv,
-): Promise<PreRouterResult> {
-	const url = new URL(request.url)
-	const host = getHost(request)
-	const proto = request.headers.get('X-Forwarded-Proto') ?? 'https'
-
-	if (url.pathname === '/img/social' && request.method === 'GET') {
-		return {
-			response: redirectResponse(
-				getLegacyGenericSocialImageUrl(`${proto}://${host}`),
-				302,
-			),
-			rateLimit: null,
-		}
-	}
-
-	if (isBogusCrawlerPath(url.pathname)) {
-		return {
-			response: new Response('Not found', { status: 404 }),
-			rateLimit: null,
-		}
-	}
-
-	if (host === 'www.kentcdodds.com') {
-		return {
-			response: redirectResponse(
-				`https://kentcdodds.com${url.pathname}${url.search}`,
-			),
-			rateLimit: null,
-		}
-	}
-	if (host === 'blog.kentcdodds.com') {
-		const blogPath = url.pathname === '/' ? '' : url.pathname
-		return {
-			response: redirectResponse(
-				`https://kentcdodds.com/blog${blogPath}${url.search}`,
-			),
-			rateLimit: null,
-		}
-	}
-
-	if (proto === 'http') {
-		return {
-			response: redirectResponse(`https://${host}${url.pathname}${url.search}`),
-			rateLimit: null,
-		}
-	}
-
-	const redirectDestination = matchRedirect({
-		redirects: parsedRedirects,
-		method: request.method,
-		pathname: url.pathname,
-		url: url.pathname + url.search,
-		protocol: proto,
-		host,
-	})
-	if (redirectDestination) {
-		return {
-			response: redirectResponse(redirectDestination, 307),
-			rateLimit: null,
-		}
-	}
-
-	if (url.pathname.endsWith('/') && url.pathname.length > 1) {
-		const safepath = url.pathname.slice(0, -1).replace(/\/+/g, '/')
-		return {
-			response: redirectResponse(`${safepath}${url.search}`),
-			rateLimit: null,
-		}
-	}
-
-	const mocks = getStringEnvBindings(env).MOCKS === 'true'
-	const rateLimit = checkRateLimit(request, { mocks })
-	if (!rateLimit.allowed) {
-		return {
-			response: createRateLimitedResponse(request, rateLimit),
-			rateLimit,
-		}
-	}
-
-	if (url.pathname === '/redirect.html' && request.method === 'GET') {
-		const cspNonce = createCspNonce()
-		const headers = new Headers({
-			'content-type': 'text/html; charset=utf-8',
-		})
-		applyHelmetSecurityHeaders(headers)
-		applyCspHeaders({ headers, request, cspNonce })
-		applyRateLimitHeaders(headers, rateLimit)
-		return {
-			response: new Response(getRickRollHtml(cspNonce), { headers }),
-			rateLimit,
-		}
-	}
-
-	if (
-		url.pathname.startsWith('/.well-known/') &&
-		request.method === 'OPTIONS'
-	) {
-		return {
-			response: new Response(null, {
-				status: 204,
-				headers: {
-					'Access-Control-Allow-Origin': '*',
-					'Access-Control-Allow-Methods': 'GET,HEAD,POST,OPTIONS',
-					'Access-Control-Allow-Headers':
-						request.headers.get('Access-Control-Request-Headers') ?? '*',
-				},
-			}),
-			rateLimit,
-		}
-	}
-
-	return { response: null, rateLimit }
-}
-
-function appendVaryValue(headers: Headers, value: string) {
-	const vary = headers.get('vary')
-	if (!vary) {
-		headers.set('vary', value)
-		return
-	}
-	const values = new Set(
-		vary
-			.split(',')
-			.map((entry) => entry.trim())
-			.filter(Boolean),
-	)
-	values.add(value)
-	headers.set('vary', Array.from(values).join(', '))
-}
-
-function appendVaryAccept(headers: Headers) {
-	appendVaryValue(headers, 'Accept')
-	appendVaryValue(headers, 'Accept-Encoding')
-}
-
-async function handleSiteRequest(
-	request: Request,
-	env: WorkerEnv,
-	ctx: ExecutionContext,
-): Promise<Response> {
-	// All per-request state (stats, waitUntil bridge, D1 session) lives in an
-	// AsyncLocalStorage context so overlapping requests in this isolate can
-	// never observe or clobber each other's state.
-	return runWithRequestContext(async () => {
-		const startedAt = Date.now()
-		const requestStartedAt = performance.now()
-		const cacheStats = beginCacheRequestStats()
-		const d1Stats = beginD1RequestStats()
-		const inboundBookmark = getD1BookmarkFromRequest(request)
-		setRequestWaitUntil(ctx.waitUntil.bind(ctx))
-		await ensureRuntimeBridges(env)
-		return runWithD1RequestContext(request, async () => {
-			const preRouter = await runPreRouterPipeline(request, env)
-			const preRouterResponse = preRouter.response
-			if (preRouterResponse) {
-				const headers = new Headers(preRouterResponse.headers)
-				headers.set('X-Isolate-Id', getIsolateId())
-				headers.set('X-Cache-Stats', formatCacheRequestStatsHeader(cacheStats))
-				headers.set('X-D1-Stats', formatD1RequestStatsHeader(d1Stats))
-				if (firstRequestTimings) {
-					headers.set(
-						'X-Cold-Start-Timing',
-						formatColdStartTiming({
-							...firstRequestTimings,
-							request: performance.now() - requestStartedAt,
-						}),
-					)
-					firstRequestTimings = null
-				}
-				logRequest(
-					request,
-					new Response(preRouterResponse.body, {
-						status: preRouterResponse.status,
-						statusText: preRouterResponse.statusText,
-						headers,
-					}),
-					startedAt,
-				)
-				return new Response(preRouterResponse.body, {
-					status: preRouterResponse.status,
-					statusText: preRouterResponse.statusText,
-					headers,
-				})
-			}
-
-			const cspNonce = createCspNonce()
-			const handlerStartedAt = performance.now()
-			const handler = await getSiteRequestHandler(request)
-			const handlerReadyMs = performance.now() - handlerStartedAt
-			let response = await handler(request, {
-				cloudflare: { env, ctx },
-				cspNonce,
-			} as AppLoadContext)
-			const handlerServeMs = performance.now() - handlerStartedAt - handlerReadyMs
-
-			const url = new URL(request.url)
-			const acceptHeader = request.headers.get('Accept') ?? ''
-			if (requestPrefersMarkdown(acceptHeader)) {
-				const { maybeConvertHtmlResponseToMarkdown } =
-					await getMarkdownNegotiation()
-				response = await maybeConvertHtmlResponseToMarkdown(response)
-			}
-
-			const headers = new Headers(response.headers)
-			applyHelmetSecurityHeaders(headers)
-			applyCspHeaders({ headers, request, cspNonce })
-			// Reuse the pre-router rate-limit result so a request only consumes one
-			// quota unit (checkRateLimit increments the window on every call).
-			const mocks = getStringEnvBindings(env).MOCKS === 'true'
-			const rateLimit = preRouter.rateLimit ?? checkRateLimit(request, { mocks })
-			applyRateLimitHeaders(headers, rateLimit)
-			if (
-				rateLimit.tier === 'markdown' &&
-				rateLimit.remaining <= rateLimit.limit / 2
-			) {
-				const hints = getAgentSearchHintHeaders(url.pathname)
-				for (const [key, value] of Object.entries(hints)) {
-					headers.set(key, value)
-				}
-			}
-			if (url.pathname.startsWith('/.well-known/')) {
-				headers.set('Access-Control-Allow-Origin', '*')
-			}
-			if (
-				response.ok &&
-				Boolean(headers.get('content-type')?.match(/\btext\/(html|markdown)\b/i))
-			) {
-				appendVaryAccept(headers)
-			}
-			headers.set('X-Isolate-Id', getIsolateId())
-			headers.set('X-Cache-Stats', formatCacheRequestStatsHeader(cacheStats))
-			headers.set('X-D1-Stats', formatD1RequestStatsHeader(d1Stats))
-			if (firstRequestTimings) {
-				headers.set(
-					'X-Cold-Start-Timing',
-					formatColdStartTiming({
-						...firstRequestTimings,
-						handlerReady: handlerReadyMs,
-						handlerServe: handlerServeMs,
-						request: performance.now() - requestStartedAt,
-					}),
-				)
-				firstRequestTimings = null
-			}
-
-			const outboundBookmark = await getOutboundD1Bookmark()
-			if (
-				outboundBookmark &&
-				outboundBookmark !== inboundBookmark &&
-				outboundBookmark !== 'first-unconstrained' &&
-				outboundBookmark !== 'first-primary'
-			) {
-				appendD1BookmarkCookie(headers, outboundBookmark)
-			}
-			const finalResponse = new Response(response.body, {
-				status: response.status,
-				statusText: response.statusText,
-				headers,
-			})
-			logRequest(request, finalResponse, startedAt)
-			return finalResponse
-		})
-	})
-}
-
-export default {
-	async fetch(
-		request: Request,
-		env: WorkerEnv,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		try {
-			return await handleSiteRequest(request, env, ctx)
-		} catch (error: unknown) {
-			console.error('app-worker fetch failed', error)
-			return new Response('Internal Server Error', { status: 500 })
-		}
+function decorateResponseHeaders(
+	headers: Headers,
+	timing: {
+		requestStartedAtPerfNow: number
+		handlerReadyMs?: number
+		handlerServeMs?: number
 	},
+) {
+	headers.set('X-Isolate-Id', getIsolateId())
+	if (firstRequestTimings) {
+		headers.set(
+			'X-Cold-Start-Timing',
+			formatColdStartTiming({
+				...firstRequestTimings,
+				...(timing.handlerReadyMs === undefined
+					? {}
+					: { handlerReady: timing.handlerReadyMs }),
+				...(timing.handlerServeMs === undefined
+					? {}
+					: { handlerServe: timing.handlerServeMs }),
+				request: performance.now() - timing.requestStartedAtPerfNow,
+			}),
+		)
+		firstRequestTimings = null
+	}
 }
+
+export default createWorkerFetchHandler({
+	redirectsText,
+	ensureRuntimeBridges,
+	decorateResponseHeaders,
+	requestHandlerMode: 'production',
+	errorLogLabel: 'app-worker fetch failed',
+	async getServerBuild() {
+		if (!cachedServerBuild) {
+			const handlerImportStartedAt = performance.now()
+			cachedServerBuild = (await import(
+				// @ts-ignore -- generated by `npm run build:site --workspace site-worker`;
+				// absent in environments (like CI validate) that typecheck without building.
+				'../../../site/build/server/index.js'
+			)) as unknown as ServerBuild
+			if (firstRequestTimings) {
+				firstRequestTimings.handlerImport =
+					performance.now() - handlerImportStartedAt
+			}
+		}
+		return cachedServerBuild
+	},
+})

--- a/services/site/app/utils/worker-request-pipeline.server.ts
+++ b/services/site/app/utils/worker-request-pipeline.server.ts
@@ -1,0 +1,550 @@
+import type { ExecutionContext } from '@cloudflare/workers-types'
+import * as sharedReact from 'react'
+import * as sharedJsxRuntime from 'react/jsx-runtime'
+import {
+	createRequestHandler,
+	type AppLoadContext,
+	type ServerBuild,
+} from 'react-router'
+import {
+	beginCacheRequestStats,
+	formatCacheRequestStatsHeader,
+} from './cache-request-stats.server.ts'
+import {
+	beginD1RequestStats,
+	formatD1RequestStatsHeader,
+} from './db/d1-request-stats.server.ts'
+import {
+	appendD1BookmarkCookie,
+	getD1BookmarkFromRequest,
+} from './db/d1-bookmark-cookie.server.ts'
+import {
+	getOutboundD1Bookmark,
+	runWithD1RequestContext,
+} from './db/d1-session-request.server.ts'
+import { setRequestWaitUntil } from './background-task.server.ts'
+import { runWithRequestContext } from './request-context.server.ts'
+import { getEnv } from './env.server.ts'
+import { type RuntimeBindingSource } from './runtime-bindings.server.ts'
+import { getLegacyGenericSocialImageUrl } from '../og/meta.server.ts'
+import {
+	getRickRollHtml,
+	matchRedirect,
+	parseRedirectsString,
+} from './redirects-core.server.ts'
+import { applySecurityHeaders as applyHelmetSecurityHeaders } from './security-headers.server.ts'
+import { applySecurityHeaders as applyCspHeaders } from '../../../site-worker/src/dynamic/csp.ts'
+import {
+	type RateLimitResult,
+	applyRateLimitHeaders,
+	checkRateLimit,
+	createRateLimitedResponse,
+	getAgentSearchHintHeaders,
+} from '../../../site-worker/src/dynamic/rate-limiting.ts'
+
+const sharedReactGlobalKey = Symbol.for('kentcdodds.sharedReact')
+const sharedJsxRuntimeGlobalKey = Symbol.for('kentcdodds.sharedJsxRuntime')
+
+function publishSharedReactGlobals() {
+	;(globalThis as Record<symbol, unknown>)[sharedReactGlobalKey] = sharedReact
+	;(globalThis as Record<symbol, unknown>)[sharedJsxRuntimeGlobalKey] =
+		sharedJsxRuntime
+}
+
+publishSharedReactGlobals()
+
+export type WorkerEnv = RuntimeBindingSource & Record<string, unknown>
+
+type SiteRequestHandler = (
+	request: Request,
+	loadContext?: AppLoadContext,
+) => Promise<Response>
+
+type MarkdownNegotiation = typeof import('./markdown-negotiation.server.ts')
+
+type ServerBuildSource = ServerBuild | (() => Promise<ServerBuild>)
+
+type ResponseDecorationTiming = {
+	requestStartedAtPerfNow: number
+	handlerReadyMs?: number
+	handlerServeMs?: number
+}
+
+export type WorkerFetchHandlerOptions = {
+	redirectsText: string
+	ensureRuntimeBridges: (env: WorkerEnv) => Promise<void>
+	getServerBuild: (request: Request) => Promise<ServerBuildSource>
+	requestHandlerMode: string
+	errorLogLabel: string
+	cspMode?: string
+	handleEarlyRequest?: (
+		request: Request,
+		env: WorkerEnv,
+		ctx: ExecutionContext,
+	) => Promise<Response | null>
+	decorateResponseHeaders?: (
+		headers: Headers,
+		timing: ResponseDecorationTiming,
+	) => void
+}
+
+let markdownNegotiationPromise: Promise<MarkdownNegotiation> | undefined
+
+function getMarkdownNegotiation() {
+	if (!markdownNegotiationPromise) {
+		markdownNegotiationPromise = import('./markdown-negotiation.server.ts')
+	}
+	return markdownNegotiationPromise
+}
+
+export function getStringEnvBindings(env: WorkerEnv) {
+	return Object.fromEntries(
+		Object.entries(env).filter((entry): entry is [string, string] => {
+			return typeof entry[1] === 'string'
+		}),
+	)
+}
+
+function createCspNonce() {
+	const bytes = new Uint8Array(16)
+	crypto.getRandomValues(bytes)
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+		'',
+	)
+}
+
+function getHost(request: Request) {
+	const url = new URL(request.url)
+	return (
+		request.headers.get('X-Forwarded-Host') ??
+		request.headers.get('host') ??
+		url.host
+	)
+}
+
+function getWorkerAllowedActionOrigins(request: Request) {
+	const requestHost = new URL(request.url).host
+	return Array.from(new Set([...getEnv().allowedActionOrigins, requestHost]))
+}
+
+const markdownMediaType = 'text/markdown'
+
+function requestPrefersMarkdown(acceptHeader: string | null): boolean {
+	if (!acceptHeader) return false
+	const entries = acceptHeader
+		.split(',')
+		.map((part) => part.trim())
+		.filter(Boolean)
+	let htmlQ = -1
+	let markdownQ = -1
+	for (const entry of entries) {
+		const segments = entry.split(';').map((segment) => segment.trim())
+		const type = segments[0]
+		if (!type) continue
+		const qParam = segments.find((segment) => segment.startsWith('q='))
+		const q = qParam ? Number.parseFloat(qParam.slice(2)) : 1
+		if (type === 'text/html') htmlQ = q
+		if (type === markdownMediaType) markdownQ = q
+	}
+	if (markdownQ < 0) return false
+	if (htmlQ < 0) return true
+	return markdownQ >= htmlQ
+}
+
+const bogusCrawlerCallPathEndings = new Set([
+	'Express.js',
+	'Next.js',
+	'React.js',
+	'index.js',
+	'meta.json',
+	'u003e',
+])
+
+export function isBogusCrawlerPath(pathname: string) {
+	if (pathname.includes('/node_modules/')) return true
+	if (!pathname.startsWith('/calls/')) return false
+	const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1)
+	return bogusCrawlerCallPathEndings.has(lastSegment)
+}
+
+function redirectResponse(destination: string, status = 301) {
+	return new Response(null, {
+		status,
+		headers: { Location: destination },
+	})
+}
+
+type PreRouterResult = {
+	response: Response | null
+	rateLimit: RateLimitResult | null
+}
+
+function appendVaryValue(headers: Headers, value: string) {
+	const vary = headers.get('vary')
+	if (!vary) {
+		headers.set('vary', value)
+		return
+	}
+	const values = new Set(
+		vary
+			.split(',')
+			.map((entry) => entry.trim())
+			.filter(Boolean),
+	)
+	values.add(value)
+	headers.set('vary', Array.from(values).join(', '))
+}
+
+function appendVaryAccept(headers: Headers) {
+	appendVaryValue(headers, 'Accept')
+	appendVaryValue(headers, 'Accept-Encoding')
+}
+
+function shouldSkipRequestLog(request: Request, response: Response) {
+	if (response.status !== 200) return false
+	const url = new URL(request.url)
+	const headToRoot = request.method === 'HEAD' && url.pathname === '/'
+	const getToHealthcheck =
+		request.method === 'GET' && url.pathname === '/healthcheck'
+	return headToRoot || getToHealthcheck
+}
+
+function logRequest(request: Request, response: Response, startedAt: number) {
+	if (shouldSkipRequestLog(request, response)) return
+	const url = new URL(request.url)
+	const host = getHost(request)
+	const duration = Date.now() - startedAt
+	const contentLength = response.headers.get('content-length') ?? '-'
+	console.log(
+		[
+			request.method,
+			`${host}${decodeURIComponent(url.pathname + url.search)}`,
+			String(response.status),
+			contentLength,
+			'-',
+			String(duration),
+			'ms',
+		].join(' '),
+	)
+}
+
+export function createWorkerFetchHandler(options: WorkerFetchHandlerOptions) {
+	const parsedRedirects = parseRedirectsString(options.redirectsText)
+
+	// Handlers are cached per request host: allowedActionOrigins includes the
+	// request host, so a single cached handler would pin action origin checks to
+	// whichever host happened to arrive first (e.g. the warmup cron's internal
+	// host), breaking POSTs from the real public host on that isolate.
+	const requestHandlersByHost = new Map<string, SiteRequestHandler>()
+	const MAX_CACHED_REQUEST_HANDLERS = 10
+
+	async function getSiteRequestHandler(
+		request: Request,
+	): Promise<SiteRequestHandler> {
+		const host = new URL(request.url).host
+		const cached = requestHandlersByHost.get(host)
+		if (cached) return cached
+
+		const buildSource = await options.getServerBuild(request)
+		const handler = (
+			typeof buildSource === 'function'
+				? createRequestHandler(async () => {
+						const build = await buildSource()
+						return {
+							...build,
+							allowedActionOrigins:
+								getWorkerAllowedActionOrigins(request),
+						}
+					}, options.requestHandlerMode)
+				: createRequestHandler(
+						{
+							...buildSource,
+							allowedActionOrigins:
+								getWorkerAllowedActionOrigins(request),
+						},
+						options.requestHandlerMode,
+					)
+		) as SiteRequestHandler
+
+		requestHandlersByHost.set(host, handler)
+		for (const key of requestHandlersByHost.keys()) {
+			if (requestHandlersByHost.size <= MAX_CACHED_REQUEST_HANDLERS) break
+			if (key !== host) requestHandlersByHost.delete(key)
+		}
+		return handler
+	}
+
+	async function runPreRouterPipeline(
+		request: Request,
+		env: WorkerEnv,
+		ctx: ExecutionContext,
+	): Promise<PreRouterResult> {
+		const url = new URL(request.url)
+		const host = getHost(request)
+		const proto = request.headers.get('X-Forwarded-Proto') ?? 'https'
+
+		if (options.handleEarlyRequest) {
+			const earlyResponse = await options.handleEarlyRequest(
+				request,
+				env,
+				ctx,
+			)
+			if (earlyResponse) {
+				return { response: earlyResponse, rateLimit: null }
+			}
+		}
+
+		if (url.pathname === '/img/social' && request.method === 'GET') {
+			return {
+				response: redirectResponse(
+					getLegacyGenericSocialImageUrl(`${proto}://${host}`),
+					302,
+				),
+				rateLimit: null,
+			}
+		}
+
+		if (isBogusCrawlerPath(url.pathname)) {
+			return {
+				response: new Response('Not found', { status: 404 }),
+				rateLimit: null,
+			}
+		}
+
+		if (host === 'www.kentcdodds.com') {
+			return {
+				response: redirectResponse(
+					`https://kentcdodds.com${url.pathname}${url.search}`,
+				),
+				rateLimit: null,
+			}
+		}
+		if (host === 'blog.kentcdodds.com') {
+			const blogPath = url.pathname === '/' ? '' : url.pathname
+			return {
+				response: redirectResponse(
+					`https://kentcdodds.com/blog${blogPath}${url.search}`,
+				),
+				rateLimit: null,
+			}
+		}
+
+		if (proto === 'http') {
+			return {
+				response: redirectResponse(
+					`https://${host}${url.pathname}${url.search}`,
+				),
+				rateLimit: null,
+			}
+		}
+
+		const redirectDestination = matchRedirect({
+			redirects: parsedRedirects,
+			method: request.method,
+			pathname: url.pathname,
+			url: url.pathname + url.search,
+			protocol: proto,
+			host,
+		})
+		if (redirectDestination) {
+			return {
+				response: redirectResponse(redirectDestination, 307),
+				rateLimit: null,
+			}
+		}
+
+		if (url.pathname.endsWith('/') && url.pathname.length > 1) {
+			const safepath = url.pathname.slice(0, -1).replace(/\/+/g, '/')
+			return {
+				response: redirectResponse(`${safepath}${url.search}`),
+				rateLimit: null,
+			}
+		}
+
+		const mocks = getStringEnvBindings(env).MOCKS === 'true'
+		const rateLimit = checkRateLimit(request, { mocks })
+		if (!rateLimit.allowed) {
+			return {
+				response: createRateLimitedResponse(request, rateLimit),
+				rateLimit,
+			}
+		}
+
+		if (url.pathname === '/redirect.html' && request.method === 'GET') {
+			const cspNonce = createCspNonce()
+			const headers = new Headers({
+				'content-type': 'text/html; charset=utf-8',
+			})
+			applyHelmetSecurityHeaders(headers)
+			applyCspHeaders({ headers, request, cspNonce })
+			applyRateLimitHeaders(headers, rateLimit)
+			return {
+				response: new Response(getRickRollHtml(cspNonce), { headers }),
+				rateLimit,
+			}
+		}
+
+		if (
+			url.pathname.startsWith('/.well-known/') &&
+			request.method === 'OPTIONS'
+		) {
+			return {
+				response: new Response(null, {
+					status: 204,
+					headers: {
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'GET,HEAD,POST,OPTIONS',
+						'Access-Control-Allow-Headers':
+							request.headers.get('Access-Control-Request-Headers') ?? '*',
+					},
+				}),
+				rateLimit,
+			}
+		}
+
+		return { response: null, rateLimit }
+	}
+
+	async function handleSiteRequest(
+		request: Request,
+		env: WorkerEnv,
+		ctx: ExecutionContext,
+	): Promise<Response> {
+		// All per-request state (stats, waitUntil bridge, D1 session) lives in an
+		// AsyncLocalStorage context so overlapping requests in this isolate can
+		// never observe or clobber each other's state.
+		return runWithRequestContext(async () => {
+			const startedAt = Date.now()
+			const requestStartedAtPerfNow = performance.now()
+			const cacheStats = beginCacheRequestStats()
+			const d1Stats = beginD1RequestStats()
+			const inboundBookmark = getD1BookmarkFromRequest(request)
+			setRequestWaitUntil(ctx.waitUntil.bind(ctx))
+			await options.ensureRuntimeBridges(env)
+			return runWithD1RequestContext(request, async () => {
+				const preRouter = await runPreRouterPipeline(request, env, ctx)
+				const preRouterResponse = preRouter.response
+				if (preRouterResponse) {
+					const headers = new Headers(preRouterResponse.headers)
+					options.decorateResponseHeaders?.(headers, {
+						requestStartedAtPerfNow,
+					})
+					headers.set(
+						'X-Cache-Stats',
+						formatCacheRequestStatsHeader(cacheStats),
+					)
+					headers.set('X-D1-Stats', formatD1RequestStatsHeader(d1Stats))
+					logRequest(
+						request,
+						new Response(preRouterResponse.body, {
+							status: preRouterResponse.status,
+							statusText: preRouterResponse.statusText,
+							headers,
+						}),
+						startedAt,
+					)
+					return new Response(preRouterResponse.body, {
+						status: preRouterResponse.status,
+						statusText: preRouterResponse.statusText,
+						headers,
+					})
+				}
+
+				const cspNonce = createCspNonce()
+				const handlerStartedAt = performance.now()
+				const handler = await getSiteRequestHandler(request)
+				const handlerReadyMs = performance.now() - handlerStartedAt
+				let response = await handler(request, {
+					cloudflare: { env, ctx },
+					cspNonce,
+				} as AppLoadContext)
+				const handlerServeMs =
+					performance.now() - handlerStartedAt - handlerReadyMs
+
+				const url = new URL(request.url)
+				const acceptHeader = request.headers.get('Accept') ?? ''
+				if (requestPrefersMarkdown(acceptHeader)) {
+					const { maybeConvertHtmlResponseToMarkdown } =
+						await getMarkdownNegotiation()
+					response = await maybeConvertHtmlResponseToMarkdown(response)
+				}
+
+				const headers = new Headers(response.headers)
+				applyHelmetSecurityHeaders(headers)
+				applyCspHeaders({
+					headers,
+					request,
+					cspNonce,
+					...(options.cspMode === undefined
+						? {}
+						: { mode: options.cspMode }),
+				})
+				// Reuse the pre-router rate-limit result so a request only consumes one
+				// quota unit (checkRateLimit increments the window on every call).
+				const mocks = getStringEnvBindings(env).MOCKS === 'true'
+				const rateLimit =
+					preRouter.rateLimit ?? checkRateLimit(request, { mocks })
+				applyRateLimitHeaders(headers, rateLimit)
+				if (
+					rateLimit.tier === 'markdown' &&
+					rateLimit.remaining <= rateLimit.limit / 2
+				) {
+					const hints = getAgentSearchHintHeaders(url.pathname)
+					for (const [key, value] of Object.entries(hints)) {
+						headers.set(key, value)
+					}
+				}
+				if (url.pathname.startsWith('/.well-known/')) {
+					headers.set('Access-Control-Allow-Origin', '*')
+				}
+				if (
+					response.ok &&
+					Boolean(
+						headers.get('content-type')?.match(/\btext\/(html|markdown)\b/i),
+					)
+				) {
+					appendVaryAccept(headers)
+				}
+				options.decorateResponseHeaders?.(headers, {
+					requestStartedAtPerfNow,
+					handlerReadyMs,
+					handlerServeMs,
+				})
+				headers.set('X-Cache-Stats', formatCacheRequestStatsHeader(cacheStats))
+				headers.set('X-D1-Stats', formatD1RequestStatsHeader(d1Stats))
+
+				const outboundBookmark = await getOutboundD1Bookmark()
+				if (
+					outboundBookmark &&
+					outboundBookmark !== inboundBookmark &&
+					outboundBookmark !== 'first-unconstrained' &&
+					outboundBookmark !== 'first-primary'
+				) {
+					appendD1BookmarkCookie(headers, outboundBookmark)
+				}
+				const finalResponse = new Response(response.body, {
+					status: response.status,
+					statusText: response.statusText,
+					headers,
+				})
+				logRequest(request, finalResponse, startedAt)
+				return finalResponse
+			})
+		})
+	}
+
+	return {
+		async fetch(
+			request: Request,
+			env: WorkerEnv,
+			ctx: ExecutionContext,
+		): Promise<Response> {
+			try {
+				return await handleSiteRequest(request, env, ctx)
+			} catch (error: unknown) {
+				console.error(options.errorLogLabel, error)
+				return new Response('Internal Server Error', { status: 500 })
+			}
+		},
+	}
+}

--- a/services/site/workers/dev-entry.ts
+++ b/services/site/workers/dev-entry.ts
@@ -1,129 +1,28 @@
 import type { ExecutionContext } from '@cloudflare/workers-types'
-import * as sharedReact from 'react'
-import * as sharedJsxRuntime from 'react/jsx-runtime'
-import {
-	createRequestHandler,
-	type AppLoadContext,
-	type ServerBuild,
-} from 'react-router'
-import {
-	beginCacheRequestStats,
-	formatCacheRequestStatsHeader,
-} from '#app/utils/cache-request-stats.server.ts'
-import {
-	beginD1RequestStats,
-	formatD1RequestStatsHeader,
-} from '#app/utils/db/d1-request-stats.server.ts'
-import {
-	appendD1BookmarkCookie,
-	getD1BookmarkFromRequest,
-} from '#app/utils/db/d1-bookmark-cookie.server.ts'
-import {
-	getOutboundD1Bookmark,
-	runWithD1RequestContext,
-} from '#app/utils/db/d1-session-request.server.ts'
+import { type ServerBuild } from 'react-router'
 import { installDevMockFetch } from '#app/utils/dev-outbound-fetch.server.ts'
-import { setRequestWaitUntil } from '#app/utils/background-task.server.ts'
-import { runWithRequestContext } from '#app/utils/request-context.server.ts'
-import { setRuntimeEnvSource, getEnv } from '#app/utils/env.server.ts'
-import {
-	setRuntimeBindingSource,
-	type RuntimeBindingSource,
-} from '#app/utils/runtime-bindings.server.ts'
-import { getLegacyGenericSocialImageUrl } from '#app/og/meta.server.ts'
+import { setRuntimeEnvSource } from '#app/utils/env.server.ts'
+import { setRuntimeBindingSource } from '#app/utils/runtime-bindings.server.ts'
 import { handleOgImageRequest } from '#app/og/handler.server.ts'
-import {
-	getRickRollHtml,
-	matchRedirect,
-	parseRedirectsString,
-} from '#app/utils/redirects-core.server.ts'
 import { type MdxDevManifestModule } from '../other/vite-plugins/mdx-dev-manifest.ts'
 import redirectsText from '../other/_redirects.txt'
-import { applySecurityHeaders as applyHelmetSecurityHeaders } from '#app/utils/security-headers.server.ts'
-import { applySecurityHeaders as applyCspHeaders } from '../../site-worker/src/dynamic/csp.ts'
-import {
-	type RateLimitResult,
-	applyRateLimitHeaders,
-	checkRateLimit,
-	createRateLimitedResponse,
-	getAgentSearchHintHeaders,
-} from '../../site-worker/src/dynamic/rate-limiting.ts'
 import { handleMediaRequest } from '../../site-worker/src/media.ts'
 import { PRODUCTION_MEDIA_ORIGIN } from '#app/utils/media-serving.server.ts'
+import {
+	createWorkerFetchHandler,
+	getStringEnvBindings,
+	type WorkerEnv,
+} from '#app/utils/worker-request-pipeline.server.ts'
 
 if (import.meta.hot) {
 	import.meta.hot.accept()
 }
 
-const sharedReactGlobalKey = Symbol.for('kentcdodds.sharedReact')
-const sharedJsxRuntimeGlobalKey = Symbol.for('kentcdodds.sharedJsxRuntime')
-
-function publishSharedReactGlobals() {
-	;(globalThis as Record<symbol, unknown>)[sharedReactGlobalKey] = sharedReact
-	;(globalThis as Record<symbol, unknown>)[sharedJsxRuntimeGlobalKey] =
-		sharedJsxRuntime
-}
-
-publishSharedReactGlobals()
-
-type WorkerEnv = RuntimeBindingSource & Record<string, unknown>
-
-type SiteRequestHandler = (
-	request: Request,
-	loadContext?: AppLoadContext,
-) => Promise<Response>
-
-type MarkdownNegotiation =
-	typeof import('#app/utils/markdown-negotiation.server.ts')
-
-const parsedRedirects = parseRedirectsString(redirectsText)
 const contentDataKey = Symbol.for('kentcdodds.contentData')
 const loadMdxModuleKey = Symbol.for('kentcdodds.loadMdxModule')
 
 let fetchMocksInstalled = false
 let manifestPromise: Promise<MdxDevManifestModule> | null = null
-let markdownNegotiationPromise: Promise<MarkdownNegotiation> | undefined
-
-const requestHandlersByHost = new Map<string, SiteRequestHandler>()
-const MAX_CACHED_REQUEST_HANDLERS = 10
-
-function getMarkdownNegotiation() {
-	if (!markdownNegotiationPromise) {
-		markdownNegotiationPromise =
-			import('#app/utils/markdown-negotiation.server.ts')
-	}
-	return markdownNegotiationPromise
-}
-
-function getStringEnvBindings(env: WorkerEnv) {
-	return Object.fromEntries(
-		Object.entries(env).filter((entry): entry is [string, string] => {
-			return typeof entry[1] === 'string'
-		}),
-	)
-}
-
-function createCspNonce() {
-	const bytes = new Uint8Array(16)
-	crypto.getRandomValues(bytes)
-	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
-		'',
-	)
-}
-
-function getHost(request: Request) {
-	const url = new URL(request.url)
-	return (
-		request.headers.get('X-Forwarded-Host') ??
-		request.headers.get('host') ??
-		url.host
-	)
-}
-
-function getWorkerAllowedActionOrigins(request: Request) {
-	const requestHost = new URL(request.url).host
-	return Array.from(new Set([...getEnv().allowedActionOrigins, requestHost]))
-}
 
 async function readDevManifestFromDisk(): Promise<MdxDevManifestModule> {
 	const { join } = await import('node:path')
@@ -200,85 +99,6 @@ async function ensureRuntimeBridges(env: WorkerEnv) {
 	}
 }
 
-async function getSiteRequestHandler(
-	request: Request,
-): Promise<SiteRequestHandler> {
-	const host = new URL(request.url).host
-	const cached = requestHandlersByHost.get(host)
-	if (cached) return cached
-
-	const handler = createRequestHandler(
-		async () => {
-			const build =
-				(await import('virtual:react-router/server-build')) as ServerBuild
-			return {
-				...build,
-				allowedActionOrigins: getWorkerAllowedActionOrigins(request),
-			}
-		},
-		import.meta.env.MODE,
-	) as SiteRequestHandler
-
-	requestHandlersByHost.set(host, handler)
-	for (const key of requestHandlersByHost.keys()) {
-		if (requestHandlersByHost.size <= MAX_CACHED_REQUEST_HANDLERS) break
-		if (key !== host) requestHandlersByHost.delete(key)
-	}
-	return handler
-}
-
-const markdownMediaType = 'text/markdown'
-
-function requestPrefersMarkdown(acceptHeader: string | null): boolean {
-	if (!acceptHeader) return false
-	const entries = acceptHeader
-		.split(',')
-		.map((part) => part.trim())
-		.filter(Boolean)
-	let htmlQ = -1
-	let markdownQ = -1
-	for (const entry of entries) {
-		const segments = entry.split(';').map((segment) => segment.trim())
-		const type = segments[0]
-		if (!type) continue
-		const qParam = segments.find((segment) => segment.startsWith('q='))
-		const q = qParam ? Number.parseFloat(qParam.slice(2)) : 1
-		if (type === 'text/html') htmlQ = q
-		if (type === markdownMediaType) markdownQ = q
-	}
-	if (markdownQ < 0) return false
-	if (htmlQ < 0) return true
-	return markdownQ >= htmlQ
-}
-
-const bogusCrawlerCallPathEndings = new Set([
-	'Express.js',
-	'Next.js',
-	'React.js',
-	'index.js',
-	'meta.json',
-	'u003e',
-])
-
-function isBogusCrawlerPath(pathname: string) {
-	if (pathname.includes('/node_modules/')) return true
-	if (!pathname.startsWith('/calls/')) return false
-	const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1)
-	return bogusCrawlerCallPathEndings.has(lastSegment)
-}
-
-function redirectResponse(destination: string, status = 301) {
-	return new Response(null, {
-		status,
-		headers: { Location: destination },
-	})
-}
-
-type PreRouterResult = {
-	response: Response | null
-	rateLimit: RateLimitResult | null
-}
-
 async function handleDevMediaRequest(
 	request: Request,
 	env: WorkerEnv,
@@ -290,302 +110,33 @@ async function handleDevMediaRequest(
 	return handleMediaRequest(request, env as never, ctx, { fallbackOrigins })
 }
 
-async function runPreRouterPipeline(
+async function handleEarlyRequest(
 	request: Request,
 	env: WorkerEnv,
 	ctx: ExecutionContext,
-): Promise<PreRouterResult> {
+) {
 	const url = new URL(request.url)
-	const host = getHost(request)
-	const proto = request.headers.get('X-Forwarded-Proto') ?? 'https'
 
 	if (url.pathname.startsWith('/media/')) {
-		const response = await handleDevMediaRequest(request, env, ctx)
-		return { response, rateLimit: null }
+		return handleDevMediaRequest(request, env, ctx)
 	}
 
 	if (url.pathname === '/resources/og-image') {
-		const response = await handleOgImageRequest(request, env)
-		return { response, rateLimit: null }
+		return handleOgImageRequest(request, env)
 	}
 
-	if (url.pathname === '/img/social' && request.method === 'GET') {
-		return {
-			response: redirectResponse(
-				getLegacyGenericSocialImageUrl(`${proto}://${host}`),
-				302,
-			),
-			rateLimit: null,
-		}
-	}
-
-	if (isBogusCrawlerPath(url.pathname)) {
-		return {
-			response: new Response('Not found', { status: 404 }),
-			rateLimit: null,
-		}
-	}
-
-	if (host === 'www.kentcdodds.com') {
-		return {
-			response: redirectResponse(
-				`https://kentcdodds.com${url.pathname}${url.search}`,
-			),
-			rateLimit: null,
-		}
-	}
-	if (host === 'blog.kentcdodds.com') {
-		const blogPath = url.pathname === '/' ? '' : url.pathname
-		return {
-			response: redirectResponse(
-				`https://kentcdodds.com/blog${blogPath}${url.search}`,
-			),
-			rateLimit: null,
-		}
-	}
-
-	if (proto === 'http') {
-		return {
-			response: redirectResponse(`https://${host}${url.pathname}${url.search}`),
-			rateLimit: null,
-		}
-	}
-
-	const redirectDestination = matchRedirect({
-		redirects: parsedRedirects,
-		method: request.method,
-		pathname: url.pathname,
-		url: url.pathname + url.search,
-		protocol: proto,
-		host,
-	})
-	if (redirectDestination) {
-		return {
-			response: redirectResponse(redirectDestination, 307),
-			rateLimit: null,
-		}
-	}
-
-	if (url.pathname.endsWith('/') && url.pathname.length > 1) {
-		const safepath = url.pathname.slice(0, -1).replace(/\/+/g, '/')
-		return {
-			response: redirectResponse(`${safepath}${url.search}`),
-			rateLimit: null,
-		}
-	}
-
-	const mocks = getStringEnvBindings(env).MOCKS === 'true'
-	const rateLimit = checkRateLimit(request, { mocks })
-	if (!rateLimit.allowed) {
-		return {
-			response: createRateLimitedResponse(request, rateLimit),
-			rateLimit,
-		}
-	}
-
-	if (url.pathname === '/redirect.html' && request.method === 'GET') {
-		const cspNonce = createCspNonce()
-		const headers = new Headers({
-			'content-type': 'text/html; charset=utf-8',
-		})
-		applyHelmetSecurityHeaders(headers)
-		applyCspHeaders({ headers, request, cspNonce })
-		applyRateLimitHeaders(headers, rateLimit)
-		return {
-			response: new Response(getRickRollHtml(cspNonce), { headers }),
-			rateLimit,
-		}
-	}
-
-	if (
-		url.pathname.startsWith('/.well-known/') &&
-		request.method === 'OPTIONS'
-	) {
-		return {
-			response: new Response(null, {
-				status: 204,
-				headers: {
-					'Access-Control-Allow-Origin': '*',
-					'Access-Control-Allow-Methods': 'GET,HEAD,POST,OPTIONS',
-					'Access-Control-Allow-Headers':
-						request.headers.get('Access-Control-Request-Headers') ?? '*',
-				},
-			}),
-			rateLimit,
-		}
-	}
-
-	return { response: null, rateLimit }
+	return null
 }
 
-function appendVaryValue(headers: Headers, value: string) {
-	const vary = headers.get('vary')
-	if (!vary) {
-		headers.set('vary', value)
-		return
-	}
-	const values = new Set(
-		vary
-			.split(',')
-			.map((entry) => entry.trim())
-			.filter(Boolean),
-	)
-	values.add(value)
-	headers.set('vary', Array.from(values).join(', '))
-}
-
-function appendVaryAccept(headers: Headers) {
-	appendVaryValue(headers, 'Accept')
-	appendVaryValue(headers, 'Accept-Encoding')
-}
-
-function shouldSkipRequestLog(request: Request, response: Response) {
-	if (response.status !== 200) return false
-	const url = new URL(request.url)
-	const headToRoot = request.method === 'HEAD' && url.pathname === '/'
-	const getToHealthcheck =
-		request.method === 'GET' && url.pathname === '/healthcheck'
-	return headToRoot || getToHealthcheck
-}
-
-function logRequest(request: Request, response: Response, startedAt: number) {
-	if (shouldSkipRequestLog(request, response)) return
-	const url = new URL(request.url)
-	const host = getHost(request)
-	const duration = Date.now() - startedAt
-	const contentLength = response.headers.get('content-length') ?? '-'
-	console.log(
-		[
-			request.method,
-			`${host}${decodeURIComponent(url.pathname + url.search)}`,
-			String(response.status),
-			contentLength,
-			'-',
-			String(duration),
-			'ms',
-		].join(' '),
-	)
-}
-
-async function handleSiteRequest(
-	request: Request,
-	env: WorkerEnv,
-	ctx: ExecutionContext,
-): Promise<Response> {
-	// All per-request state (stats, waitUntil bridge, D1 session) lives in an
-	// AsyncLocalStorage context so overlapping requests in this isolate can
-	// never observe or clobber each other's state.
-	return runWithRequestContext(async () => {
-		const startedAt = Date.now()
-		const cacheStats = beginCacheRequestStats()
-		const d1Stats = beginD1RequestStats()
-		const inboundBookmark = getD1BookmarkFromRequest(request)
-		setRequestWaitUntil(ctx.waitUntil.bind(ctx))
-		await ensureRuntimeBridges(env)
-		return runWithD1RequestContext(request, async () => {
-			const preRouter = await runPreRouterPipeline(request, env, ctx)
-			const preRouterResponse = preRouter.response
-			if (preRouterResponse) {
-				const headers = new Headers(preRouterResponse.headers)
-				headers.set('X-Cache-Stats', formatCacheRequestStatsHeader(cacheStats))
-				headers.set('X-D1-Stats', formatD1RequestStatsHeader(d1Stats))
-				logRequest(
-					request,
-					new Response(preRouterResponse.body, {
-						status: preRouterResponse.status,
-						statusText: preRouterResponse.statusText,
-						headers,
-					}),
-					startedAt,
-				)
-				return new Response(preRouterResponse.body, {
-					status: preRouterResponse.status,
-					statusText: preRouterResponse.statusText,
-					headers,
-				})
-			}
-
-			const cspNonce = createCspNonce()
-			const handler = await getSiteRequestHandler(request)
-			let response = await handler(request, {
-				cloudflare: { env, ctx },
-				cspNonce,
-			} as AppLoadContext)
-
-			const url = new URL(request.url)
-			const acceptHeader = request.headers.get('Accept') ?? ''
-			if (requestPrefersMarkdown(acceptHeader)) {
-				const { maybeConvertHtmlResponseToMarkdown } =
-					await getMarkdownNegotiation()
-				response = await maybeConvertHtmlResponseToMarkdown(response)
-			}
-
-			const headers = new Headers(response.headers)
-			applyHelmetSecurityHeaders(headers)
-			applyCspHeaders({
-				headers,
-				request,
-				cspNonce,
-				mode: import.meta.env.DEV ? 'development' : 'production',
-			})
-			const mocks = getStringEnvBindings(env).MOCKS === 'true'
-			const rateLimit =
-				preRouter.rateLimit ?? checkRateLimit(request, { mocks })
-			applyRateLimitHeaders(headers, rateLimit)
-			if (
-				rateLimit.tier === 'markdown' &&
-				rateLimit.remaining <= rateLimit.limit / 2
-			) {
-				const hints = getAgentSearchHintHeaders(url.pathname)
-				for (const [key, value] of Object.entries(hints)) {
-					headers.set(key, value)
-				}
-			}
-			if (url.pathname.startsWith('/.well-known/')) {
-				headers.set('Access-Control-Allow-Origin', '*')
-			}
-			if (
-				response.ok &&
-				Boolean(
-					headers.get('content-type')?.match(/\btext\/(html|markdown)\b/i),
-				)
-			) {
-				appendVaryAccept(headers)
-			}
-			headers.set('X-Cache-Stats', formatCacheRequestStatsHeader(cacheStats))
-			headers.set('X-D1-Stats', formatD1RequestStatsHeader(d1Stats))
-
-			const outboundBookmark = await getOutboundD1Bookmark()
-			if (
-				outboundBookmark &&
-				outboundBookmark !== inboundBookmark &&
-				outboundBookmark !== 'first-unconstrained' &&
-				outboundBookmark !== 'first-primary'
-			) {
-				appendD1BookmarkCookie(headers, outboundBookmark)
-			}
-			const finalResponse = new Response(response.body, {
-				status: response.status,
-				statusText: response.statusText,
-				headers,
-			})
-			logRequest(request, finalResponse, startedAt)
-			return finalResponse
-		})
-	})
-}
-
-export default {
-	async fetch(
-		request: Request,
-		env: WorkerEnv,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		try {
-			return await handleSiteRequest(request, env, ctx)
-		} catch (error: unknown) {
-			console.error('dev-worker fetch failed', error)
-			return new Response('Internal Server Error', { status: 500 })
-		}
+export default createWorkerFetchHandler({
+	redirectsText,
+	ensureRuntimeBridges,
+	handleEarlyRequest,
+	requestHandlerMode: import.meta.env.MODE,
+	cspMode: import.meta.env.DEV ? 'development' : 'production',
+	errorLogLabel: 'dev-worker fetch failed',
+	async getServerBuild() {
+		return async () =>
+			(await import('virtual:react-router/server-build')) as ServerBuild
 	},
-}
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`services/site/workers/dev-entry.ts` (591 lines) and `services/site-worker/src/dynamic/bootstrap.ts` (571 lines) hand-maintained near-identical request pipelines — the largest remaining duplication from the Fly → Cloudflare migration (#813), and a silent-drift risk since both copies of rate limiting, CSP, redirects, markdown negotiation, and stats headers had to be edited in lockstep.

This extracts one shared module, `services/site/app/utils/worker-request-pipeline.server.ts` (~550 lines), exporting a `createWorkerFetchHandler(options)` factory. Both entries are now thin wrappers (dev-entry 146 lines, bootstrap 116 lines) that supply only their genuine differences. Net **−351 lines**, and the pipeline can no longer drift.

### Shared (moved verbatim into the factory)

Shared React globals publishing, pre-router pipeline (`/img/social`, bogus-crawler 404s, www/blog host redirects, http→https, `_redirects.txt` matching, trailing-slash strip, rate limiting, `/redirect.html`, `/.well-known/` CORS), per-host request-handler cache with `allowedActionOrigins` merging, markdown negotiation, security/CSP headers, agent-search hint headers, Vary handling, `X-Cache-Stats`/`X-D1-Stats`, D1 bookmark cookie, request logging, and the error-wrapping fetch export.

### Per-entry (factory options)

- `ensureRuntimeBridges` — dev: MDX dev manifest + outbound fetch mocks (re-runs each request); prod: `site-content-data.json` + `mdx/{dir}/{slug}.js` loader with cold-start timing (runs once).
- `handleEarlyRequest` — dev-only `/media/*` and `/resources/og-image` (prod's parent worker handles those).
- `getServerBuild` — dev: lazy `virtual:react-router/server-build` per handler; prod: cached static import of the site server build with handler-import timing.
- `decorateResponseHeaders` — prod-only `X-Isolate-Id` + `X-Cold-Start-Timing`.
- `cspMode`, `requestHandlerMode`, `errorLogLabel`, `redirectsText`.

No behavior changes. Subtle behaviors preserved deliberately: the `/redirect.html` branch applies CSP without a mode in both entries (as today), the rate-limit result is reused between pre-router and final response (single quota unit), and the per-host handler-cache rationale comment is retained.

`bootstrap.test.ts` now imports `isBogusCrawlerPath` from the shared module. Architecture doc updated to mention the shared pipeline.

## Testing

- ✅ `npm run lint` + `npm run typecheck` (both workspaces)
- ✅ `npm run test:backend --workspace kentcdodds.com` (64 files / 207 tests)
- ✅ `npm run test --workspace site-worker` (81 tests, incl. `bootstrap.test.ts`)
- ✅ `npm run build --workspace kentcdodds.com` and `npm run build:app-worker --workspace site-worker` (esbuild bundle of the refactored bootstrap + shared module)
- ✅ `npm run test:e2e:run` — all 13 Playwright e2e tests pass through the refactored dev entry
- ✅ Dev-server smoke: `/` 200 with `X-Cache-Stats`/`X-D1-Stats`, `streamController.enqueue` present (SSR streaming contract), `/blog/` → 301 `/blog`, `Accept: text/markdown` negotiation, bogus-crawler 404, `/redirect.html` CSP header
- ✅ Manual GUI walkthrough (recorded): homepage, theme toggle (light/dark SSR + fetcher round trip), blog list, MDX post rendering with code blocks, trailing-slash redirect, `/chats`

<a href="https://cursor.com/agents/bc-b128be5a-0496-4cfa-98c2-6f5fe281a3f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshared_pipeline_dev_site_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-66c4d7a5-a311-425c-bd2b-06fb4a7216c3" alt="shared_pipeline_dev_site_walkthrough.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b128be5a-0496-4cfa-98c2-6f5fe281a3f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b128be5a-0496-4cfa-98c2-6f5fe281a3f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling consistency for the site worker, including redirects, security headers, rate limiting, and markdown response behavior.
  * Dev requests now route through a shared flow, with special handling preserved for media and OG image requests.

* **Documentation**
  * Clarified how the worker bootstrap and development entry point are expected to behave, making the architecture easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->