### PR TITLE
Fix search sync D1 batch overflowing 32 MiB RPC limit

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -89,6 +89,11 @@ reference:
 - Search Worker URL: if `SEARCH_WORKER_URL` contains `mock`, MSW returns fixtures;
   otherwise MSW passthrough sends traffic to that URL (e.g. local `wrangler dev`
   on `http://127.0.0.1:8787`). Tests expect a mock URL (see `.env.example`).
+- Search sync caveat: `/internal/sync` loads lexical artifacts from R2 and writes
+  them into the search-worker D1 via `db.batch()`. Cloudflare limits serialized
+  RPC args to 32 MiB; large podcast/youtube sources must be written in sized
+  batches (`replaceSearchSource` in `services/search-worker/src/search-db.ts`).
+  Do not collapse those writes back into a single giant batch.
 - Content is filesystem-based: blog posts are MDX files in `services/site/content/blog/`.
   `README.md` is repository documentation, not a post, and must stay out of
   `blogList`; syndication routes consume that list directly.

--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -91,9 +91,14 @@ reference:
   on `http://127.0.0.1:8787`). Tests expect a mock URL (see `.env.example`).
 - Search sync caveat: `/internal/sync` loads lexical artifacts from R2 and writes
   them into the search-worker D1 via `db.batch()`. Cloudflare limits serialized
-  RPC args to 32 MiB; large podcast/youtube sources must be written in sized
+  RPC args to 32 MiB; large podcast/YouTube sources must be written in sized
   batches (`replaceSearchSource` in `services/search-worker/src/search-db.ts`).
-  Do not collapse those writes back into a single giant batch.
+  Do not collapse those writes back into a single giant batch. Consequence: a
+  large replace spans multiple batches and is therefore not atomic. Deletes run
+  first and the `lexical_sources` row is inserted last, so a mid-sync failure
+  leaves the source unmarked and the next sync retries instead of skipping.
+  Keep that ordering. `queryLexicalSearch` joins `lexical_sources` so partial
+  rows written mid-replace are not searchable until the source is marked.
 - Content is filesystem-based: blog posts are MDX files in `services/site/content/blog/`.
   `README.md` is repository documentation, not a post, and must stay out of
   `blogList`; syndication routes consume that list directly.

--- a/services/search-worker/src/search-db.test.ts
+++ b/services/search-worker/src/search-db.test.ts
@@ -33,17 +33,35 @@ type BoundStatement = {
 
 function createBatchDb() {
 	const boundStatements: Array<BoundStatement> = []
+	const batches: Array<Array<BoundStatement>> = []
 	const db = {
 		prepare: vi.fn((sql: string) => ({
 			bind: vi.fn((...values: Array<unknown>) => ({ sql, values })),
 		})),
 		batch: vi.fn(async (statements: Array<D1PreparedStatement>) => {
-			boundStatements.push(...(statements as unknown as Array<BoundStatement>))
+			const bound = statements as unknown as Array<BoundStatement>
+			boundStatements.push(...bound)
+			batches.push(bound)
 			return []
 		}),
 	} as unknown as D1Database
 
-	return { db, boundStatements }
+	return { db, boundStatements, batches }
+}
+
+function estimateBatchBytes(statements: Array<BoundStatement>) {
+	let bytes = 0
+	for (const statement of statements) {
+		bytes += statement.sql.length + 128
+		for (const value of statement.values) {
+			if (typeof value === 'string') bytes += value.length
+			else if (typeof value === 'number' || typeof value === 'boolean')
+				bytes += 16
+			else if (value == null) bytes += 4
+			else bytes += String(value).length
+		}
+	}
+	return bytes
 }
 
 test('replaceSearchSource scopes duplicate chunk storage ids by source', async () => {
@@ -142,6 +160,49 @@ test('replaceSearchSource scopes duplicate chunk storage ids by source', async (
 	expect(docInsertStatements.map((statement) => statement.values[7])).toEqual([
 		2, 2,
 	])
+})
+
+test('replaceSearchSource chunks D1 batches under the RPC size limit', async () => {
+	const { db, boundStatements, batches } = createBatchDb()
+	// Reproduce the podcast sync failure mode: one giant replace exceeds 32 MiB
+	// when sent as a single D1 batch RPC payload (~35.7 MiB in production).
+	const chunkText = 'a'.repeat(250_000)
+	const chunkCount = 80
+	const artifact: LexicalSearchArtifact = {
+		version: 1,
+		generatedAt: '2026-07-24T00:00:00.000Z',
+		chunks: Array.from({ length: chunkCount }, (_, index) => ({
+			id: `podcast:episode:chunk:${index}`,
+			type: 'podcast',
+			slug: 'episode',
+			url: '/chats/episode',
+			title: 'Large Podcast Episode',
+			snippet: 'chunk snippet',
+			text: chunkText,
+			chunkIndex: index,
+			chunkCount,
+		})),
+	}
+
+	await replaceSearchSource({
+		db,
+		sourceKey: 'lexical-search/podcasts.json',
+		artifact,
+		syncedAt: '2026-07-24T01:00:00.000Z',
+	})
+
+	const D1_RPC_HARD_LIMIT_BYTES = 32 * 1024 * 1024
+	const totalEstimatedBytes = estimateBatchBytes(boundStatements)
+	expect(totalEstimatedBytes).toBeGreaterThan(D1_RPC_HARD_LIMIT_BYTES)
+	expect(batches.length).toBeGreaterThan(1)
+	for (const batch of batches) {
+		expect(estimateBatchBytes(batch)).toBeLessThan(D1_RPC_HARD_LIMIT_BYTES)
+	}
+
+	const sourceInsertIndex = boundStatements.findIndex((statement) =>
+		statement.sql.includes('INSERT INTO lexical_sources'),
+	)
+	expect(sourceInsertIndex).toBe(boundStatements.length - 1)
 })
 
 test('queryLexicalSearch quotes hyphenated date tokens for FTS', async () => {

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -589,6 +589,7 @@ export async function queryLexicalSearch({
 						c.imageAlt
 					FROM lexical_search_fts f
 					JOIN lexical_chunks c ON c.id = f.id
+					JOIN lexical_sources s ON s.sourceKey = c.sourceKey
 					WHERE lexical_search_fts MATCH ?
 					ORDER BY bm25(lexical_search_fts, 10.0, 1.0), c.chunkIndex
 					LIMIT ?

--- a/services/search-worker/src/search-db.ts
+++ b/services/search-worker/src/search-db.ts
@@ -260,16 +260,85 @@ function isFtsQuerySyntaxError(error: unknown) {
 	)
 }
 
-async function runStatementsInTransaction({
+/**
+ * Cloudflare D1/Workers RPC rejects serialized arguments larger than 32 MiB.
+ * Keep each batch well under that ceiling; statement-count is a secondary cap.
+ */
+const D1_BATCH_MAX_SERIALIZED_BYTES = 8 * 1024 * 1024
+const D1_BATCH_MAX_STATEMENTS = 200
+
+type SizedPreparedStatement = {
+	statement: D1PreparedStatement
+	estimatedBytes: number
+}
+
+function estimateSerializedBytes(
+	sqlText: string,
+	values: ReadonlyArray<unknown>,
+) {
+	let bytes = sqlText.length
+	for (const value of values) {
+		if (typeof value === 'string') {
+			bytes += value.length
+		} else if (typeof value === 'number' || typeof value === 'boolean') {
+			bytes += 16
+		} else if (value == null) {
+			bytes += 4
+		} else {
+			bytes += String(value).length
+		}
+	}
+	// Cap'n Proto / RPC framing overhead per statement (conservative).
+	return bytes + 128
+}
+
+function prepareSizedStatement(
+	db: D1Database,
+	sqlText: string,
+	values: ReadonlyArray<unknown>,
+): SizedPreparedStatement {
+	return {
+		statement: db.prepare(sqlText).bind(...values),
+		estimatedBytes: estimateSerializedBytes(sqlText, values),
+	}
+}
+
+async function runBatchedStatements({
 	db,
 	statements,
+	maxSerializedBytes = D1_BATCH_MAX_SERIALIZED_BYTES,
+	maxStatements = D1_BATCH_MAX_STATEMENTS,
 }: {
 	db: D1Database
-	statements: Array<D1PreparedStatement>
+	statements: ReadonlyArray<SizedPreparedStatement>
+	maxSerializedBytes?: number
+	maxStatements?: number
 }) {
 	if (statements.length === 0) return
-	// D1 batch() runs all statements atomically (implicit transaction), not BEGIN/COMMIT.
-	await db.batch(statements)
+
+	let batch: Array<D1PreparedStatement> = []
+	let batchBytes = 0
+
+	const flush = async () => {
+		if (batch.length === 0) return
+		// Each D1 batch() is atomic; large source replaces span multiple batches.
+		await db.batch(batch)
+		batch = []
+		batchBytes = 0
+	}
+
+	for (const { statement, estimatedBytes } of statements) {
+		const wouldExceedBytes =
+			batch.length > 0 && batchBytes + estimatedBytes > maxSerializedBytes
+		const wouldExceedCount = batch.length >= maxStatements
+		if (wouldExceedBytes || wouldExceedCount) {
+			await flush()
+		}
+		batch.push(statement)
+		batchBytes += estimatedBytes
+	}
+
+	await flush()
 }
 
 async function setMetadataValue({
@@ -331,39 +400,40 @@ export async function replaceSearchSource({
 	syncedAt: string
 }) {
 	const docs = buildDocRecords({ sourceKey, artifact })
-	const statements: Array<D1PreparedStatement> = [
-		db
-			.prepare('DELETE FROM lexical_search_fts WHERE sourceKey = ?')
-			.bind(sourceKey),
-		db
-			.prepare('DELETE FROM lexical_chunks WHERE sourceKey = ?')
-			.bind(sourceKey),
-		db.prepare('DELETE FROM lexical_docs WHERE sourceKey = ?').bind(sourceKey),
-		db
-			.prepare('DELETE FROM lexical_sources WHERE sourceKey = ?')
-			.bind(sourceKey),
-		db
-			.prepare(
-				`
-					INSERT INTO lexical_sources (sourceKey, generatedAt, chunkCount, syncedAt)
-					VALUES (?, ?, ?, ?)
-				`,
-			)
-			.bind(sourceKey, artifact.generatedAt, artifact.chunks.length, syncedAt),
+	// Delete first (including source metadata) so a mid-sync failure leaves the
+	// source unmarked and the next sync retries instead of skipping.
+	const statements: Array<SizedPreparedStatement> = [
+		prepareSizedStatement(
+			db,
+			'DELETE FROM lexical_search_fts WHERE sourceKey = ?',
+			[sourceKey],
+		),
+		prepareSizedStatement(
+			db,
+			'DELETE FROM lexical_chunks WHERE sourceKey = ?',
+			[sourceKey],
+		),
+		prepareSizedStatement(db, 'DELETE FROM lexical_docs WHERE sourceKey = ?', [
+			sourceKey,
+		]),
+		prepareSizedStatement(
+			db,
+			'DELETE FROM lexical_sources WHERE sourceKey = ?',
+			[sourceKey],
+		),
 	]
 
 	for (const doc of docs.values()) {
 		statements.push(
-			db
-				.prepare(
-					`
-						INSERT INTO lexical_docs (
-							docId, sourceKey, type, slug, url, title, snippet, chunkCount,
-							imageUrl, imageAlt, sourceUpdatedAt, transcriptSource
-						) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-					`,
-				)
-				.bind(
+			prepareSizedStatement(
+				db,
+				`
+					INSERT INTO lexical_docs (
+						docId, sourceKey, type, slug, url, title, snippet, chunkCount,
+						imageUrl, imageAlt, sourceUpdatedAt, transcriptSource
+					) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				`,
+				[
 					doc.docId,
 					doc.sourceKey,
 					doc.type,
@@ -376,7 +446,8 @@ export async function replaceSearchSource({
 					doc.imageAlt ?? null,
 					doc.sourceUpdatedAt ?? null,
 					doc.transcriptSource ?? null,
-				),
+				],
+			),
 		)
 	}
 
@@ -398,17 +469,16 @@ export async function replaceSearchSource({
 		})
 		const storageDocId = getStorageDocId({ sourceKey, docId })
 		statements.push(
-			db
-				.prepare(
-					`
-						INSERT INTO lexical_chunks (
-							id, docId, sourceKey, type, slug, url, title, snippet, text,
-							chunkIndex, chunkCount, startSeconds, endSeconds, imageUrl,
-							imageAlt, sourceUpdatedAt, transcriptSource
-						) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-					`,
-				)
-				.bind(
+			prepareSizedStatement(
+				db,
+				`
+					INSERT INTO lexical_chunks (
+						id, docId, sourceKey, type, slug, url, title, snippet, text,
+						chunkIndex, chunkCount, startSeconds, endSeconds, imageUrl,
+						imageAlt, sourceUpdatedAt, transcriptSource
+					) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				`,
+				[
 					storageChunkId,
 					storageDocId,
 					sourceKey,
@@ -426,19 +496,32 @@ export async function replaceSearchSource({
 					chunk.imageAlt ?? null,
 					chunk.sourceUpdatedAt ?? null,
 					chunk.transcriptSource ?? null,
-				),
-			db
-				.prepare(
-					`
-						INSERT INTO lexical_search_fts (id, docId, sourceKey, title, text)
-						VALUES (?, ?, ?, ?, ?)
-					`,
-				)
-				.bind(storageChunkId, storageDocId, sourceKey, chunk.title, chunk.text),
+				],
+			),
+			prepareSizedStatement(
+				db,
+				`
+					INSERT INTO lexical_search_fts (id, docId, sourceKey, title, text)
+					VALUES (?, ?, ?, ?, ?)
+				`,
+				[storageChunkId, storageDocId, sourceKey, chunk.title, chunk.text],
+			),
 		)
 	}
 
-	await runStatementsInTransaction({ db, statements })
+	// Mark the source complete only after all docs/chunks are written.
+	statements.push(
+		prepareSizedStatement(
+			db,
+			`
+				INSERT INTO lexical_sources (sourceKey, generatedAt, chunkCount, syncedAt)
+				VALUES (?, ?, ?, ?)
+			`,
+			[sourceKey, artifact.generatedAt, artifact.chunks.length, syncedAt],
+		),
+	)
+
+	await runBatchedStatements({ db, statements })
 }
 
 export async function clearSearchSource({
@@ -448,21 +531,29 @@ export async function clearSearchSource({
 	db: D1Database
 	sourceKey: string
 }) {
-	await runStatementsInTransaction({
+	await runBatchedStatements({
 		db,
 		statements: [
-			db
-				.prepare('DELETE FROM lexical_search_fts WHERE sourceKey = ?')
-				.bind(sourceKey),
-			db
-				.prepare('DELETE FROM lexical_chunks WHERE sourceKey = ?')
-				.bind(sourceKey),
-			db
-				.prepare('DELETE FROM lexical_docs WHERE sourceKey = ?')
-				.bind(sourceKey),
-			db
-				.prepare('DELETE FROM lexical_sources WHERE sourceKey = ?')
-				.bind(sourceKey),
+			prepareSizedStatement(
+				db,
+				'DELETE FROM lexical_search_fts WHERE sourceKey = ?',
+				[sourceKey],
+			),
+			prepareSizedStatement(
+				db,
+				'DELETE FROM lexical_chunks WHERE sourceKey = ?',
+				[sourceKey],
+			),
+			prepareSizedStatement(
+				db,
+				'DELETE FROM lexical_docs WHERE sourceKey = ?',
+				[sourceKey],
+			),
+			prepareSizedStatement(
+				db,
+				'DELETE FROM lexical_sources WHERE sourceKey = ?',
+				[sourceKey],
+			),
 		],
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search worker `/internal/sync` was failing in CI (`sync-search-worker`) because `replaceSearchSource` sent one giant `db.batch()` for large lexical artifacts (podcasts ~35.7 MiB). Cloudflare D1 rejects serialized RPC arguments over 32 MiB:

```text
D1_ERROR: Serialized RPC arguments or return values are limited to 32MiB,
but the size of this value was: 35772551 bytes.
```

Indexing itself succeeded; only the search-worker D1 sync RPC failed.

## Fix

In `services/search-worker/src/search-db.ts`:

- Chunk D1 writes by estimated serialized size (8 MiB soft cap) and statement count (200)
- Delete existing source rows first, write docs/chunks in sized batches, then insert `lexical_sources` last so a mid-sync failure retries instead of being skipped as already synced
- Gate `queryLexicalSearch` on `lexical_sources` so partial mid-replace rows are not searchable

## Test plan

- [x] Unit test reproduces a >32 MiB replace payload and asserts each D1 batch stays under the hard limit
- [x] Asserts `lexical_sources` insert is last
- [x] `npm test --workspace search-worker` passes
- [x] After deploy of search-worker, re-run Sync Search Worker and confirm `/internal/sync` succeeds — https://github.com/kentcdodds/kentcdodds.com/actions/runs/30140952716 (`Sync succeeded: {"ok":true,"syncedAt":"2026-07-25T02:43:40.534Z"}`)

## Notes

Deploy Search Worker on merge: https://github.com/kentcdodds/kentcdodds.com/actions/runs/30140470835/job/89632633548
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5cd0a28-e5aa-4fba-a4e5-5512a2f9e9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5cd0a28-e5aa-4fba-a4e5-5512a2f9e9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search synchronization for large podcast and YouTube sources by batching D1 writes to stay within RPC payload limits.
  - Prevented incomplete data from becoming searchable until a source is fully marked as complete.
  - Ensured interrupted syncs can be retried safely after partial failures.
- **Documentation**
  - Added a “Search sync caveat” note describing non-atomic sync behavior and guidance for chunked replacements under size constraints.
- **Tests**
  - Added coverage to verify oversized sources are split across multiple D1 batches and inserted in the correct order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->