### PR TITLE
Filter Cloudflare edge 502/503/524 Sentry noise (KCD-VH)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -29,13 +29,18 @@ fixes it.
   errors — those can hide real outages. Message/stack drop rules must establish
   an external source (distinctive third-party signature, extension/IAB URL, or
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
-- Client `RouteErrorResponse: 502 Route Error` (from
+- Client `RouteErrorResponse: 502/503/524 Route Error` (from
   `useCapturedRouteError` / `getRouteErrorResponseException`) often wraps
-  Cloudflare's generic Bad Gateway HTML (`<title>… | 502: Bad gateway</title>`,
-  Ray ID, host Error). That is edge/origin failure during document or SPA data
-  fetch, not an app `throw` of status 502. Confirm via
-  `extra.route_error_response.data` before treating it as a route bug. App code
-  almost never throws 502 (exception: `resources/lookout`).
+  Cloudflare's generic edge HTML (`<title>… | 502: Bad gateway</title>`,
+  `503: Service unavailable`, `524: A timeout occurred`, Ray ID). That is
+  edge/origin failure during document or SPA data fetch, not an app `throw`.
+  Confirm via `extra.route_error_response.data` before treating it as a route
+  bug. Related client noise: React Router `Error: 502 `/`503 ` from
+  `fetchAndApplyManifestPatches` when `__manifest` hits the same edge
+  statuses. Filters: `sentry-noise.ts`
+  (`isCloudflareEdgeRouteError` / `isReactRouterEdgeHttpStatusError`). App
+  502/503 responses carry a non-empty body (`resources/lookout`, search) and
+  must not be filtered.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -3,7 +3,10 @@ import {
 	SENTRY_DENY_URLS,
 	SENTRY_IGNORE_ERRORS,
 	isBrowserExtensionError,
+	isCloudflareEdgeErrorHtml,
+	isCloudflareEdgeRouteError,
 	isDegradedUiPerformanceEvent,
+	isReactRouterEdgeHttpStatusError,
 	isWalletUserRejection,
 	shouldDropSentryEvent,
 } from '../sentry-noise.ts'
@@ -140,6 +143,134 @@ test('does not broadly ignore generic Failed to fetch', () => {
 	expect(
 		matchesIgnoreError('NetworkError when attempting to fetch resource.'),
 	).toBe(false)
+})
+
+test('filters Cloudflare edge RouteErrorResponse HTML (KCD-VH family)', () => {
+	const badGatewayHtml = `<!DOCTYPE html><html><head><title>kentcdodds.com | 502: Bad gateway</title></head><body>Ray ID: abc123 cloudflare</body></html>`
+	const timeoutHtml = `<!DOCTYPE html><html><head><title>kentcdodds.com | 524: A timeout occurred</title></head><body>Cloudflare Ray ID: xyz</body></html>`
+
+	expect(isCloudflareEdgeErrorHtml(badGatewayHtml)).toBe(true)
+	expect(isCloudflareEdgeErrorHtml(timeoutHtml)).toBe(true)
+	expect(isCloudflareEdgeErrorHtml('<title>App Error</title>')).toBe(false)
+
+	expect(
+		isCloudflareEdgeRouteError({
+			status: 502,
+			statusText: '',
+			data: badGatewayHtml,
+		}),
+	).toBe(true)
+	expect(
+		isCloudflareEdgeRouteError({
+			status: 503,
+			statusText: '',
+			data: '',
+		}),
+	).toBe(true)
+	expect(
+		isCloudflareEdgeRouteError({
+			status: 502,
+			statusText: '',
+			data: 'Failed to proxy request to Sentry',
+		}),
+	).toBe(false)
+	expect(
+		isCloudflareEdgeRouteError({
+			status: 503,
+			statusText: '',
+			data: { error: 'Search temporarily unavailable' },
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent({
+			exception: {
+				values: [{ type: 'RouteErrorResponse', value: '502 Route Error' }],
+			},
+			extra: {
+				route_error_response: {
+					status: 502,
+					statusText: '',
+					data: badGatewayHtml,
+				},
+			},
+		}),
+	).toBe(true)
+})
+
+test('filters React Router manifest-patch edge HTTP status errors (KCD-ZH/YD/YF)', () => {
+	const original = new Error('502 ')
+	original.stack =
+		'Error: 502 \n    at fetchAndApplyManifestPatches (react-router/dist/chunk.js:1:1)'
+
+	expect(
+		isReactRouterEdgeHttpStatusError(
+			{
+				exception: {
+					values: [
+						{
+							type: 'Error',
+							value: '502 ',
+							stacktrace: {
+								frames: [
+									{
+										filename:
+											'../../../node_modules/react-router/dist/development/chunk.mjs',
+										function: 'fetchAndApplyManifestPatches',
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+			{ originalException: original },
+		),
+	).toBe(true)
+
+	expect(
+		isReactRouterEdgeHttpStatusError({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: '502 ',
+						stacktrace: {
+							frames: [{ filename: '/app/routes/blog.tsx', function: 'loader' }],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'Error',
+							value: '503 ',
+							stacktrace: {
+								frames: [
+									{
+										filename: 'react-router/dist/chunk.mjs',
+										function: 'fetchAndApplyManifestPatches',
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+			{
+				originalException: Object.assign(new Error('503 '), {
+					stack: 'Error: 503 \n    at fetchAndApplyManifestPatches (x:1:1)',
+				}),
+			},
+		),
+	).toBe(true)
 })
 
 test('detects browser extension stacks and denyUrls', () => {

--- a/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
+++ b/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
@@ -70,6 +70,22 @@ describe('useCapturedRouteError', () => {
 		})
 	})
 
+	it('does not capture Cloudflare edge Bad Gateway route errors', async () => {
+		const routeErrorResponse = {
+			status: 502,
+			statusText: '',
+			data: `<!DOCTYPE html><html><head><title>kentcdodds.com | 502: Bad gateway</title></head><body>Ray ID: abc cloudflare</body></html>`,
+		}
+		mockUseRouteError.mockReturnValue(routeErrorResponse)
+		mockIsRouteErrorResponse.mockImplementation(
+			(error: unknown) => error === routeErrorResponse,
+		)
+
+		await render(<TestComponent />)
+
+		expect(mockCaptureException).not.toHaveBeenCalled()
+	})
+
 	it('does not capture non-5xx route error responses', async () => {
 		const routeErrorResponse = {
 			status: 404,

--- a/services/site/app/utils/misc-react.tsx
+++ b/services/site/app/utils/misc-react.tsx
@@ -17,6 +17,7 @@ import { type OptionalTeam, type User } from '#app/types.ts'
 import { images } from '../images.tsx'
 import { buildMediaUrl } from './media.ts'
 import { getOptionalTeam } from './misc.ts'
+import { isCloudflareEdgeRouteError } from './sentry-noise.ts'
 
 export * from './misc.ts'
 
@@ -226,15 +227,19 @@ export function useCapturedRouteError() {
 	if (isRouteErrorResponse(error)) {
 		if (error.status < 500) return error
 
-		Sentry.captureException(getRouteErrorResponseException(error), {
-			extra: {
-				route_error_response: {
-					status: error.status,
-					statusText: error.statusText,
-					data: error.data,
+		// Cloudflare edge/origin HTML (or bare empty-body 502/503/524) is not an
+		// app throw — still render the boundary, but do not report to Sentry.
+		if (!isCloudflareEdgeRouteError(error)) {
+			Sentry.captureException(getRouteErrorResponseException(error), {
+				extra: {
+					route_error_response: {
+						status: error.status,
+						statusText: error.statusText,
+						data: error.data,
+					},
 				},
-			},
-		})
+			})
+		}
 		return error
 	}
 

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -46,17 +46,39 @@ export const SENTRY_DENY_URLS: Array<RegExp> = [
 type SentryExceptionValue = {
 	type?: string | null
 	value?: string | null
-	stacktrace?: { frames?: Array<{ filename?: string | null }> | null } | null
+	stacktrace?: {
+		frames?: Array<{
+			filename?: string | null
+			function?: string | null
+		}> | null
+	} | null
+}
+
+type RouteErrorResponseExtra = {
+	status?: number | null
+	statusText?: string | null
+	data?: unknown
 }
 
 type SentryEventLike = {
 	message?: string | null
 	request?: { url?: string | null } | null
 	exception?: { values?: Array<SentryExceptionValue> | null } | null
+	extra?: { route_error_response?: RouteErrorResponseExtra | null } | null
 }
 
 const WALLET_PROVIDER_STACK =
 	/metamask|coinbase|rainbow|walletconnect|phantom|ethereum|eip-1193|inpage\.js|nkbihfbeogaeaoehlefnkodbefgpgknn/i
+
+/** Cloudflare edge HTML error pages (502/503/524) seen on SPA .data fetches. */
+const CLOUDFLARE_EDGE_ERROR_TITLE =
+	/<\s*title[^>]*>[^<]*\|\s*5(?:02:\s*Bad gateway|03:\s*Service unavailable|24:\s*A timeout occurred)\s*<\s*\/\s*title\s*>/i
+
+const CLOUDFLARE_EDGE_STATUSES = new Set([502, 503, 524])
+
+const REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE = /^5(?:02|03|24)\s*$/
+
+const REACT_ROUTER_MANIFEST_PATCH_STACK = /fetchAndApplyManifestPatches/
 
 export function isBrowserExtensionError(exception: unknown): boolean {
 	if (!(exception instanceof Error) || !exception.stack) return false
@@ -94,6 +116,71 @@ function stackBlob(event: SentryEventLike, originalException: unknown): string {
 	const errorStack =
 		originalException instanceof Error ? (originalException.stack ?? '') : ''
 	return `${frameFiles}\n${errorStack}`
+}
+
+export function isCloudflareEdgeErrorHtml(data: string): boolean {
+	if (!CLOUDFLARE_EDGE_ERROR_TITLE.test(data)) return false
+	// Ray ID + "cloudflare" are stable markers on the generic edge HTML page.
+	return /Ray ID/i.test(data) || /cloudflare/i.test(data)
+}
+
+/**
+ * Client RouteErrorResponse for edge/origin 502/503/524 — not an app throw.
+ * Confirmed via Sentry `extra.route_error_response.data` (Cloudflare HTML) or
+ * bare empty-body statuses during SPA data/manifest fetches (KCD-VH family).
+ * App 502/503 responses carry a non-empty body (lookout string / search JSON).
+ */
+export function isCloudflareEdgeRouteError(error: {
+	status: number
+	statusText?: string | null
+	data?: unknown
+}): boolean {
+	if (!CLOUDFLARE_EDGE_STATUSES.has(error.status)) return false
+
+	if (typeof error.data === 'string' && isCloudflareEdgeErrorHtml(error.data)) {
+		return true
+	}
+
+	const statusText = error.statusText ?? ''
+	const emptyBody = error.data === '' || error.data == null
+	return statusText === '' && emptyBody
+}
+
+function routeErrorExtra(
+	event: SentryEventLike,
+): RouteErrorResponseExtra | null {
+	return event.extra?.route_error_response ?? null
+}
+
+export function isCloudflareEdgeRouteErrorEvent(event: SentryEventLike): boolean {
+	const route = routeErrorExtra(event)
+	if (!route || typeof route.status !== 'number') return false
+
+	return isCloudflareEdgeRouteError({
+		status: route.status,
+		statusText: route.statusText,
+		data: route.data,
+	})
+}
+
+/**
+ * React Router surfaces bare `Error: 502 ` / `503 ` / `524 ` from
+ * fetchAndApplyManifestPatches when `__manifest` hits an edge HTTP failure
+ * (KCD-ZH / KCD-YD / KCD-YF). Require the RR frame — never the status alone.
+ */
+export function isReactRouterEdgeHttpStatusError(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const messages = eventMessages(event)
+	const original = hint.originalException
+	if (original instanceof Error) messages.push(original.message)
+
+	if (!messages.some((message) => REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE.test(message))) {
+		return false
+	}
+
+	return REACT_ROUTER_MANIFEST_PATCH_STACK.test(stackBlob(event, original))
 }
 
 /**
@@ -136,6 +223,8 @@ export function shouldDropSentryEvent(
 	if (isBrowserExtensionError(hint.originalException)) return true
 	if (isWalletUserRejection(event, hint)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true
+	if (isCloudflareEdgeRouteErrorEvent(event)) return true
+	if (isReactRouterEdgeHttpStatusError(event, hint)) return true
 	if (event.request?.url?.includes('/lookout')) return true
 	if (event.request?.url?.includes('translate-pa.googleapis.com')) return true
 	return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Client `RouteErrorResponse: 502 Route Error` (and related 503/524) events are Cloudflare edge/origin failures during SPA `.data` / `__manifest` fetches, not app throws. Confirmed via Sentry `extra.route_error_response.data` containing Cloudflare HTML (`<title>… | 502: Bad gateway</title>`, Ray ID).

## Changes

- Add narrow filters in `sentry-noise.ts`:
  - Cloudflare edge HTML / bare empty-body 502/503/524 `RouteErrorResponse` extras
  - React Router `Error: 502 `/`503 `/`524 ` from `fetchAndApplyManifestPatches`
- Skip capture for edge route errors in `useCapturedRouteError`
- Keep real app 502/503 (lookout string body, search JSON) reporting
- Document the family in `docs/agents/bugfix-workflow.md`

## Sentry issues

- KCD-VH (7286947856) — main
- KCD-ZH (7559620419), KCD-YD (7420333688), KCD-YF (7434046721) — same edge-5xx family

## Risk

Low — client noise filter + capture skip with unit/browser tests. No auth/billing/migration surface.

## Review notes

CodeRabbit nit about empty-body 503: intentional. Confirmed KCD-VH events have empty `data` during edge `__manifest`/`.data` 503s; app 502/503 responses in this repo always carry a non-empty body and are covered by tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4b8e340-2b5a-47b9-8a9e-f506093d61e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b8e340-2b5a-47b9-8a9e-f506093d61e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive error reports caused by temporary Cloudflare edge failures and React Router manifest requests.
  * Cloudflare 502, 503, and 524 error pages are now recognized more reliably.
  * Genuine application errors with server-error responses continue to be reported.
  * Improved handling of captured route errors so edge-generated failures are excluded from monitoring noise.

* **Documentation**
  * Clarified troubleshooting guidance for distinguishing edge infrastructure failures from application route errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->