### PR TITLE
Fix recurring phantom RSS post

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -90,6 +90,8 @@ reference:
   otherwise MSW passthrough sends traffic to that URL (e.g. local `wrangler dev`
   on `http://127.0.0.1:8787`). Tests expect a mock URL (see `.env.example`).
 - Content is filesystem-based: blog posts are MDX files in `services/site/content/blog/`.
+  `README.md` is repository documentation, not a post, and must stay out of
+  `blogList`; syndication routes consume that list directly.
   The MDX dev-watcher sidecar (`other/mdx-artifacts/dev-watcher.ts`) compiles
   content to `node_modules/.cache/mdx-dev/` and triggers Vite full-reload on change.
 - `npm run dev` runs concurrently: MDX dev-watcher sidecar + `react-router dev`

--- a/services/site/app/utils/mdx.server.ts
+++ b/services/site/app/utils/mdx.server.ts
@@ -322,27 +322,7 @@ export async function getLocalBlogMdxListItemsUncached() {
 		return aTime > zTime ? -1 : aTime === zTime ? 0 : 1
 	})
 
-	const readmeListItem = await getReadmeBlogListItem()
-	if (readmeListItem) pages.push(readmeListItem)
-
 	return pages
-}
-
-async function getReadmeBlogListItem(): Promise<Omit<MdxPage, 'code'> | null> {
-	const filePath = path.join(process.cwd(), 'content', 'blog', 'README.md')
-	try {
-		const source = await fs.readFile(filePath, 'utf8')
-		const frontmatter = parseYamlFrontmatter(source) as MdxPage['frontmatter']
-		return {
-			slug: 'README',
-			editLink: `https://github.com/kentcdodds/kentcdodds.com/edit/main/${toGitHubEditPath(filePath)}`,
-			readTime: calculateReadingTime(source),
-			dateDisplay: frontmatter.date ? formatDate(frontmatter.date) : undefined,
-			frontmatter,
-		}
-	} catch {
-		return null
-	}
 }
 
 function toMdxDirListEntry(

--- a/services/site/other/mdx-artifacts/__tests__/blog-list.test.ts
+++ b/services/site/other/mdx-artifacts/__tests__/blog-list.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest'
+import { getLocalBlogMdxListItemsUncached } from '#app/utils/mdx.server.ts'
+
+test('blog list excludes non-post README files', async () => {
+	const posts = await getLocalBlogMdxListItemsUncached()
+
+	expect(posts.some((post) => /^readme$/i.test(post.slug))).toBe(false)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- exclude the blog README from generated `blogList` artifacts
- add a regression test proving non-post README files cannot enter syndication data
- document the content-list boundary for future artifact changes

## Root cause
The Cloudflare artifact migration explicitly appended `content/blog/README.md` to `blogList`. RSS consumed that list directly and filled the README's absent metadata with `Untitled Post`, `This post is... indescribable`, and the current date, causing feed readers to repeatedly surface it as new.

## Verification
- live baseline: 213 items, including the `/blog/README` phantom
- local treatment: 212 items, no phantom fallback text or README URL
- local `/blog/README`: 404
- focused regression test passes
- pre-commit lint, typecheck, and site build pass
- pre-push test suites pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ef5-09cb-705a-b3e5-88a0f28e0d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ef5-09cb-705a-b3e5-88a0f28e0d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the repository README from the blog listing and syndication feeds.
  - Blog listings now include only eligible blog posts, excluding documentation files.

- **Tests**
  - Added coverage to verify README files are not included in blog results.

- **Documentation**
  - Clarified that the repository README is documentation and should not be treated as a blog post.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->