### PR TITLE
Fix password reset 500 from upsert bind-order bug

### DIFF
--- a/docs/agents/data-table-conventions.md
+++ b/docs/agents/data-table-conventions.md
@@ -87,6 +87,14 @@ Import from `#app/utils/db.server.ts`.
 | `delete` / `deleteMany` | `db.delete(table, id)` / `db.deleteMany(table, { where })` |
 | `upsert` (single field unique) | `db.query(table).upsert(values, { conflictTarget: ['email'], update })` |
 | `upsert` (composite unique) | `db.query(table).upsert(values, { conflictTarget: [...], update, touch: true })` |
+
+### Upsert bind-order caveat
+
+`SqliteExecutorDataTableAdapter.compileUpsertStatement` must push INSERT
+bound values before ON CONFLICT UPDATE values. SQL placeholder order is
+`INSERT ... VALUES (?, ...) ON CONFLICT DO UPDATE SET col = ?`; if update
+params are pushed first, columns get the wrong bindings (e.g. Password
+`userId` receiving the hash → FK failure / 500 on password set/reset).
 | `count` | `db.count(table, { where })` |
 | `groupBy` | `db.query(table).groupBy('col').select({...})` **or** `db.exec(sql\`...\`)` |
 | `$queryRaw` / `$executeRaw` | `db.exec(sql\`...\`)` or `db.exec({ text, values })` |

--- a/services/site/app/utils/db/__tests__/password-upsert-bind-order.server.test.ts
+++ b/services/site/app/utils/db/__tests__/password-upsert-bind-order.server.test.ts
@@ -1,0 +1,112 @@
+import { createDatabase, query } from '@remix-run/data-table'
+import { expect, test } from 'vitest'
+import { createSqliteExecutorDataTableAdapter } from '../d1-data-table-adapter.server.ts'
+import { passwordTable, userTable } from '../schema.server.ts'
+import {
+	createMigratedMemoryDatabase,
+	createNodeSqliteExecutor,
+} from '../test-helpers.server.ts'
+
+test('upsert binds insert values before on-conflict update values', () => {
+	const adapter = createSqliteExecutorDataTableAdapter(
+		createNodeSqliteExecutor(createMigratedMemoryDatabase()),
+	)
+	const compiled = adapter.compileSql({
+		kind: 'upsert',
+		table: passwordTable,
+		values: {
+			userId: '784535d3-6727-4062-94ef-ede66a7c8c63',
+			hash: 'hash-insert',
+			createdAt: new Date('2026-07-21T12:00:00.000Z'),
+			updatedAt: new Date('2026-07-21T12:00:00.000Z'),
+		},
+		conflictTarget: ['userId'],
+		update: {
+			hash: 'hash-update',
+			updatedAt: new Date('2026-07-21T13:00:00.000Z'),
+		},
+	})
+
+	expect(compiled).toHaveLength(1)
+	expect(compiled[0]?.text).toBe(
+		'insert into "Password" ("userId", "hash", "createdAt", "updatedAt") values (?, ?, ?, ?) on conflict ("userId") do update set "hash" = ?, "updatedAt" = ?',
+	)
+	expect(compiled[0]?.values).toEqual([
+		'784535d3-6727-4062-94ef-ede66a7c8c63',
+		'hash-insert',
+		new Date('2026-07-21T12:00:00.000Z'),
+		new Date('2026-07-21T12:00:00.000Z'),
+		'hash-update',
+		new Date('2026-07-21T13:00:00.000Z'),
+	])
+})
+
+test('password upsert inserts a Password row for users without one', async () => {
+	const sqlite = createMigratedMemoryDatabase()
+	const db = createDatabase(
+		createSqliteExecutorDataTableAdapter(createNodeSqliteExecutor(sqlite)),
+		{ now: () => new Date('2026-07-21T12:00:00.000Z') },
+	)
+
+	const user = await db.create(
+		userTable,
+		{
+			email: 'password-upsert@example.com',
+			firstName: 'Damien',
+			team: 'BLUE',
+			role: 'MEMBER',
+		},
+		{ returnRow: true },
+	)
+
+	await db.exec(
+		query(passwordTable).upsert(
+			{ userId: user.id, hash: 'hash-1' },
+			{
+				conflictTarget: ['userId'],
+				update: { hash: 'hash-1' },
+				touch: true,
+			},
+		),
+	)
+
+	const row = await db.find(passwordTable, user.id)
+	expect(row?.hash).toBe('hash-1')
+	expect(row?.createdAt).toBeInstanceOf(Date)
+	expect(row?.updatedAt).toBeInstanceOf(Date)
+})
+
+test('password upsert updates an existing Password row', async () => {
+	const sqlite = createMigratedMemoryDatabase()
+	const db = createDatabase(
+		createSqliteExecutorDataTableAdapter(createNodeSqliteExecutor(sqlite)),
+		{ now: () => new Date('2026-07-21T12:00:00.000Z') },
+	)
+
+	const user = await db.create(
+		userTable,
+		{
+			email: 'password-update@example.com',
+			firstName: 'Pat',
+			team: 'RED',
+			role: 'MEMBER',
+		},
+		{ returnRow: true },
+	)
+	await db.create(passwordTable, { userId: user.id, hash: 'old-hash' })
+
+	await db.exec(
+		query(passwordTable).upsert(
+			{ userId: user.id, hash: 'new-hash' },
+			{
+				conflictTarget: ['userId'],
+				update: { hash: 'new-hash' },
+				touch: true,
+			},
+		),
+	)
+
+	expect(await db.find(passwordTable, user.id)).toMatchObject({
+		hash: 'new-hash',
+	})
+})

--- a/services/site/app/utils/db/d1-data-table-adapter.server.ts
+++ b/services/site/app/utils/db/d1-data-table-adapter.server.ts
@@ -592,6 +592,17 @@ function compileUpsertStatement(
 		throw new Error('upsert requires at least one value')
 	}
 
+	// Bind insert placeholders before the ON CONFLICT update placeholders so
+	// context.values matches SQL placeholder order (INSERT ... then UPDATE).
+	const insertValuesSql = insertColumns
+		.map((column) =>
+			pushValue(
+				context,
+				(statement.values as Record<string, unknown>)[column],
+			),
+		)
+		.join(', ')
+
 	const updateValues = statement.update ?? statement.values
 	const updateColumns = Object.keys(updateValues)
 	let conflictClause = ''
@@ -626,14 +637,7 @@ function compileUpsertStatement(
 			' (' +
 			insertColumns.map((column) => quotePath(column)).join(', ') +
 			') values (' +
-			insertColumns
-				.map((column) =>
-					pushValue(
-						context,
-						(statement.values as Record<string, unknown>)[column],
-					),
-				)
-				.join(', ') +
+			insertValuesSql +
 			')' +
 			conflictClause +
 			compileReturningClause(statement.returning),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Damien reported a 500 on `/reset-password` while trying to set a password (business Gmail + screenshot). Sentry [KCD-SE](https://kent-c-dodds-tech-llc.sentry.io/issues/6985178386/) and Cloudflare analytics showed `POST /reset-password.data` → 500. Production D1 showed his user had **no** `Password` row.

Root cause: `SqliteExecutorDataTableAdapter.compileUpsertStatement` pushed ON CONFLICT **update** bound values before INSERT values, but SQL placeholder order is INSERT then UPDATE. That bound `Password.userId` to the hash → SQLite FK failure → 500 on first-time password set (and password change via the same upsert path).

## Fix

- Bind INSERT params before ON CONFLICT UPDATE params in `compileUpsertStatement`
- Regression tests for bind order + insert/update Password upserts
- Doc note in `docs/agents/data-table-conventions.md`

## Verification

- Local unit tests for bind order and Password upsert insert/update pass
- After deploy: password set/reset for a user without a Password row should succeed (no 500)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-546d8215-e874-49aa-9067-321b964643cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-546d8215-e874-49aa-9067-321b964643cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed password insert and update operations so values are assigned to the correct fields.
  - Resolved failures when setting or resetting passwords, including cases that could produce server errors.
  - Improved password record creation and updates for users with or without an existing password.

- **Tests**
  - Added coverage for password upsert behavior, including value ordering, insertion, and updates.

- **Documentation**
  - Documented the required parameter ordering for upsert operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->