### PR TITLE
Filter React Router single-fetch routeId Sentry noise (KCD-VP)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -36,6 +36,13 @@ fixes it.
   fetch, not an app `throw` of status 502. Confirm via
   `extra.route_error_response.data` before treating it as a route bug. App code
   almost never throws 502 (exception: `resources/lookout`).
+- Client `Error: No result found for routeId "…"` is React Router's
+  `SingleFetchNoResultError` from `unwrapSingleFetchResult` when a stale client
+  route tree asks for a routeId missing from the server's single-fetch `.data`
+  response (tab held open across deploys). Stack is entirely in `react-router`;
+  the same signature appears for many still-existing routes (`routes/courses`,
+  `routes/blog_/$slug`, etc.). Filter via `sentry-noise.ts` — do not "fix" by
+  re-adding routes that already exist.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -31,20 +31,6 @@ fixes it.
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
 - Client `RouteErrorResponse: 502/503/524 Route Error` (from
   `useCapturedRouteError` / `getRouteErrorResponseException`) often wraps
-<<<<<<< HEAD
-  Cloudflare's generic Bad Gateway HTML (`<title>… | 502: Bad gateway</title>`,
-  Ray ID, host Error). That is edge/origin failure during document or SPA data
-  fetch, not an app `throw` of status 502. Confirm via
-  `extra.route_error_response.data` before treating it as a route bug. App code
-  almost never throws 502 (exception: `resources/lookout`).
-- Client `Error: No result found for routeId "…"` is React Router's
-  `SingleFetchNoResultError` from `unwrapSingleFetchResult` when a stale client
-  route tree asks for a routeId missing from the server's single-fetch `.data`
-  response (tab held open across deploys). Stack is entirely in `react-router`;
-  the same signature appears for many still-existing routes (`routes/courses`,
-  `routes/blog_/$slug`, etc.). Filter via `sentry-noise.ts` — do not "fix" by
-  re-adding routes that already exist.
-=======
   Cloudflare's generic edge HTML (`<title>… | 502: Bad gateway</title>`,
   `503: Service unavailable`, `524: A timeout occurred`, Ray ID). That is
   edge/origin failure during document or SPA data fetch, not an app `throw`.
@@ -55,7 +41,13 @@ fixes it.
   (`isCloudflareEdgeRouteError` / `isReactRouterEdgeHttpStatusError`). App
   502/503 responses carry a non-empty body (`resources/lookout`, search) and
   must not be filtered.
->>>>>>> origin/main
+- Client `Error: No result found for routeId "…"` is React Router's
+  `SingleFetchNoResultError` from `unwrapSingleFetchResult` when a stale client
+  route tree asks for a routeId missing from the server's single-fetch `.data`
+  response (tab held open across deploys). Stack is entirely in `react-router`;
+  the same signature appears for many still-existing routes (`routes/courses`,
+  `routes/blog_/$slug`, etc.). Filter via `sentry-noise.ts` — do not "fix" by
+  re-adding routes that already exist.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -129,6 +129,23 @@ test('filters injected elem.firstChild parsers (KCD-ZZ)', () => {
 	).toBe(true)
 })
 
+test('filters React Router single-fetch routeId skew (KCD-VP family)', () => {
+	expect(
+		matchesIgnoreError('No result found for routeId "routes/courses"'),
+	).toBe(true)
+	expect(
+		matchesIgnoreError(
+			'No result found for routeId "routes/blog_/$slug"',
+		),
+	).toBe(true)
+	expect(
+		matchesIgnoreError(
+			'No result found for routeId "routes/calls/$season/$episode/$slug"',
+		),
+	).toBe(true)
+	expect(matchesIgnoreError('No result found for route')).toBe(false)
+})
+
 test('keeps Module load timeout filter (KCD-ZS / KCD-ZT)', () => {
 	expect(matchesIgnoreError('Module load timeout: m_1001')).toBe(true)
 	expect(matchesIgnoreError('Module load timeout: m_1004')).toBe(true)

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -31,6 +31,10 @@ export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	/document\.querySelector\("meta\[property='og:type'\]"\)\.content/,
 	// Injected HTML parsers / translators mutating the DOM (KCD-ZZ).
 	/evaluating 'elem\.firstChild'/,
+	// React Router SingleFetchNoResultError: client route tree / single-fetch
+	// response skew across deploys (stale tab). Distinctive framework message from
+	// unwrapSingleFetchResult — not an app missing-route bug (KCD-VP family).
+	/No result found for routeId "/,
 ]
 
 export const SENTRY_DENY_URLS: Array<RegExp> = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Client `Error: No result found for routeId "…"` is React Router's `SingleFetchNoResultError` from `unwrapSingleFetchResult` when a stale client route tree asks for a routeId missing from the server's single-fetch `.data` response (tab held open across deploys).

Confirmed not a missing-route bug: the same signature fires for many still-existing routes (`routes/courses`, `routes/blog_/$slug`, `routes/login`, `routes/index`, etc.), stacks are entirely in `react-router`, and KCD-ZD breadcrumbs show "No routes matched" + `__manifest` fetch after a stale/old client.

## Changes

- Narrow `ignoreErrors` filter in `sentry-noise.ts` for the distinctive framework message
- Unit tests for the KCD-VP / KCD-ZD / KCD-XS signatures
- Document the family in `docs/agents/bugfix-workflow.md`

## Sentry issues

- KCD-VP (7288779185) — main
- KCD-ZD (7541868081), KCD-XS (7370295223) — same SingleFetchNoResultError family

## Risk

Low — client noise filter + unit tests. No auth/billing/migration surface.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aec2cbd-fe85-4367-a43f-cab9627683a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aec2cbd-fe85-4367-a43f-cab9627683a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy Sentry reporting for React Router single-fetch “no result found” routeId errors caused by stale routes after deployments.
  * Kept alerts for broader “no result found” cases that may signal real problems.

* **Documentation**
  * Added triage guidance for identifying these deployment-related routing events.

* **Tests**
  * Added test coverage to confirm the Sentry noise filter behavior across the affected routeId patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->