### PR TITLE
Filter Sentry client noise from extensions and crawlers (C-2)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -26,4 +26,6 @@ fixes it.
 - Client SDK filters live in `services/site/app/utils/sentry-noise.ts` (wired
   from `monitoring.client.tsx`): prefer narrow `ignoreErrors` / `denyUrls` /
   `beforeSend` signatures. Do not broadly filter `Failed to fetch` / network
-  errors — those can hide real outages.
+  errors — those can hide real outages. Message/stack drop rules must establish
+  an external source (distinctive third-party signature, extension/IAB URL, or
+  provider error code such as EIP-1193 `4001`) — never a generic phrase alone.

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -23,3 +23,7 @@ fixes it.
 - If evidence points to app code, file or fix the bug; if it points to
   external/injected noise, open a PR to filter it instead of adding defensive
   code.
+- Client SDK filters live in `services/site/app/utils/sentry-noise.ts` (wired
+  from `monitoring.client.tsx`): prefer narrow `ignoreErrors` / `denyUrls` /
+  `beforeSend` signatures. Do not broadly filter `Failed to fetch` / network
+  errors — those can hide real outages.

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -4,6 +4,7 @@ import {
 	SENTRY_IGNORE_ERRORS,
 	isBrowserExtensionError,
 	isDegradedUiPerformanceEvent,
+	isWalletUserRejection,
 	shouldDropSentryEvent,
 } from '../sentry-noise.ts'
 
@@ -41,10 +42,64 @@ test('filters injected extension post Method not found (KCD-W9)', () => {
 	expect(matchesIgnoreError('Error invoking post: Method not found')).toBe(true)
 })
 
-test('filters EIP-1193 wallet user rejection (KCD-ZV)', () => {
+test('scopes EIP-1193 wallet user rejection (KCD-ZV)', () => {
+	expect(matchesIgnoreError('user rejected the request')).toBe(false)
+
 	expect(
-		matchesIgnoreError(
-			'Non-Error promise rejection captured with value: user rejected the request',
+		isWalletUserRejection(
+			{},
+			{
+				originalException: { code: 4001, message: 'User rejected the request' },
+			},
+		),
+	).toBe(true)
+
+	expect(
+		isWalletUserRejection({
+			exception: {
+				values: [
+					{
+						type: 'UnhandledRejection',
+						value:
+							'Non-Error promise rejection captured with value: user rejected the request',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	expect(
+		isWalletUserRejection({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'user rejected the request',
+						stacktrace: {
+							frames: [{ filename: '/app/routes/checkout.tsx' }],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'UnhandledRejection',
+							value:
+								'Non-Error promise rejection captured with value: user rejected the request',
+						},
+					],
+				},
+			},
+			{
+				originalException: { code: 4001, message: 'User rejected the request' },
+			},
 		),
 	).toBe(true)
 })
@@ -94,6 +149,11 @@ test('detects browser extension stacks and denyUrls', () => {
 	expect(isBrowserExtensionError(extensionError)).toBe(true)
 	expect(matchesDenyUrl('chrome-extension://abc/content.js')).toBe(true)
 	expect(matchesDenyUrl('moz-extension://abc/content.js')).toBe(true)
+
+	const anonymousScriptError = new Error('boom')
+	anonymousScriptError.stack =
+		'Error: boom\n    at anonymous scripts:1:1\n    at /app/routes/blog.tsx:10:2'
+	expect(isBrowserExtensionError(anonymousScriptError)).toBe(false)
 })
 
 test('drops degraded UI performance noise and lookout/translate requests', () => {

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from 'vitest'
+import {
+	SENTRY_DENY_URLS,
+	SENTRY_IGNORE_ERRORS,
+	isBrowserExtensionError,
+	isDegradedUiPerformanceEvent,
+	shouldDropSentryEvent,
+} from '../sentry-noise.ts'
+
+function matchesIgnoreError(message: string) {
+	return SENTRY_IGNORE_ERRORS.some((pattern) => {
+		if (typeof pattern === 'string') return message.includes(pattern)
+		return pattern.test(message)
+	})
+}
+
+function matchesDenyUrl(url: string) {
+	return SENTRY_DENY_URLS.some((pattern) => pattern.test(url))
+}
+
+test('filters Outlook SafeLinks Non-Error rejection (KCD-1K)', () => {
+	expect(
+		matchesIgnoreError(
+			'Non-Error promise rejection captured with value: Object Not Found Matching Id:2, MethodName:update, ParamCount:4',
+		),
+	).toBe(true)
+})
+
+test('filters Firefox for iOS __firefox__ bridge (KCD-RB)', () => {
+	expect(matchesIgnoreError("Can't find variable: __firefox__")).toBe(true)
+	expect(matchesIgnoreError('__firefox__ is not defined')).toBe(true)
+})
+
+test('filters WebExtension runtime.sendMessage tab-not-found (KCD-JC)', () => {
+	expect(
+		matchesIgnoreError('Invalid call to runtime.sendMessage(). Tab not found.'),
+	).toBe(true)
+})
+
+test('filters injected extension post Method not found (KCD-W9)', () => {
+	expect(matchesIgnoreError('Error invoking post: Method not found')).toBe(true)
+})
+
+test('filters EIP-1193 wallet user rejection (KCD-ZV)', () => {
+	expect(
+		matchesIgnoreError(
+			'Non-Error promise rejection captured with value: user rejected the request',
+		),
+	).toBe(true)
+})
+
+test('filters Android in-app browser postMessage bridge (KCD-ZM)', () => {
+	expect(
+		matchesIgnoreError('Error invoking postMessage: Java object is gone'),
+	).toBe(true)
+	expect(matchesDenyUrl('iabjs://navigation_performance_logger_android')).toBe(
+		true,
+	)
+})
+
+test('filters injected og:type meta scrapers (KCD-2K family)', () => {
+	expect(
+		matchesIgnoreError(
+			"null is not an object (evaluating 'document.querySelector(\"meta[property='og:type']\").content')",
+		),
+	).toBe(true)
+})
+
+test('filters injected elem.firstChild parsers (KCD-ZZ)', () => {
+	expect(
+		matchesIgnoreError(
+			"undefined is not an object (evaluating 'elem.firstChild')",
+		),
+	).toBe(true)
+})
+
+test('keeps Module load timeout filter (KCD-ZS / KCD-ZT)', () => {
+	expect(matchesIgnoreError('Module load timeout: m_1001')).toBe(true)
+	expect(matchesIgnoreError('Module load timeout: m_1004')).toBe(true)
+})
+
+test('does not broadly ignore generic Failed to fetch', () => {
+	expect(matchesIgnoreError('Failed to fetch (kentcdodds.com)')).toBe(false)
+	expect(matchesIgnoreError('Load failed')).toBe(false)
+	expect(
+		matchesIgnoreError('NetworkError when attempting to fetch resource.'),
+	).toBe(false)
+})
+
+test('detects browser extension stacks and denyUrls', () => {
+	const extensionError = new Error('boom')
+	extensionError.stack =
+		'Error: boom\n    at chrome-extension://abc/content.js:1:1'
+	expect(isBrowserExtensionError(extensionError)).toBe(true)
+	expect(matchesDenyUrl('chrome-extension://abc/content.js')).toBe(true)
+	expect(matchesDenyUrl('moz-extension://abc/content.js')).toBe(true)
+})
+
+test('drops degraded UI performance noise and lookout/translate requests', () => {
+	expect(
+		isDegradedUiPerformanceEvent({ message: 'Degraded UI Performance' }),
+	).toBe(true)
+	expect(
+		shouldDropSentryEvent({
+			message: 'Degraded UI Performance',
+		}),
+	).toBe(true)
+	expect(
+		shouldDropSentryEvent({
+			request: { url: 'https://kentcdodds.com/resources/lookout' },
+		}),
+	).toBe(true)
+	expect(
+		shouldDropSentryEvent({
+			request: { url: 'https://translate-pa.googleapis.com/v1/translate' },
+		}),
+	).toBe(true)
+	expect(
+		shouldDropSentryEvent({
+			message: 'Real app bug',
+			request: { url: 'https://kentcdodds.com/blog' },
+		}),
+	).toBe(false)
+})

--- a/services/site/app/utils/monitoring.client.tsx
+++ b/services/site/app/utils/monitoring.client.tsx
@@ -2,30 +2,21 @@ import {
 	init as sentryInit,
 	reactRouterTracingIntegration,
 } from '@sentry/react-router'
+import {
+	SENTRY_DENY_URLS,
+	SENTRY_IGNORE_ERRORS,
+	shouldDropSentryEvent,
+} from './sentry-noise.ts'
 
 export function init() {
 	sentryInit({
 		dsn: ENV.SENTRY_DSN,
 		tunnel: '/resources/lookout',
 		environment: ENV.MODE,
-		ignoreErrors: [
-			// Add any other errors you want to ignore
-			'Request to /lookout failed',
-			"Can't find variable: CONFIG",
-			'CONFIG is not defined',
-			// Injected/third-party module loaders (seen from chatgpt.com referrers).
-			/^Module load timeout: m_\d+$/,
-		],
+		ignoreErrors: SENTRY_IGNORE_ERRORS,
+		denyUrls: SENTRY_DENY_URLS,
 		beforeSend(event, hint) {
-			if (isBrowserExtensionError(hint.originalException)) {
-				return null
-			}
-			// Ignore events related to the /lookout endpoint
-			if (event.request?.url?.includes('/lookout')) {
-				return null
-			}
-			// Filter out errors related to Google translation service
-			if (event.request?.url?.includes('translate-pa.googleapis.com')) {
+			if (shouldDropSentryEvent(event, hint)) {
 				return null
 			}
 			return event
@@ -44,14 +35,4 @@ export function init() {
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 0,
 	})
-}
-
-function isBrowserExtensionError(exception: unknown): boolean {
-	if (exception instanceof Error && exception.stack) {
-		const extensionPattern =
-			/chrome-extension:|moz-extension:|extensions|anonymous scripts/
-		return extensionPattern.test(exception.stack)
-	}
-
-	return false
 }

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -1,0 +1,80 @@
+/**
+ * Narrow client-side Sentry noise filters for injected third-party scripts,
+ * browser extensions, in-app browsers, and similar non-app sources.
+ *
+ * Prefer message/URL signatures over broad network-error filters so real
+ * outages still alert.
+ */
+
+export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
+	// Tunnel / self-reporting
+	'Request to /lookout failed',
+	// Broken local/dev CONFIG injection
+	"Can't find variable: CONFIG",
+	'CONFIG is not defined',
+	// Injected/third-party module loaders (seen from chatgpt.com referrers).
+	/Module load timeout: m_\d+/,
+	// Microsoft Outlook SafeLinks / Office link-preview crawler (KCD-1K).
+	/Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+/,
+	// Firefox for iOS content-script bridge (KCD-RB).
+	/Can't find variable: __firefox__/,
+	/__firefox__ is not defined/,
+	// WebExtension messaging API leaking into the page (KCD-JC).
+	/Invalid call to runtime\.sendMessage\(\)\. Tab not found/,
+	// Injected extension post bridge (KCD-W9).
+	/Error invoking post: Method not found/,
+	// EIP-1193 wallet extension user dismissal (KCD-ZV).
+	/user rejected the request/,
+	// Android in-app browser (Instagram/etc.) native bridge (KCD-ZM).
+	/Error invoking postMessage: Java object is gone/,
+	// Injected social/OG scrapers reading meta tags that aren't present (KCD-2K family).
+	/document\.querySelector\("meta\[property='og:type'\]"\)\.content/,
+	// Injected HTML parsers / translators mutating the DOM (KCD-ZZ).
+	/evaluating 'elem\.firstChild'/,
+]
+
+export const SENTRY_DENY_URLS: Array<RegExp> = [
+	/chrome-extension:\/\//i,
+	/moz-extension:\/\//i,
+	/safari-web-extension:\/\//i,
+	/safari-extension:\/\//i,
+	/webkit-masked-url:\/\//i,
+	// Android in-app browser injected scripts (Instagram, etc.).
+	/iabjs:/i,
+]
+
+type SentryExceptionValue = {
+	type?: string | null
+	value?: string | null
+}
+
+type SentryEventLike = {
+	message?: string | null
+	request?: { url?: string | null } | null
+	exception?: { values?: Array<SentryExceptionValue> | null } | null
+}
+
+export function isBrowserExtensionError(exception: unknown): boolean {
+	if (!(exception instanceof Error) || !exception.stack) return false
+	return /chrome-extension:|moz-extension:|safari-web-extension:|safari-extension:|webkit-masked-url:|iabjs:|anonymous scripts/i.test(
+		exception.stack,
+	)
+}
+
+export function isDegradedUiPerformanceEvent(event: SentryEventLike): boolean {
+	if (event.message === 'Degraded UI Performance') return true
+	return (event.exception?.values ?? []).some(
+		(value) => value.type === 'Degraded UI Performance',
+	)
+}
+
+export function shouldDropSentryEvent(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	if (isBrowserExtensionError(hint.originalException)) return true
+	if (isDegradedUiPerformanceEvent(event)) return true
+	if (event.request?.url?.includes('/lookout')) return true
+	if (event.request?.url?.includes('translate-pa.googleapis.com')) return true
+	return false
+}

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -3,7 +3,9 @@
  * browser extensions, in-app browsers, and similar non-app sources.
  *
  * Prefer message/URL signatures over broad network-error filters so real
- * outages still alert.
+ * outages still alert. Drop rules must establish an external source via a
+ * distinctive payload signature, extension/IAB URL, or provider error code —
+ * not a generic phrase alone.
  */
 
 export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
@@ -23,8 +25,6 @@ export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	/Invalid call to runtime\.sendMessage\(\)\. Tab not found/,
 	// Injected extension post bridge (KCD-W9).
 	/Error invoking post: Method not found/,
-	// EIP-1193 wallet extension user dismissal (KCD-ZV).
-	/user rejected the request/,
 	// Android in-app browser (Instagram/etc.) native bridge (KCD-ZM).
 	/Error invoking postMessage: Java object is gone/,
 	// Injected social/OG scrapers reading meta tags that aren't present (KCD-2K family).
@@ -46,6 +46,7 @@ export const SENTRY_DENY_URLS: Array<RegExp> = [
 type SentryExceptionValue = {
 	type?: string | null
 	value?: string | null
+	stacktrace?: { frames?: Array<{ filename?: string | null }> | null } | null
 }
 
 type SentryEventLike = {
@@ -54,9 +55,12 @@ type SentryEventLike = {
 	exception?: { values?: Array<SentryExceptionValue> | null } | null
 }
 
+const WALLET_PROVIDER_STACK =
+	/metamask|coinbase|rainbow|walletconnect|phantom|ethereum|eip-1193|inpage\.js|nkbihfbeogaeaoehlefnkodbefgpgknn/i
+
 export function isBrowserExtensionError(exception: unknown): boolean {
 	if (!(exception instanceof Error) || !exception.stack) return false
-	return /chrome-extension:|moz-extension:|safari-web-extension:|safari-extension:|webkit-masked-url:|iabjs:|anonymous scripts/i.test(
+	return /chrome-extension:|moz-extension:|safari-web-extension:|safari-extension:|webkit-masked-url:|iabjs:/i.test(
 		exception.stack,
 	)
 }
@@ -68,11 +72,69 @@ export function isDegradedUiPerformanceEvent(event: SentryEventLike): boolean {
 	)
 }
 
+function eventMessages(event: SentryEventLike): Array<string> {
+	const messages = (event.exception?.values ?? [])
+		.map((value) => value.value ?? '')
+		.filter(Boolean)
+	if (event.message) messages.push(event.message)
+	return messages
+}
+
+function hasStackFrames(event: SentryEventLike): boolean {
+	return (event.exception?.values ?? []).some(
+		(value) => (value.stacktrace?.frames?.length ?? 0) > 0,
+	)
+}
+
+function stackBlob(event: SentryEventLike, originalException: unknown): string {
+	const frameFiles = (event.exception?.values ?? [])
+		.flatMap((value) => value.stacktrace?.frames ?? [])
+		.map((frame) => frame.filename ?? '')
+		.join('\n')
+	const errorStack =
+		originalException instanceof Error ? (originalException.stack ?? '') : ''
+	return `${frameFiles}\n${errorStack}`
+}
+
+/**
+ * EIP-1193 wallet extensions reject with code 4001 / "user rejected the
+ * request". Only drop when that provider signal is present — never on the
+ * phrase alone.
+ */
+export function isWalletUserRejection(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const original = hint.originalException
+	if (original && typeof original === 'object' && 'code' in original) {
+		const code = (original as { code?: unknown }).code
+		if (code === 4001 || code === '4001') return true
+	}
+
+	const looksLikeUserRejection = eventMessages(event).some((message) =>
+		/user rejected the request/i.test(message),
+	)
+	if (!looksLikeUserRejection) return false
+
+	// Non-Error wallet rejections often have zero frames; require a provider
+	// marker whenever any stack evidence exists.
+	if (hasStackFrames(event) || original instanceof Error) {
+		return WALLET_PROVIDER_STACK.test(stackBlob(event, original))
+	}
+
+	return (event.exception?.values ?? []).some(
+		(value) =>
+			value.type === 'UnhandledRejection' ||
+			/Non-Error promise rejection/i.test(value.value ?? ''),
+	)
+}
+
 export function shouldDropSentryEvent(
 	event: SentryEventLike,
 	hint: { originalException?: unknown } = {},
 ): boolean {
 	if (isBrowserExtensionError(hint.originalException)) return true
+	if (isWalletUserRejection(event, hint)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true
 	if (event.request?.url?.includes('/lookout')) return true
 	if (event.request?.url?.includes('translate-pa.googleapis.com')) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Track **C-2** (`kcd-sentry-hygiene`) for the Sentry cleanup program. Adds narrow client SDK filters so archived/third-party noise stops reappearing in project `kcd`.

- New `services/site/app/utils/sentry-noise.ts` owns `ignoreErrors`, `denyUrls`, and `beforeSend` drop predicates
- Covers Outlook SafeLinks (KCD-1K), Firefox iOS `__firefox__` (KCD-RB), WebExtension `runtime.sendMessage` (KCD-JC), injected `post` bridge (KCD-W9), EIP-1193 wallet dismissals (KCD-ZV), Android IAB `iabjs:` (KCD-ZM), injected `og:type` scrapers (KCD-2K family), `elem.firstChild` parsers (KCD-ZZ), and Degraded UI Performance events
- Intentionally does **not** broadly filter `Failed to fetch` / `Load failed` / `NetworkError` (could hide real outages) — left as recommendations for C-1
- Unit tests for the filter signatures

## Deploy impact

Merging deploys **kentcdodds.com** via `deploy-site.yml`. Low risk: client Sentry config only; no auth/payment/data-deletion changes.

## Test plan

- [x] `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/sentry-noise.test.ts`
- [x] `npm run typecheck --workspace kentcdodds.com`
- [x] Pre-push workspace tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa65c7ce-59ba-41ac-93cc-a1cdbf1fc296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa65c7ce-59ba-41ac-93cc-a1cdbf1fc296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring by filtering known Sentry noise from browser extension/IAB bridges, wallet user-rejection events, degraded UI performance signals, and specific third-party request patterns (e.g., `/lookout` and `translate-pa.googleapis.com`).
  * Preserved reporting for genuine application bugs and generic network failures.
* **Tests**
  * Added automated coverage for error-message matching, URL filtering, extension/wallet classification, and event drop rules.
* **Documentation**
  * Updated the Sentry triage workflow with safer guidance on using precise ignore rules and avoiding broad “Failed to fetch” suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->