### PR TITLE
Refresh Call Kent caches after publishing

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -119,6 +119,13 @@ reference:
   worker's outbound fetch mocks end-to-end, but running the real worker sandbox
   locally requires Docker plus real R2-accessible inputs. The sandbox image
   expects `services/call-kent-audio-worker/assets/{intro,interstitial,outro}.mp3`.
+- Transistor episode-list ordering is not chronological across Call Kent
+  seasons. Determine the current season from the maximum `season` across every
+  paginated result; selecting the first descending result can publish into
+  Season 1.
+- Call Kent publish waits until the new Transistor episode is list-ready, then
+  rotates both the episode-cache key and parent page-cache generation before
+  redirecting. Keep those invalidations after durable caller-episode persistence.
 
 ## Mock architecture
 

--- a/services/site-worker/src/rpc/cache-rpc.test.ts
+++ b/services/site-worker/src/rpc/cache-rpc.test.ts
@@ -1,5 +1,4 @@
 import { expect, test, vi } from 'vitest'
-import { callKentEpisodesCacheGenerationKey } from '../../../site/app/utils/call-kent-cache-keys.ts'
 import { CacheRpc } from './cache-rpc.ts'
 import type { ParentWorkerEnv } from './types.ts'
 
@@ -16,7 +15,7 @@ test('bumpPageCacheGeneration updates CONTENT_KV', async () => {
 	expect(put).toHaveBeenCalledWith('page-cache:generation', '1784085261000')
 })
 
-test('invalidates Call Kent episode and page cache generations together', async () => {
+test('bumps a named cache generation in CONTENT_KV', async () => {
 	vi.useFakeTimers()
 	vi.setSystemTime(new Date('2026-07-15T03:14:21.000Z'))
 	const put = vi.fn().mockResolvedValue(undefined)
@@ -25,26 +24,24 @@ test('invalidates Call Kent episode and page cache generations together', async 
 	} as unknown as ParentWorkerEnv
 	const rpc = new CacheRpc({} as ExecutionContext, env)
 
-	await expect(rpc.invalidateCallKentCaches()).resolves.toEqual({
-		episodesCacheGeneration: '1784085261000',
-		pageCacheGeneration: '1784085261000',
-	})
-	expect(put).toHaveBeenCalledWith(
-		callKentEpisodesCacheGenerationKey,
+	await expect(rpc.bumpGeneration('transistor-episodes:12345')).resolves.toBe(
 		'1784085261000',
 	)
-	expect(put).toHaveBeenCalledWith('page-cache:generation', '1784085261000')
+	expect(put).toHaveBeenCalledWith(
+		'cache:generation:transistor-episodes:12345',
+		'1784085261000',
+	)
 })
 
-test('reads the persisted Call Kent episode cache generation', async () => {
+test('reads a named cache generation from CONTENT_KV', async () => {
 	const get = vi.fn().mockResolvedValue('episodes-123')
 	const env = {
 		CONTENT_KV: { get },
 	} as unknown as ParentWorkerEnv
 	const rpc = new CacheRpc({} as ExecutionContext, env)
 
-	await expect(rpc.getCallKentEpisodesCacheGeneration()).resolves.toBe(
+	await expect(rpc.getGeneration('transistor-episodes:12345')).resolves.toBe(
 		'episodes-123',
 	)
-	expect(get).toHaveBeenCalledWith(callKentEpisodesCacheGenerationKey)
+	expect(get).toHaveBeenCalledWith('cache:generation:transistor-episodes:12345')
 })

--- a/services/site-worker/src/rpc/cache-rpc.test.ts
+++ b/services/site-worker/src/rpc/cache-rpc.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest'
+import { callKentEpisodesCacheGenerationKey } from '../../../site/app/utils/call-kent-cache-keys.ts'
+import { CacheRpc } from './cache-rpc.ts'
+import type { ParentWorkerEnv } from './types.ts'
+
+test('bumpPageCacheGeneration updates CONTENT_KV', async () => {
+	vi.useFakeTimers()
+	vi.setSystemTime(new Date('2026-07-15T03:14:21.000Z'))
+	const put = vi.fn().mockResolvedValue(undefined)
+	const env = {
+		CONTENT_KV: { put },
+	} as unknown as ParentWorkerEnv
+	const rpc = new CacheRpc({} as ExecutionContext, env)
+
+	await expect(rpc.bumpPageCacheGeneration()).resolves.toBe('1784085261000')
+	expect(put).toHaveBeenCalledWith('page-cache:generation', '1784085261000')
+})
+
+test('invalidates Call Kent episode and page cache generations together', async () => {
+	vi.useFakeTimers()
+	vi.setSystemTime(new Date('2026-07-15T03:14:21.000Z'))
+	const put = vi.fn().mockResolvedValue(undefined)
+	const env = {
+		CONTENT_KV: { put },
+	} as unknown as ParentWorkerEnv
+	const rpc = new CacheRpc({} as ExecutionContext, env)
+
+	await expect(rpc.invalidateCallKentCaches()).resolves.toEqual({
+		episodesCacheGeneration: '1784085261000',
+		pageCacheGeneration: '1784085261000',
+	})
+	expect(put).toHaveBeenCalledWith(
+		callKentEpisodesCacheGenerationKey,
+		'1784085261000',
+	)
+	expect(put).toHaveBeenCalledWith('page-cache:generation', '1784085261000')
+})
+
+test('reads the persisted Call Kent episode cache generation', async () => {
+	const get = vi.fn().mockResolvedValue('episodes-123')
+	const env = {
+		CONTENT_KV: { get },
+	} as unknown as ParentWorkerEnv
+	const rpc = new CacheRpc({} as ExecutionContext, env)
+
+	await expect(rpc.getCallKentEpisodesCacheGeneration()).resolves.toBe(
+		'episodes-123',
+	)
+	expect(get).toHaveBeenCalledWith(callKentEpisodesCacheGenerationKey)
+})

--- a/services/site-worker/src/rpc/cache-rpc.ts
+++ b/services/site-worker/src/rpc/cache-rpc.ts
@@ -5,7 +5,6 @@ import {
 	encodeCacheEntry,
 	getKvExpirationTtl,
 } from '../../../site/app/utils/cache-encoding.server.ts'
-import { callKentEpisodesCacheGenerationKey } from '../../../site/app/utils/call-kent-cache-keys.ts'
 import type { ParentWorkerEnv } from './types.ts'
 import { bumpPageCacheGeneration } from '../page-cache.ts'
 import {
@@ -16,6 +15,7 @@ import {
 
 const KV_VALUE_PREFIX = 'cache:value:'
 const KV_METADATA_PREFIX = 'cache:metadata:'
+const CACHE_GENERATION_PREFIX = 'cache:generation:'
 const KV_EDGE_CACHE_TTL_SECONDS = 60
 
 export class CacheRpc extends WorkerEntrypoint<ParentWorkerEnv> {
@@ -79,21 +79,19 @@ export class CacheRpc extends WorkerEntrypoint<ParentWorkerEnv> {
 		return bumpPageCacheGeneration(this.env.CONTENT_KV)
 	}
 
-	async getCallKentEpisodesCacheGeneration() {
+	async getGeneration(name: string) {
 		return (
-			(await this.env.CONTENT_KV.get(callKentEpisodesCacheGenerationKey)) ?? '0'
+			(await this.env.CONTENT_KV.get(`${CACHE_GENERATION_PREFIX}${name}`)) ??
+			'0'
 		)
 	}
 
-	async invalidateCallKentCaches() {
-		const episodesCacheGeneration = Date.now().toString()
+	async bumpGeneration(name: string) {
+		const generation = Date.now().toString()
 		await this.env.CONTENT_KV.put(
-			callKentEpisodesCacheGenerationKey,
-			episodesCacheGeneration,
+			`${CACHE_GENERATION_PREFIX}${name}`,
+			generation,
 		)
-		const pageCacheGeneration = await bumpPageCacheGeneration(
-			this.env.CONTENT_KV,
-		)
-		return { episodesCacheGeneration, pageCacheGeneration }
+		return generation
 	}
 }

--- a/services/site-worker/src/rpc/cache-rpc.ts
+++ b/services/site-worker/src/rpc/cache-rpc.ts
@@ -5,7 +5,9 @@ import {
 	encodeCacheEntry,
 	getKvExpirationTtl,
 } from '../../../site/app/utils/cache-encoding.server.ts'
+import { callKentEpisodesCacheGenerationKey } from '../../../site/app/utils/call-kent-cache-keys.ts'
 import type { ParentWorkerEnv } from './types.ts'
+import { bumpPageCacheGeneration } from '../page-cache.ts'
 import {
 	deleteKvCacheLruEntry,
 	getKvCacheLruEntry,
@@ -71,5 +73,27 @@ export class CacheRpc extends WorkerEntrypoint<ParentWorkerEnv> {
 		})
 
 		return list.keys.map((entry) => entry.name.slice(KV_VALUE_PREFIX.length))
+	}
+
+	async bumpPageCacheGeneration() {
+		return bumpPageCacheGeneration(this.env.CONTENT_KV)
+	}
+
+	async getCallKentEpisodesCacheGeneration() {
+		return (
+			(await this.env.CONTENT_KV.get(callKentEpisodesCacheGenerationKey)) ?? '0'
+		)
+	}
+
+	async invalidateCallKentCaches() {
+		const episodesCacheGeneration = Date.now().toString()
+		await this.env.CONTENT_KV.put(
+			callKentEpisodesCacheGenerationKey,
+			episodesCacheGeneration,
+		)
+		const pageCacheGeneration = await bumpPageCacheGeneration(
+			this.env.CONTENT_KV,
+		)
+		return { episodesCacheGeneration, pageCacheGeneration }
 	}
 }

--- a/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
+++ b/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
@@ -11,6 +11,7 @@ vi.mock('#app/utils/cache.server.ts', () => ({
 			getFreshValue(),
 	),
 	shouldForceFresh: vi.fn(() => false),
+	invalidatePageCache: vi.fn(),
 }))
 
 vi.mock('#app/utils/session.server.ts', () => ({
@@ -29,8 +30,15 @@ vi.mock('#app/utils/db.server.ts', () => ({
 		create: vi.fn(async (_table, data: { id: string }) => ({
 			id: data.id,
 		})),
+		findOne: vi.fn(),
+		update: vi.fn(),
 		updateMany: vi.fn(),
 	},
+}))
+
+vi.mock('#app/utils/auth-write-flows.server.ts', () => ({
+	recordPublishedCallKentEpisode: vi.fn(),
+	replaceCallKentEpisodeDraft: vi.fn(),
 }))
 
 vi.mock('#app/utils/call-kent-transcription-queue.server.ts', () => ({
@@ -47,6 +55,7 @@ vi.mock('#app/utils/send-email.server.ts', () => ({
 
 vi.mock('#app/utils/transistor.server.ts', () => ({
 	createEpisode: vi.fn(),
+	refreshEpisodesAfterPublish: vi.fn(),
 }))
 
 vi.mock('#app/utils/markdown.server.ts', () => ({
@@ -95,7 +104,14 @@ vi.mock('#app/utils/call-kent-audio-storage.server.ts', () => ({
 
 import { putCallAudioFromDataUrl } from '#app/utils/call-kent-audio-storage.server.ts'
 import { enqueueCallKentTranscriptionJob } from '#app/utils/call-kent-transcription-queue.server.ts'
+import { invalidatePageCache } from '#app/utils/cache.server.ts'
 import { db } from '#app/utils/db.server.ts'
+import { recordPublishedCallKentEpisode } from '#app/utils/auth-write-flows.server.ts'
+import { sendEmail } from '#app/utils/send-email.server.ts'
+import {
+	createEpisode,
+	refreshEpisodesAfterPublish,
+} from '#app/utils/transistor.server.ts'
 import { action } from '../save.tsx'
 
 test('create-call accepts a large multipart audio file', async () => {
@@ -341,4 +357,94 @@ test('create-call rejects malformed legacy audio strings', async () => {
 		},
 	})
 	expect(putCallAudioFromDataUrl).not.toHaveBeenCalled()
+})
+
+test('publish invalidates the parent page cache after persistence without failing the redirect', async () => {
+	vi.clearAllMocks()
+	vi.mocked(db.findOne).mockResolvedValueOnce({
+		id: 'call_1',
+		userId: 'user_1',
+		title: 'Call title',
+		notes: null,
+		isAnonymous: false,
+		audioKey: 'call-audio',
+		createdAt: new Date('2026-07-15T03:00:00.000Z'),
+		user: {
+			firstName: 'Probe',
+			email: 'probe@example.com',
+			team: 'BLUE',
+		},
+		episodeDraft: {
+			status: 'READY',
+			title: 'Exploring Interests at 15',
+			description: 'Episode description',
+			keywords: 'interests,learning',
+			transcript: 'Probe: How should I explore my interests?',
+			episodeAudioKey: 'episode-audio',
+			responseAudioKey: null,
+			callerSegmentAudioKey: null,
+			responseSegmentAudioKey: null,
+		},
+	} as never)
+	vi.mocked(createEpisode).mockResolvedValueOnce({
+		transistorEpisodeId: 'episode_28',
+		episodeUrl: 'https://kentcdodds.com/calls/05/28/exploring-interests-at-15',
+		episodePath: '/calls/05/28/exploring-interests-at-15',
+		imageUrl: 'https://kentcdodds.com/resources/og-image',
+		seasonNumber: 5,
+		episodeNumber: 28,
+		slug: 'exploring-interests-at-15',
+	})
+	vi.mocked(recordPublishedCallKentEpisode).mockResolvedValueOnce(undefined)
+	vi.mocked(refreshEpisodesAfterPublish).mockResolvedValueOnce(true)
+	vi.mocked(invalidatePageCache).mockRejectedValueOnce(
+		new Error('CACHE_RPC unavailable'),
+	)
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const body = new URLSearchParams({
+		intent: 'publish-episode-draft',
+		callId: 'call_1',
+	})
+	const request = new Request('http://localhost/resources/calls/save', {
+		method: 'POST',
+		body,
+	})
+
+	try {
+		const response = (await action({ request } as never)) as Response
+
+		expect(response.status).toBe(302)
+		expect(response.headers.get('location')).toBe('/calls')
+		expect(recordPublishedCallKentEpisode).toHaveBeenCalledOnce()
+		expect(refreshEpisodesAfterPublish).toHaveBeenCalledWith({
+			episodeId: 'episode_28',
+		})
+		expect(invalidatePageCache).toHaveBeenCalledOnce()
+		expect(sendEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: 'probe@example.com',
+				subject: 'Your "Call Kent" episode has been published',
+			}),
+		)
+		expect(
+			vi.mocked(recordPublishedCallKentEpisode).mock.invocationCallOrder[0],
+		).toBeLessThan(
+			vi.mocked(refreshEpisodesAfterPublish).mock.invocationCallOrder[0] ?? 0,
+		)
+		expect(
+			vi.mocked(refreshEpisodesAfterPublish).mock.invocationCallOrder[0],
+		).toBeLessThan(
+			vi.mocked(invalidatePageCache).mock.invocationCallOrder[0] ?? 0,
+		)
+		expect(
+			vi.mocked(invalidatePageCache).mock.invocationCallOrder[0],
+		).toBeLessThan(vi.mocked(sendEmail).mock.invocationCallOrder[0] ?? 0)
+		expect(consoleError).toHaveBeenCalledWith(
+			'Call Kent episode published but page cache invalidation failed.',
+			{ transistorEpisodeId: 'episode_28' },
+			expect.any(Error),
+		)
+	} finally {
+		consoleError.mockRestore()
+	}
 })

--- a/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
+++ b/services/site/app/routes/resources/calls/__tests__/save-create-call.test.ts
@@ -54,6 +54,7 @@ vi.mock('#app/utils/send-email.server.ts', () => ({
 }))
 
 vi.mock('#app/utils/transistor.server.ts', () => ({
+	bumpEpisodesCacheGeneration: vi.fn(),
 	createEpisode: vi.fn(),
 	refreshEpisodesAfterPublish: vi.fn(),
 }))
@@ -109,6 +110,7 @@ import { db } from '#app/utils/db.server.ts'
 import { recordPublishedCallKentEpisode } from '#app/utils/auth-write-flows.server.ts'
 import { sendEmail } from '#app/utils/send-email.server.ts'
 import {
+	bumpEpisodesCacheGeneration,
 	createEpisode,
 	refreshEpisodesAfterPublish,
 } from '#app/utils/transistor.server.ts'
@@ -397,6 +399,7 @@ test('publish invalidates the parent page cache after persistence without failin
 	})
 	vi.mocked(recordPublishedCallKentEpisode).mockResolvedValueOnce(undefined)
 	vi.mocked(refreshEpisodesAfterPublish).mockResolvedValueOnce(true)
+	vi.mocked(bumpEpisodesCacheGeneration).mockResolvedValueOnce('episodes-123')
 	vi.mocked(invalidatePageCache).mockRejectedValueOnce(
 		new Error('CACHE_RPC unavailable'),
 	)
@@ -419,6 +422,7 @@ test('publish invalidates the parent page cache after persistence without failin
 		expect(refreshEpisodesAfterPublish).toHaveBeenCalledWith({
 			episodeId: 'episode_28',
 		})
+		expect(bumpEpisodesCacheGeneration).toHaveBeenCalledOnce()
 		expect(invalidatePageCache).toHaveBeenCalledOnce()
 		expect(sendEmail).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -434,13 +438,18 @@ test('publish invalidates the parent page cache after persistence without failin
 		expect(
 			vi.mocked(refreshEpisodesAfterPublish).mock.invocationCallOrder[0],
 		).toBeLessThan(
+			vi.mocked(bumpEpisodesCacheGeneration).mock.invocationCallOrder[0] ?? 0,
+		)
+		expect(
+			vi.mocked(bumpEpisodesCacheGeneration).mock.invocationCallOrder[0],
+		).toBeLessThan(
 			vi.mocked(invalidatePageCache).mock.invocationCallOrder[0] ?? 0,
 		)
 		expect(
 			vi.mocked(invalidatePageCache).mock.invocationCallOrder[0],
 		).toBeLessThan(vi.mocked(sendEmail).mock.invocationCallOrder[0] ?? 0)
 		expect(consoleError).toHaveBeenCalledWith(
-			'Call Kent episode published but page cache invalidation failed.',
+			'Call Kent episode published but cache invalidation failed.',
 			{ transistorEpisodeId: 'episode_28' },
 			expect.any(Error),
 		)

--- a/services/site/app/routes/resources/calls/save.tsx
+++ b/services/site/app/routes/resources/calls/save.tsx
@@ -11,6 +11,7 @@ import {
 	putEpisodeDraftResponseAudioFromBuffer,
 } from '#app/utils/call-kent-audio-storage.server.ts'
 import { runBackgroundTask } from '#app/utils/background-task.server.ts'
+import { invalidatePageCache } from '#app/utils/cache.server.ts'
 import { requestCallKentEpisodeAudioGeneration } from '#app/utils/call-kent-audio-processor.server.ts'
 import { getPublishedCallKentEpisodeEmail } from '#app/utils/call-kent-published-email.ts'
 import { getErrorForCallKentQuestionText } from '#app/utils/call-kent-text-to-speech.ts'
@@ -43,7 +44,10 @@ import {
 import { sendEmail } from '#app/utils/send-email.server.ts'
 import { requireAdminUser, requireUser } from '#app/utils/session.server.ts'
 import { teamEmoji } from '#app/utils/team-provider.tsx'
-import { createEpisode } from '#app/utils/transistor.server.ts'
+import {
+	createEpisode,
+	refreshEpisodesAfterPublish,
+} from '#app/utils/transistor.server.ts'
 import { type Route } from './+types/save'
 
 type ActionData = RecordingFormData
@@ -390,32 +394,6 @@ async function publishCall({
 		})
 		publishedTransistorEpisodeId = published.transistorEpisodeId
 
-		if (published.episodeUrl) {
-			try {
-				const callUser = call.user
-				const email = getPublishedCallKentEpisodeEmail({
-					firstName: callUser.firstName,
-					episodeTitle: title,
-					episodeUrl: published.episodeUrl,
-					imageUrl: published.imageUrl,
-				})
-				runBackgroundTask(() =>
-					sendEmail({
-						to: callUser.email,
-						from: `"Kent C. Dodds" <hello+calls@kentcdodds.com>`,
-						subject: `Your "Call Kent" episode has been published`,
-						text: email.text,
-						html: email.html,
-					}),
-				)
-			} catch (error: unknown) {
-				console.error(
-					`Problem sending email about a call: ${published.episodeUrl}`,
-					error,
-				)
-			}
-		}
-
 		// Persist a per-caller record so users can see their episodes on /me even
 		// after the raw call record is removed.
 		try {
@@ -437,6 +415,61 @@ async function publishCall({
 				error,
 			)
 			throw error
+		}
+
+		try {
+			const episodeIsListReady = await refreshEpisodesAfterPublish({
+				episodeId: published.transistorEpisodeId,
+			})
+			if (!episodeIsListReady) {
+				console.warn(
+					'Transistor episode was published but did not become list-ready before the refresh timeout.',
+					{ transistorEpisodeId: published.transistorEpisodeId },
+				)
+			}
+		} catch (error: unknown) {
+			// The episode and local caller record are already durable. Cache refresh
+			// failures must not encourage publishing the same episode again.
+			console.error('Unable to refresh episodes after Transistor publish.', {
+				transistorEpisodeId: published.transistorEpisodeId,
+				error,
+			})
+		}
+
+		try {
+			await invalidatePageCache()
+		} catch (error: unknown) {
+			// Publishing and DB persistence have completed. The redirect should
+			// still succeed even if cache invalidation is temporarily unavailable.
+			console.error(
+				'Call Kent episode published but page cache invalidation failed.',
+				{ transistorEpisodeId: published.transistorEpisodeId },
+				error,
+			)
+		}
+
+		if (published.episodeUrl) {
+			try {
+				const callUser = call.user
+				const email = getPublishedCallKentEpisodeEmail({
+					firstName: callUser.firstName,
+					episodeTitle: title,
+					episodeUrl: published.episodeUrl,
+					imageUrl: published.imageUrl,
+				})
+				await sendEmail({
+					to: callUser.email,
+					from: `"Kent C. Dodds" <hello+calls@kentcdodds.com>`,
+					subject: `Your "Call Kent" episode has been published`,
+					text: email.text,
+					html: email.html,
+				})
+			} catch (error: unknown) {
+				console.error(
+					`Problem sending email about a call: ${published.episodeUrl}`,
+					error,
+				)
+			}
 		}
 
 		// Best-effort cleanup of stored audio blobs after publish.

--- a/services/site/app/routes/resources/calls/save.tsx
+++ b/services/site/app/routes/resources/calls/save.tsx
@@ -45,6 +45,7 @@ import { sendEmail } from '#app/utils/send-email.server.ts'
 import { requireAdminUser, requireUser } from '#app/utils/session.server.ts'
 import { teamEmoji } from '#app/utils/team-provider.tsx'
 import {
+	bumpEpisodesCacheGeneration,
 	createEpisode,
 	refreshEpisodesAfterPublish,
 } from '#app/utils/transistor.server.ts'
@@ -417,8 +418,9 @@ async function publishCall({
 			throw error
 		}
 
+		let episodeIsListReady = false
 		try {
-			const episodeIsListReady = await refreshEpisodesAfterPublish({
+			episodeIsListReady = await refreshEpisodesAfterPublish({
 				episodeId: published.transistorEpisodeId,
 			})
 			if (!episodeIsListReady) {
@@ -436,16 +438,19 @@ async function publishCall({
 			})
 		}
 
-		try {
-			await invalidatePageCache()
-		} catch (error: unknown) {
-			// Publishing and DB persistence have completed. The redirect should
-			// still succeed even if cache invalidation is temporarily unavailable.
-			console.error(
-				'Call Kent episode published but page cache invalidation failed.',
-				{ transistorEpisodeId: published.transistorEpisodeId },
-				error,
-			)
+		if (episodeIsListReady) {
+			try {
+				await bumpEpisodesCacheGeneration()
+				await invalidatePageCache()
+			} catch (error: unknown) {
+				// Publishing and DB persistence have completed. The redirect should
+				// still succeed even if cache invalidation is temporarily unavailable.
+				console.error(
+					'Call Kent episode published but cache invalidation failed.',
+					{ transistorEpisodeId: published.transistorEpisodeId },
+					error,
+				)
+			}
 		}
 
 		if (published.episodeUrl) {

--- a/services/site/app/utils/__tests__/auth-write-flows.server.test.ts
+++ b/services/site/app/utils/__tests__/auth-write-flows.server.test.ts
@@ -32,6 +32,19 @@ test('recordPublishedCallKentEpisode upserts the caller episode before deleting 
 	})
 
 	expect(db.exec).toHaveBeenCalledTimes(1)
+	expect(db.exec).toHaveBeenCalledWith(
+		expect.stringContaining('INSERT INTO "CallKentCallerEpisode"'),
+		[
+			expect.any(String),
+			expect.any(String),
+			expect.any(String),
+			'user-1',
+			'Call title',
+			'Call notes',
+			0,
+			'episode-1',
+		],
+	)
 	expect(db.deleteMany).toHaveBeenCalledWith(callTable, {
 		where: { id: 'call-1' },
 	})

--- a/services/site/app/utils/__tests__/cache.server.test.ts
+++ b/services/site/app/utils/__tests__/cache.server.test.ts
@@ -25,9 +25,7 @@ test('uses the lru cache before CACHE_RPC on worker cache hits', async () => {
 	})
 	const { beginCacheRequestStats, cache, formatCacheRequestStatsHeader } =
 		await import('../cache.server.ts')
-	const { runWithRequestContext } = await import(
-		'../request-context.server.ts'
-	)
+	const { runWithRequestContext } = await import('../request-context.server.ts')
 	const key = `worker-cache:${randomUUID()}`
 	const entry = {
 		value: { ok: true },
@@ -46,7 +44,9 @@ test('uses the lru cache before CACHE_RPC on worker cache hits', async () => {
 	})
 
 	expect(rpcGet).not.toHaveBeenCalled()
-	expect(formatCacheRequestStatsHeader(stats)).toBe('lru_hits=1,rpc_calls=0,rpc_ms=0.0')
+	expect(formatCacheRequestStatsHeader(stats)).toBe(
+		'lru_hits=1,rpc_calls=0,rpc_ms=0.0',
+	)
 })
 
 test('lists kv keys from CACHE_RPC in getAllCacheKeys', async () => {
@@ -83,4 +83,44 @@ test('searches kv keys from CACHE_RPC in searchCacheKeys', async () => {
 		lru: expect.any(Array),
 	})
 	expect(cacheRpc.keys).toHaveBeenCalledWith('search', 25)
+})
+
+test('invalidates Call Kent episode and page cache generations through CACHE_RPC', async () => {
+	const invalidateCallKentCaches = vi.fn().mockResolvedValue({
+		episodesCacheGeneration: 'episodes-123',
+		pageCacheGeneration: 'pages-123',
+	})
+	setRuntimeBindingSource({
+		CACHE_RPC: {
+			get: vi.fn(),
+			set: vi.fn(),
+			delete: vi.fn(),
+			keys: vi.fn(),
+			invalidateCallKentCaches,
+		},
+	})
+	const { invalidatePageCache } = await import('../cache.server.ts')
+
+	await expect(invalidatePageCache()).resolves.toBe('pages-123')
+	expect(invalidateCallKentCaches).toHaveBeenCalledOnce()
+})
+
+test('reads the Call Kent episode cache generation through CACHE_RPC', async () => {
+	const getCallKentEpisodesCacheGeneration = vi
+		.fn()
+		.mockResolvedValue('episodes-123')
+	setRuntimeBindingSource({
+		CACHE_RPC: {
+			get: vi.fn(),
+			set: vi.fn(),
+			delete: vi.fn(),
+			keys: vi.fn(),
+			getCallKentEpisodesCacheGeneration,
+		},
+	})
+	const { getCallKentEpisodesCacheGeneration: readGeneration } =
+		await import('../cache.server.ts')
+
+	await expect(readGeneration()).resolves.toBe('episodes-123')
+	expect(getCallKentEpisodesCacheGeneration).toHaveBeenCalledOnce()
 })

--- a/services/site/app/utils/__tests__/cache.server.test.ts
+++ b/services/site/app/utils/__tests__/cache.server.test.ts
@@ -85,42 +85,19 @@ test('searches kv keys from CACHE_RPC in searchCacheKeys', async () => {
 	expect(cacheRpc.keys).toHaveBeenCalledWith('search', 25)
 })
 
-test('invalidates Call Kent episode and page cache generations through CACHE_RPC', async () => {
-	const invalidateCallKentCaches = vi.fn().mockResolvedValue({
-		episodesCacheGeneration: 'episodes-123',
-		pageCacheGeneration: 'pages-123',
-	})
+test('invalidates the parent page cache through CACHE_RPC', async () => {
+	const bumpPageCacheGeneration = vi.fn().mockResolvedValue('pages-123')
 	setRuntimeBindingSource({
 		CACHE_RPC: {
 			get: vi.fn(),
 			set: vi.fn(),
 			delete: vi.fn(),
 			keys: vi.fn(),
-			invalidateCallKentCaches,
+			bumpPageCacheGeneration,
 		},
 	})
 	const { invalidatePageCache } = await import('../cache.server.ts')
 
 	await expect(invalidatePageCache()).resolves.toBe('pages-123')
-	expect(invalidateCallKentCaches).toHaveBeenCalledOnce()
-})
-
-test('reads the Call Kent episode cache generation through CACHE_RPC', async () => {
-	const getCallKentEpisodesCacheGeneration = vi
-		.fn()
-		.mockResolvedValue('episodes-123')
-	setRuntimeBindingSource({
-		CACHE_RPC: {
-			get: vi.fn(),
-			set: vi.fn(),
-			delete: vi.fn(),
-			keys: vi.fn(),
-			getCallKentEpisodesCacheGeneration,
-		},
-	})
-	const { getCallKentEpisodesCacheGeneration: readGeneration } =
-		await import('../cache.server.ts')
-
-	await expect(readGeneration()).resolves.toBe('episodes-123')
-	expect(getCallKentEpisodesCacheGeneration).toHaveBeenCalledOnce()
+	expect(bumpPageCacheGeneration).toHaveBeenCalledOnce()
 })

--- a/services/site/app/utils/__tests__/transistor.server.test.ts
+++ b/services/site/app/utils/__tests__/transistor.server.test.ts
@@ -1,7 +1,9 @@
 import { expect, test, vi } from 'vitest'
 
-const { cacheDelete } = vi.hoisted(() => ({
+const { bumpGeneration, cacheDelete, getGeneration } = vi.hoisted(() => ({
+	bumpGeneration: vi.fn().mockResolvedValue('next'),
 	cacheDelete: vi.fn(),
+	getGeneration: vi.fn().mockResolvedValue('test'),
 }))
 
 vi.mock('../cache.server.ts', () => {
@@ -12,10 +14,13 @@ vi.mock('../cache.server.ts', () => {
 		}: {
 			getFreshValue: (context: {}) => unknown
 		}) => await getFreshValue({}),
-		getCallKentEpisodesCacheGeneration: async () => 'test',
 		shouldForceFresh: async () => true,
 	}
 })
+
+vi.mock('../runtime-bindings.server.ts', () => ({
+	getRuntimeBinding: () => ({ bumpGeneration, getGeneration }),
+}))
 
 function makeEpisode({
 	id,
@@ -109,6 +114,15 @@ test('getCurrentSeason uses the highest season across unordered pages', async ()
 	} finally {
 		fetchSpy.mockRestore()
 	}
+})
+
+test('bumps a show-scoped episode cache generation', async () => {
+	bumpGeneration.mockClear()
+	const { bumpEpisodesCacheGeneration } =
+		await import('../transistor.server.ts')
+
+	await expect(bumpEpisodesCacheGeneration()).resolves.toBe('next')
+	expect(bumpGeneration).toHaveBeenCalledWith('transistor-episodes:12345')
 })
 
 test('an immediate refresh can cache an episode before it is list-ready', async () => {

--- a/services/site/app/utils/__tests__/transistor.server.test.ts
+++ b/services/site/app/utils/__tests__/transistor.server.test.ts
@@ -1,16 +1,52 @@
 import { expect, test, vi } from 'vitest'
 
+const { cacheDelete } = vi.hoisted(() => ({
+	cacheDelete: vi.fn(),
+}))
+
 vi.mock('../cache.server.ts', () => {
 	return {
-		cache: {},
+		cache: { delete: cacheDelete },
 		cachified: async ({
 			getFreshValue,
 		}: {
 			getFreshValue: (context: {}) => unknown
 		}) => await getFreshValue({}),
+		getCallKentEpisodesCacheGeneration: async () => 'test',
 		shouldForceFresh: async () => true,
 	}
 })
+
+function makeEpisode({
+	id,
+	audioProcessing,
+}: {
+	id: string
+	audioProcessing: boolean
+}) {
+	return {
+		id,
+		type: 'episode',
+		attributes: {
+			number: 28,
+			season: 5,
+			title: 'Exploring Interests at 15',
+			summary: 'summary',
+			description: '<p>description</p>',
+			keywords: 'testing',
+			duration: 231,
+			status: 'published',
+			image_url: 'https://example.com/image.jpg',
+			media_url: 'https://example.com/audio.mp3',
+			share_url: 'https://example.com/share',
+			embed_html: '',
+			embed_html_dark: '',
+			published_at: '2026-07-15T03:14:21.000Z',
+			updated_at: '2026-07-15T03:14:21.000Z',
+			audio_processing: audioProcessing,
+		},
+	}
+}
 
 test('getEpisodes does not forward signal to fetch', async () => {
 	const { getEpisodes } = await import('../transistor.server.ts')
@@ -41,6 +77,138 @@ test('getEpisodes does not forward signal to fetch', async () => {
 		expect(transistorCall).toBeTruthy()
 		const requestInit = transistorCall?.[1] as RequestInit | undefined
 		expect(requestInit?.signal).toBeUndefined()
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})
+
+test('getCurrentSeason uses the highest season across unordered pages', async () => {
+	const { getCurrentSeason } = await import('../transistor.server.ts')
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) => {
+			const url = new URL(String(input))
+			const page = url.searchParams.get('pagination[page]')
+			return Response.json({
+				data: [
+					{
+						id: page === '1' ? 'season-one' : 'season-five',
+						attributes: { season: page === '1' ? 1 : 5 },
+					},
+				],
+				meta: { totalPages: 2 },
+			})
+		})
+
+	try {
+		await expect(getCurrentSeason()).resolves.toBe(5)
+		expect(fetchSpy).toHaveBeenCalledTimes(2)
+		for (const [input] of fetchSpy.mock.calls) {
+			expect(new URL(String(input)).searchParams.get('show_id')).toBe('12345')
+		}
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})
+
+test('an immediate refresh can cache an episode before it is list-ready', async () => {
+	const { getEpisodes } = await import('../transistor.server.ts')
+	const episodeId = 'new-episode'
+	let listRequest = 0
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) => {
+			if (!String(input).startsWith('https://api.transistor.fm/')) {
+				return new Response(null, { status: 200 })
+			}
+			listRequest++
+			const audioProcessing = listRequest === 1
+			return Response.json({
+				data: [makeEpisode({ id: episodeId, audioProcessing })],
+				meta: { totalPages: 1 },
+			})
+		})
+
+	try {
+		const immediate = await getEpisodes({ forceFresh: true })
+
+		const later = await getEpisodes({ forceFresh: true })
+
+		expect(immediate).toEqual([])
+		expect(later.map((episode) => episode.transistorEpisodeId)).toContain(
+			episodeId,
+		)
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})
+
+test('post-publish refresh polls until the new episode is list-ready', async () => {
+	const { refreshEpisodesAfterPublish } =
+		await import('../transistor.server.ts')
+	const episodeId = 'eventually-ready-episode'
+	let listRequest = 0
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) => {
+			if (!String(input).startsWith('https://api.transistor.fm/')) {
+				return new Response(null, { status: 200 })
+			}
+			listRequest++
+			return Response.json({
+				data: [
+					makeEpisode({
+						id: episodeId,
+						audioProcessing: listRequest === 1,
+					}),
+				],
+				meta: { totalPages: 1 },
+			})
+		})
+
+	try {
+		const ready = await refreshEpisodesAfterPublish({
+			episodeId,
+			attempts: 3,
+			delayMs: 1,
+			sleep: async () => {},
+		})
+
+		expect(ready).toBe(true)
+		expect(listRequest).toBe(2)
+		expect(cacheDelete).not.toHaveBeenCalled()
+	} finally {
+		fetchSpy.mockRestore()
+	}
+})
+
+test('post-publish refresh clears an incomplete list after timeout', async () => {
+	cacheDelete.mockClear()
+	const { refreshEpisodesAfterPublish } =
+		await import('../transistor.server.ts')
+	const episodeId = 'still-processing-episode'
+	const fetchSpy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) => {
+			if (!String(input).startsWith('https://api.transistor.fm/')) {
+				return new Response(null, { status: 200 })
+			}
+			return Response.json({
+				data: [makeEpisode({ id: episodeId, audioProcessing: true })],
+				meta: { totalPages: 1 },
+			})
+		})
+
+	try {
+		await expect(
+			refreshEpisodesAfterPublish({
+				episodeId,
+				attempts: 2,
+				delayMs: 1,
+				sleep: async () => {},
+			}),
+		).resolves.toBe(false)
+		expect(cacheDelete).toHaveBeenCalledWith('transistor:episodes:12345:test')
 	} finally {
 		fetchSpy.mockRestore()
 	}

--- a/services/site/app/utils/__tests__/transistor.server.test.ts
+++ b/services/site/app/utils/__tests__/transistor.server.test.ts
@@ -87,6 +87,22 @@ test('getEpisodes does not forward signal to fetch', async () => {
 	}
 })
 
+test('getEpisodes returns the empty fallback when cache generation lookup fails', async () => {
+	getGeneration.mockRejectedValueOnce(new Error('generation unavailable'))
+	const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+	const { getEpisodes } = await import('../transistor.server.ts')
+
+	try {
+		await expect(getEpisodes({ forceFresh: true })).resolves.toEqual([])
+		expect(consoleError).toHaveBeenCalledWith(
+			'transistor: cachified failed to resolve episodes, returning empty fallback',
+			expect.any(Error),
+		)
+	} finally {
+		consoleError.mockRestore()
+	}
+})
+
 test('getCurrentSeason uses the highest season across unordered pages', async () => {
 	const { getCurrentSeason } = await import('../transistor.server.ts')
 	const fetchSpy = vi

--- a/services/site/app/utils/auth-write-flows.server.ts
+++ b/services/site/app/utils/auth-write-flows.server.ts
@@ -1,7 +1,6 @@
 import { query } from '@remix-run/data-table'
 import { db } from './db.server.ts'
 import {
-	callKentCallerEpisodeTable,
 	callKentEpisodeDraftTable,
 	callTable,
 	passwordTable,
@@ -23,25 +22,37 @@ async function recordPublishedCallKentEpisode({
 	isAnonymous: boolean
 	transistorEpisodeId: string
 }) {
+	const now = new Date().toISOString()
 	await db.exec(
-		query(callKentCallerEpisodeTable).upsert(
-			{
-				userId,
-				callTitle,
-				callNotes,
-				isAnonymous,
-				transistorEpisodeId,
-			},
-			{
-				conflictTarget: ['transistorEpisodeId'],
-				update: {
-					userId,
-					callTitle,
-					callNotes,
-					isAnonymous,
-				},
-			},
-		),
+		`
+			INSERT INTO "CallKentCallerEpisode" (
+				"id",
+				"createdAt",
+				"updatedAt",
+				"userId",
+				"callTitle",
+				"callNotes",
+				"isAnonymous",
+				"transistorEpisodeId"
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT ("transistorEpisodeId") DO UPDATE SET
+				"updatedAt" = excluded."updatedAt",
+				"userId" = excluded."userId",
+				"callTitle" = excluded."callTitle",
+				"callNotes" = excluded."callNotes",
+				"isAnonymous" = excluded."isAnonymous"
+		`,
+		[
+			crypto.randomUUID(),
+			now,
+			now,
+			userId,
+			callTitle,
+			callNotes,
+			Number(isAnonymous),
+			transistorEpisodeId,
+		],
 	)
 	await db.deleteMany(callTable, { where: { id: callId } })
 }

--- a/services/site/app/utils/cache.server.ts
+++ b/services/site/app/utils/cache.server.ts
@@ -28,6 +28,12 @@ type CacheRpcBinding = {
 	set(key: string, entry: CacheEntry<unknown>): Promise<void>
 	delete(key: string): Promise<void>
 	keys(prefix?: string, limit?: number): Promise<Array<string>>
+	bumpPageCacheGeneration?(): Promise<string>
+	getCallKentEpisodesCacheGeneration?(): Promise<string>
+	invalidateCallKentCaches?(): Promise<{
+		episodesCacheGeneration: string
+		pageCacheGeneration: string
+	}>
 }
 
 function getCacheRpcBinding(): CacheRpcBinding | undefined {
@@ -81,6 +87,23 @@ export function getPersistentCacheLabel() {
 	return 'KV'
 }
 
+export async function invalidatePageCache() {
+	const rpc = getCacheRpcBinding()
+	if (typeof rpc?.invalidateCallKentCaches === 'function') {
+		return (await rpc.invalidateCallKentCaches()).pageCacheGeneration
+	}
+	if (typeof rpc?.bumpPageCacheGeneration !== 'function') return null
+	return rpc.bumpPageCacheGeneration()
+}
+
+export async function getCallKentEpisodesCacheGeneration() {
+	const rpc = getCacheRpcBinding()
+	if (typeof rpc?.getCallKentEpisodesCacheGeneration !== 'function') {
+		return 'local'
+	}
+	return rpc.getCallKentEpisodesCacheGeneration()
+}
+
 export const lruCache = {
 	set(key, value) {
 		const ttl = totalTtl(value.metadata)
@@ -110,7 +133,11 @@ async function setDirectKvCacheEntry(key: string, entry: CacheEntry<unknown>) {
 	if (!kv) return
 	const encoded = encodeCacheEntry(entry)
 	const expirationTtl = getKvExpirationTtl(entry)
-	await kv.put(key, JSON.stringify(encoded), expirationTtl ? { expirationTtl } : undefined)
+	await kv.put(
+		key,
+		JSON.stringify(encoded),
+		expirationTtl ? { expirationTtl } : undefined,
+	)
 }
 
 async function deleteDirectKvCacheEntry(key: string) {
@@ -119,7 +146,10 @@ async function deleteDirectKvCacheEntry(key: string) {
 	await kv.delete(key)
 }
 
-async function listDirectKvCacheKeys(prefix: string | undefined, limit: number) {
+async function listDirectKvCacheKeys(
+	prefix: string | undefined,
+	limit: number,
+) {
 	const kv = getDirectKvBinding()
 	if (!kv) return []
 	const listed = await kv.list({ prefix, limit })

--- a/services/site/app/utils/cache.server.ts
+++ b/services/site/app/utils/cache.server.ts
@@ -29,11 +29,6 @@ type CacheRpcBinding = {
 	delete(key: string): Promise<void>
 	keys(prefix?: string, limit?: number): Promise<Array<string>>
 	bumpPageCacheGeneration?(): Promise<string>
-	getCallKentEpisodesCacheGeneration?(): Promise<string>
-	invalidateCallKentCaches?(): Promise<{
-		episodesCacheGeneration: string
-		pageCacheGeneration: string
-	}>
 }
 
 function getCacheRpcBinding(): CacheRpcBinding | undefined {
@@ -89,19 +84,8 @@ export function getPersistentCacheLabel() {
 
 export async function invalidatePageCache() {
 	const rpc = getCacheRpcBinding()
-	if (typeof rpc?.invalidateCallKentCaches === 'function') {
-		return (await rpc.invalidateCallKentCaches()).pageCacheGeneration
-	}
 	if (typeof rpc?.bumpPageCacheGeneration !== 'function') return null
 	return rpc.bumpPageCacheGeneration()
-}
-
-export async function getCallKentEpisodesCacheGeneration() {
-	const rpc = getCacheRpcBinding()
-	if (typeof rpc?.getCallKentEpisodesCacheGeneration !== 'function') {
-		return 'local'
-	}
-	return rpc.getCallKentEpisodesCacheGeneration()
 }
 
 export const lruCache = {

--- a/services/site/app/utils/call-kent-cache-keys.ts
+++ b/services/site/app/utils/call-kent-cache-keys.ts
@@ -1,0 +1,2 @@
+export const callKentEpisodesCacheGenerationKey =
+	'call-kent:episodes-cache-generation'

--- a/services/site/app/utils/call-kent-cache-keys.ts
+++ b/services/site/app/utils/call-kent-cache-keys.ts
@@ -1,2 +1,0 @@
-export const callKentEpisodesCacheGenerationKey =
-	'call-kent:episodes-cache-generation'

--- a/services/site/app/utils/transistor.server.ts
+++ b/services/site/app/utils/transistor.server.ts
@@ -510,8 +510,8 @@ async function getCachedEpisodes({
 	timings?: Timings
 	signal?: AbortSignal
 }) {
-	const episodesCacheKey = await getEpisodesCacheKey()
 	try {
+		const episodesCacheKey = await getEpisodesCacheKey()
 		return await cachified({
 			cache,
 			request,

--- a/services/site/app/utils/transistor.server.ts
+++ b/services/site/app/utils/transistor.server.ts
@@ -17,18 +17,14 @@ import {
 	waitForDelay,
 	type Sleep,
 } from './abort-utils.server.ts'
-import {
-	cache,
-	cachified,
-	getCallKentEpisodesCacheGeneration,
-	shouldForceFresh,
-} from './cache.server.ts'
+import { cache, cachified, shouldForceFresh } from './cache.server.ts'
 import { getCallKentEpisodeArtworkAvatar } from './call-kent-artwork.ts'
 import { getCallKentEpisodeArtworkUrl } from './call-kent-artwork.server.ts'
 import { getOgImageSecret } from '#app/og/secrets.server.ts'
 import { getEpisodePath } from './call-kent.ts'
 import { getEnv } from './env.server.ts'
 import { stripHtml } from './markdown.server.ts'
+import { getRuntimeBinding } from './runtime-bindings.server.ts'
 import { type Timings } from './timing.server.ts'
 import { getDirectAvatarForUser } from './user-info.server.ts'
 
@@ -36,9 +32,33 @@ const EPISODES_CACHE_KEY_PREFIX = 'transistor:episodes:'
 const POST_PUBLISH_REFRESH_ATTEMPTS = 15
 const POST_PUBLISH_REFRESH_DELAY_MS = 2000
 
+type CacheGenerationRpc = {
+	getGeneration(name: string): Promise<string>
+	bumpGeneration(name: string): Promise<string>
+}
+
+function getEpisodesCacheGenerationName() {
+	return `transistor-episodes:${getEnv().CALL_KENT_PODCAST_ID}`
+}
+
+function getCacheGenerationRpc() {
+	const binding = getRuntimeBinding<CacheGenerationRpc>('CACHE_RPC')
+	if (!binding || typeof binding.getGeneration !== 'function') return null
+	return binding
+}
+
 async function getEpisodesCacheKey() {
-	const generation = await getCallKentEpisodesCacheGeneration()
+	const rpc = getCacheGenerationRpc()
+	const generation = rpc
+		? await rpc.getGeneration(getEpisodesCacheGenerationName())
+		: 'local'
 	return `${EPISODES_CACHE_KEY_PREFIX}${getEnv().CALL_KENT_PODCAST_ID}:${generation}`
+}
+
+async function bumpEpisodesCacheGeneration() {
+	const rpc = getCacheGenerationRpc()
+	if (!rpc) return null
+	return rpc.bumpGeneration(getEpisodesCacheGenerationName())
 }
 
 function getErrorCode(error: unknown) {
@@ -522,6 +542,7 @@ async function getCachedEpisodes({
 }
 
 export {
+	bumpEpisodesCacheGeneration,
 	createEpisode,
 	getCurrentSeason,
 	getCachedEpisodes as getEpisodes,

--- a/services/site/app/utils/transistor.server.ts
+++ b/services/site/app/utils/transistor.server.ts
@@ -5,6 +5,7 @@ import {
 	type TransistorAuthorizedJson,
 	type TransistorCreateEpisodeData,
 	type TransistorCreatedJson,
+	type TransistorEpisodeData,
 	type TransistorEpisodesJson,
 	type TransistorErrorResponse,
 	type TransistorPublishedJson,
@@ -14,11 +15,15 @@ import {
 	isAbortError,
 	throwIfAborted,
 	waitForDelay,
+	type Sleep,
 } from './abort-utils.server.ts'
-import { cache, cachified, shouldForceFresh } from './cache.server.ts'
 import {
-	getCallKentEpisodeArtworkAvatar,
-} from './call-kent-artwork.ts'
+	cache,
+	cachified,
+	getCallKentEpisodesCacheGeneration,
+	shouldForceFresh,
+} from './cache.server.ts'
+import { getCallKentEpisodeArtworkAvatar } from './call-kent-artwork.ts'
 import { getCallKentEpisodeArtworkUrl } from './call-kent-artwork.server.ts'
 import { getOgImageSecret } from '#app/og/secrets.server.ts'
 import { getEpisodePath } from './call-kent.ts'
@@ -26,6 +31,15 @@ import { getEnv } from './env.server.ts'
 import { stripHtml } from './markdown.server.ts'
 import { type Timings } from './timing.server.ts'
 import { getDirectAvatarForUser } from './user-info.server.ts'
+
+const EPISODES_CACHE_KEY_PREFIX = 'transistor:episodes:'
+const POST_PUBLISH_REFRESH_ATTEMPTS = 15
+const POST_PUBLISH_REFRESH_DELAY_MS = 2000
+
+async function getEpisodesCacheKey() {
+	const generation = await getCallKentEpisodesCacheGeneration()
+	return `${EPISODES_CACHE_KEY_PREFIX}${getEnv().CALL_KENT_PODCAST_ID}:${generation}`
+}
 
 function getErrorCode(error: unknown) {
 	if (!error || typeof error !== 'object') return ''
@@ -336,21 +350,54 @@ async function createEpisode({
 		slug,
 	}
 
-	// update the cache with the new episode
-	await getCachedEpisodes({ forceFresh: true })
-
 	return returnValue
 }
 
-async function getEpisodes({ signal }: { signal?: AbortSignal } = {}) {
+async function refreshEpisodesAfterPublish({
+	episodeId,
+	attempts = POST_PUBLISH_REFRESH_ATTEMPTS,
+	delayMs = POST_PUBLISH_REFRESH_DELAY_MS,
+	sleep,
+}: {
+	episodeId: string
+	attempts?: number
+	delayMs?: number
+	sleep?: Sleep
+}) {
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		const episodes = await getCachedEpisodes({ forceFresh: true })
+		if (episodes.some((episode) => episode.transistorEpisodeId === episodeId)) {
+			return true
+		}
+		if (attempt < attempts) {
+			await waitForDelay({ delayMs, sleep })
+		}
+	}
+
+	// Every forced attempt replaces the cache. Do not leave the final incomplete
+	// list cached for its normal one-day TTL.
+	await cache.delete(await getEpisodesCacheKey())
+	return false
+}
+
+async function getTransistorEpisodes({
+	signal,
+}: {
+	signal?: AbortSignal
+} = {}): Promise<Array<TransistorEpisodeData>> {
 	throwIfAborted(signal)
+	const showId = getEnv().CALL_KENT_PODCAST_ID
 	// Transistor's API max per-page is 100; fetch all pages sequentially
 	const perPage = 100
 
 	// Fetch first page to learn how many total pages there are
 	const firstPage = await fetchTransitor<TransistorEpisodesJson>({
 		endpoint: `/v1/episodes`,
-		query: { 'pagination[per]': String(perPage), 'pagination[page]': '1' },
+		query: {
+			show_id: showId,
+			'pagination[per]': String(perPage),
+			'pagination[page]': '1',
+		},
 		signal,
 	})
 
@@ -366,6 +413,7 @@ async function getEpisodes({ signal }: { signal?: AbortSignal } = {}) {
 		const pageData = await fetchTransitor<TransistorEpisodesJson>({
 			endpoint: `/v1/episodes`,
 			query: {
+				show_id: showId,
 				'pagination[per]': String(perPage),
 				'pagination[page]': String(page),
 			},
@@ -373,6 +421,11 @@ async function getEpisodes({ signal }: { signal?: AbortSignal } = {}) {
 		})
 		allEpisodesData.push(...pageData.data)
 	}
+	return allEpisodesData
+}
+
+async function getEpisodes({ signal }: { signal?: AbortSignal } = {}) {
+	const allEpisodesData = await getTransistorEpisodes({ signal })
 
 	// sort by episode number
 	const sortedTransistorEpisodes = allEpisodesData.sort((a, b) => {
@@ -418,17 +471,12 @@ async function getEpisodes({ signal }: { signal?: AbortSignal } = {}) {
 }
 
 async function getCurrentSeason() {
-	const episodesResponse = await fetchTransitor<TransistorEpisodesJson>({
-		endpoint: `/v1/episodes`,
-		query: {
-			'pagination[per]': '1',
-			order: 'desc',
-		},
-	})
-
-	const lastEpisode = episodesResponse.data[0]
-	const season = lastEpisode?.attributes.season
-	return typeof season === 'number' ? season : 1
+	const episodes = await getTransistorEpisodes()
+	return episodes.reduce(
+		(currentSeason, episode) =>
+			Math.max(currentSeason, episode.attributes.season),
+		1,
+	)
 }
 
 async function getCachedEpisodes({
@@ -442,7 +490,7 @@ async function getCachedEpisodes({
 	timings?: Timings
 	signal?: AbortSignal
 }) {
-	const episodesCacheKey = `transistor:episodes:${getEnv().CALL_KENT_PODCAST_ID}`
+	const episodesCacheKey = await getEpisodesCacheKey()
 	try {
 		return await cachified({
 			cache,
@@ -475,6 +523,8 @@ async function getCachedEpisodes({
 
 export {
 	createEpisode,
+	getCurrentSeason,
 	getCachedEpisodes as getEpisodes,
+	refreshEpisodesAfterPublish,
 	updateEpisodeTranscriptText,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- scope Transistor episode reads to the Call Kent show and choose the maximum season across all pages
- persist caller history before waiting for Transistor list readiness
- poll until the new episode is list-ready, then rotate a generic named cache generation followed by the parent page-cache generation
- keep `cache.server.ts` generic; Transistor owns its own generation name and invalidation
- await the best-effort caller notification email before redirecting
- replace the broken caller-episode upsert with explicit, correctly ordered SQL

## Production diagnosis and repair

The latest episode was not merely stale: it had been published as Season 1 Episode 28 because the first Transistor list result was treated as the current season. I moved Transistor episode `3396416` to Season 5 Episode 28, repaired its canonical URL/description and D1 caller-history row, cleared the shared episode cache, and bumped the page-cache generation. A fresh production request now shows Season 5 with 28 episodes and `Exploring Interests at 15` first.

## Email verification

Cloudflare Email Sending analytics returned no event for the caller/subject around the publish, so the original delivery remains inconclusive. This PR awaits the Email Sending REST call after durable persistence, removing the `waitUntil` uncertainty for future publishes.

## Validation

- focused Transistor, cache, caller-history, and publish-action tests
- generic CacheRpc generation tests and page-cache tests
- all workspace typechecks
- site-worker production dry-run
- complete Call Kent Playwright recording/draft/publish flow
- production page verified as Season 5 Episode 28 after repair
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-026c2337-e9f5-45c2-8ada-1e82bb480f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-026c2337-e9f5-45c2-8ada-1e82bb480f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved episode publishing to confirm the episode is available before refreshing episode and page caches.
  - Prevented incomplete episode data from remaining in cache after publishing.
  - Corrected current-season detection across paginated episode lists.
  - Publishing now continues successfully even if cache refresh/invalidation fails.

- **Improvements**
  - Added generation-tracked caching for episode and page content invalidation.
  - Made published Call Kent episode details consistently saved and updated.

- **Tests**
  - Added and expanded tests for cache generation, refresh behavior, and publish-time side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->