### PR TITLE
Filter React Router CSRF abort Sentry noise (KCD-YN)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -29,6 +29,11 @@ fixes it.
   errors — those can hide real outages. Message/stack drop rules must establish
   an external source (distinctive third-party signature, extension/IAB URL, or
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
+- Server: React Router `throwIfPotentialCSRFAttack` aborts (`…from a forwarded
+  action request. Aborting the action.`, invalid/`missing host` Origin variants)
+  are expected 400s for mismatched Origin probes. Skip Sentry in
+  `entry.server.tsx` `handleError` via `isReactRouterCsrfAbortError` (KCD-YN);
+  do not weaken CSRF checks to silence the alert.
 - Page-translator DOM mutation (Google/Chrome Translate) often surfaces as
   `RangeError: Maximum call stack size exceeded` with an unattributed
   `filename: "undefined"` frame plus UI breadcrumbs like `a > font > font`, or

--- a/services/site/app/entry.server.tsx
+++ b/services/site/app/entry.server.tsx
@@ -12,6 +12,7 @@ import {
 	appendAgentDiscoveryHeaders,
 	shouldAppendAgentDiscoveryHeaders,
 } from '#app/utils/agent-discovery.ts'
+import { isReactRouterCsrfAbortError } from '#app/utils/sentry-noise.ts'
 import { routes as otherRoutes } from './other-routes.server.ts'
 import { getEnv, getPublicEnv, init } from './utils/env.server.ts'
 import { NonceProvider } from './utils/nonce-provider.ts'
@@ -209,6 +210,10 @@ export function handleError(
 	// Skip capturing if the request is aborted as Remix docs suggest
 	// Ref: https://remix.run/docs/en/main/file-conventions/entry.server#handleerror
 	if (request.signal.aborted) {
+		return
+	}
+	// React Router CSRF rejects are expected 400s (KCD-YN), not app failures.
+	if (isReactRouterCsrfAbortError(error)) {
 		return
 	}
 	if (error instanceof Error) {

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -10,7 +10,11 @@ import {
 	isHtmlPageTranslated,
 	isInjectedBlobAddListenerError,
 	isPageTranslatorCallStackOverflow,
+<<<<<<< HEAD
 	isReactRouterDataProtocolNoise,
+=======
+	isReactRouterCsrfAbortError,
+>>>>>>> 01797435 (Filter React Router CSRF abort noise from Sentry (KCD-YN))
 	isReactRouterEdgeHttpStatusError,
 	isWalletUserRejection,
 	shouldDropSentryEvent,
@@ -716,4 +720,37 @@ test('filters page-translator call stack overflows with font breadcrumbs (KCD-QW
 			documentElement: { className: 'dark' },
 		}),
 	).toBe(false)
+})
+
+test('recognizes React Router CSRF abort messages (KCD-YN)', () => {
+	expect(
+		isReactRouterCsrfAbortError(
+			new Error(
+				'host header does not match `origin` header from a forwarded action request. Aborting the action.',
+			),
+		),
+	).toBe(true)
+	expect(
+		isReactRouterCsrfAbortError(
+			new Error(
+				'x-forwarded-host header does not match `origin` header from a forwarded action request. Aborting the action.',
+			),
+		),
+	).toBe(true)
+	expect(
+		isReactRouterCsrfAbortError(
+			new Error('`origin` header is not a valid URL. Aborting the action.'),
+		),
+	).toBe(true)
+	expect(
+		isReactRouterCsrfAbortError(
+			new Error(
+				'`x-forwarded-host` or `host` headers are not provided. One of these is needed to compare the `origin` header from a forwarded action request. Aborting the action.',
+			),
+		),
+	).toBe(true)
+	expect(isReactRouterCsrfAbortError(new Error('Aborting the action.'))).toBe(
+		false,
+	)
+	expect(isReactRouterCsrfAbortError('not an error')).toBe(false)
 })

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -10,11 +10,8 @@ import {
 	isHtmlPageTranslated,
 	isInjectedBlobAddListenerError,
 	isPageTranslatorCallStackOverflow,
-<<<<<<< HEAD
-	isReactRouterDataProtocolNoise,
-=======
 	isReactRouterCsrfAbortError,
->>>>>>> 01797435 (Filter React Router CSRF abort noise from Sentry (KCD-YN))
+	isReactRouterDataProtocolNoise,
 	isReactRouterEdgeHttpStatusError,
 	isWalletUserRejection,
 	shouldDropSentryEvent,

--- a/services/site/app/utils/__tests__/worker-request-pipeline.server.test.ts
+++ b/services/site/app/utils/__tests__/worker-request-pipeline.server.test.ts
@@ -210,3 +210,30 @@ test('worker pipeline still reaches the router for a normal path', async () => {
 	expect(response.status).toBe(200)
 	expect(await response.text()).toContain('splat')
 })
+
+test('worker pipeline CSRF-rejects POST with mismatched Origin (KCD-YN)', async () => {
+	const getServerBuild = vi.fn(async () => createMinimalSplatServerBuild())
+	const handler = createWorkerFetchHandler({
+		redirectsText: '',
+		ensureRuntimeBridges: async () => {},
+		getServerBuild,
+		requestHandlerMode: 'production',
+		errorLogLabel: 'test-csrf-abort',
+	})
+
+	const response = await handler.fetch(
+		new Request('https://kentcdodds.com/me', {
+			method: 'POST',
+			headers: {
+				Origin: 'https://evil.example',
+				Host: 'kentcdodds.com',
+			},
+		}),
+		{},
+		createTestExecutionContext(),
+	)
+
+	expect(getServerBuild).toHaveBeenCalledOnce()
+	expect(response.status).toBe(400)
+	expect(await response.text()).toBe('Bad Request')
+})

--- a/services/site/app/utils/__tests__/worker-request-pipeline.server.test.ts
+++ b/services/site/app/utils/__tests__/worker-request-pipeline.server.test.ts
@@ -6,6 +6,7 @@ import {
 	type ServerBuild,
 } from 'react-router'
 import { expect, test, vi } from 'vitest'
+import { setEnv } from '#tests/env-disposable.ts'
 import {
 	createWorkerFetchHandler,
 	isMalformedRequestPath,
@@ -212,6 +213,11 @@ test('worker pipeline still reaches the router for a normal path', async () => {
 })
 
 test('worker pipeline CSRF-rejects POST with mismatched Origin (KCD-YN)', async () => {
+	// Test env defaults allowedActionOrigins to `**`; pin production-like hosts
+	// so React Router's CSRF check still rejects foreign Origins.
+	using _ignoredEnv = setEnv({
+		ALLOWED_ACTION_ORIGINS: 'kentcdodds.com',
+	})
 	const getServerBuild = vi.fn(async () => createMinimalSplatServerBuild())
 	const handler = createWorkerFetchHandler({
 		redirectsText: '',

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -12,16 +12,6 @@
  * is wired from `entry.server.tsx` `handleError` (KCD-YN).
  */
 
-<<<<<<< HEAD
-const TURBO_STREAM_DECODE_ERROR = 'Unable to decode turbo-stream response'
-const HTML_AS_JSON_ERROR = /Unexpected token '<',\s*"<!DOCTYPE/i
-const SAFARI_JSON_PATTERN_ERROR =
-	/^The string did not match the expected pattern\.?$/i
-const REACT_ROUTER_TURBO_STREAM_STACK = /fetchAndDecodeViaTurboStream/
-const REACT_ROUTER_DATA_PROTOCOL_MANIFEST_STACK =
-	/fetchAndApplyManifestPatches|Failed to fetch manifest patches/i
-const DATA_PROTOCOL_REQUEST = /\/(?:__manifest|\S+\.data)(?:\?|$)/i
-=======
 /**
  * React Router `throwIfPotentialCSRFAttack` rejects cross-origin POSTs with
  * these exact messages, then `handleError` would otherwise report them.
@@ -40,7 +30,15 @@ export function isReactRouterCsrfAbortError(error: unknown): boolean {
 		error.message.includes(message),
 	)
 }
->>>>>>> 01797435 (Filter React Router CSRF abort noise from Sentry (KCD-YN))
+
+const TURBO_STREAM_DECODE_ERROR = 'Unable to decode turbo-stream response'
+const HTML_AS_JSON_ERROR = /Unexpected token '<',\s*"<!DOCTYPE/i
+const SAFARI_JSON_PATTERN_ERROR =
+	/^The string did not match the expected pattern\.?$/i
+const REACT_ROUTER_TURBO_STREAM_STACK = /fetchAndDecodeViaTurboStream/
+const REACT_ROUTER_DATA_PROTOCOL_MANIFEST_STACK =
+	/fetchAndApplyManifestPatches|Failed to fetch manifest patches/i
+const DATA_PROTOCOL_REQUEST = /\/(?:__manifest|\S+\.data)(?:\?|$)/i
 
 export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	// Tunnel / self-reporting

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -1,13 +1,18 @@
 /**
- * Narrow client-side Sentry noise filters for injected third-party scripts,
- * browser extensions, in-app browsers, and similar non-app sources.
+ * Narrow Sentry noise filters for injected third-party scripts, browser
+ * extensions, in-app browsers, and expected framework security rejects.
  *
  * Prefer message/URL signatures over broad network-error filters so real
  * outages still alert. Drop rules must establish an external source via a
- * distinctive payload signature, extension/IAB URL, or provider error code —
- * not a generic phrase alone.
+ * distinctive payload signature, extension/IAB URL, provider error code, or
+ * framework CSRF-abort text — not a generic phrase alone.
+ *
+ * Client SDK: wired from `monitoring.client.tsx` via `ignoreErrors` /
+ * `denyUrls` / `shouldDropSentryEvent`. Server: `isReactRouterCsrfAbortError`
+ * is wired from `entry.server.tsx` `handleError` (KCD-YN).
  */
 
+<<<<<<< HEAD
 const TURBO_STREAM_DECODE_ERROR = 'Unable to decode turbo-stream response'
 const HTML_AS_JSON_ERROR = /Unexpected token '<',\s*"<!DOCTYPE/i
 const SAFARI_JSON_PATTERN_ERROR =
@@ -16,6 +21,26 @@ const REACT_ROUTER_TURBO_STREAM_STACK = /fetchAndDecodeViaTurboStream/
 const REACT_ROUTER_DATA_PROTOCOL_MANIFEST_STACK =
 	/fetchAndApplyManifestPatches|Failed to fetch manifest patches/i
 const DATA_PROTOCOL_REQUEST = /\/(?:__manifest|\S+\.data)(?:\?|$)/i
+=======
+/**
+ * React Router `throwIfPotentialCSRFAttack` rejects cross-origin POSTs with
+ * these exact messages, then `handleError` would otherwise report them.
+ * That is expected security behavior (attacker probes / mismatched Origin),
+ * not an app bug — skip Sentry capture.
+ */
+const REACT_ROUTER_CSRF_ABORT_MESSAGES = [
+	'header does not match `origin` header from a forwarded action request. Aborting the action.',
+	'`origin` header is not a valid URL. Aborting the action.',
+	'`x-forwarded-host` or `host` headers are not provided. One of these is needed to compare the `origin` header from a forwarded action request. Aborting the action.',
+] as const
+
+export function isReactRouterCsrfAbortError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false
+	return REACT_ROUTER_CSRF_ABORT_MESSAGES.some((message) =>
+		error.message.includes(message),
+	)
+}
+>>>>>>> 01797435 (Filter React Router CSRF abort noise from Sentry (KCD-YN))
 
 export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	// Tunnel / self-reporting


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

React Router `throwIfPotentialCSRFAttack` correctly rejects cross-origin POSTs (mismatched `Origin` vs `Host` / not in `allowedActionOrigins`) with a distinctive abort error, then `handleError` was reporting those expected 400s to Sentry (KCD-YN).

Evidence: 10 events, 0 users; Fly/Node era; browsers include HeadlessChrome; concurrent scanner URI-malformed breadcrumbs; hits on `/me`, `/action/kit`, promotification actions. CSRF still applies on workerd — filtering capture, not the check.

## Changes

- Add `isReactRouterCsrfAbortError` in `sentry-noise.ts` for RR’s CSRF abort message signatures
- Skip Sentry capture in `entry.server.tsx` `handleError` for those errors
- Unit + worker-pipeline regression tests (POST with evil Origin → 400)
- Document in `docs/agents/bugfix-workflow.md`

## Risk

Low — noise filter only; CSRF protection unchanged. No auth/billing/migration surface.

## Sentry

- KCD-YN (7443048032) — ignored after merge (expected attacker-probe / CSRF reject noise)

## Status

Squash-merged as `c404661`. Outcome recorded: **filtered**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fcda01c-9d34-48cc-a4a7-bf2057937d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fcda01c-9d34-48cc-a4a7-bf2057937d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of expected React Router CSRF aborts so they no longer generate noisy console/Sentry reporting.
  - Added/verified CSRF protection behavior: `POST` requests with a mismatched `Origin` are rejected with `400 Bad Request`.
- **Documentation**
  - Updated the Sentry triage guidance to document how to identify and ignore specific CSRF-related “aborting the action” cases, without weakening CSRF checks.
- **Tests**
  - Added coverage for the new React Router CSRF “noise filtering” matcher and the `Origin`/CSRF rejection path in the worker request pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->