### PR TITLE
Filter page-translator Sentry call stack overflows (KCD-QW)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -29,6 +29,11 @@ fixes it.
   errors — those can hide real outages. Message/stack drop rules must establish
   an external source (distinctive third-party signature, extension/IAB URL, or
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
+- Page-translator DOM mutation (Google/Chrome Translate) often surfaces as
+  `RangeError: Maximum call stack size exceeded` with an unattributed
+  `filename: "undefined"` frame plus UI breadcrumbs like `a > font > font`, or
+  `html.translated-ltr` / `translated-rtl`. Do not broadly ignore call-stack
+  overflows — require that unusable stack plus translator evidence (KCD-QW).
 - Client `RouteErrorResponse: 502/503/524 Route Error` (from
   `useCapturedRouteError` / `getRouteErrorResponseException`) often wraps
   Cloudflare's generic edge HTML (`<title>… | 502: Bad gateway</title>`,

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import {
 	SENTRY_DENY_URLS,
 	SENTRY_IGNORE_ERRORS,
+	hasOnlyUnusableStackFrames,
 	isBrowserExtensionError,
 	isCloudflareEdgeErrorHtml,
 	isCloudflareEdgeRouteError,
 	isDegradedUiPerformanceEvent,
+	isHtmlPageTranslated,
 	isInjectedBlobAddListenerError,
+	isPageTranslatorCallStackOverflow,
 	isReactRouterEdgeHttpStatusError,
 	isWalletUserRejection,
 	shouldDropSentryEvent,
@@ -432,6 +435,114 @@ test('drops degraded UI performance noise and lookout/translate requests', () =>
 		shouldDropSentryEvent({
 			message: 'Real app bug',
 			request: { url: 'https://kentcdodds.com/blog' },
+		}),
+	).toBe(false)
+})
+
+test('filters page-translator call stack overflows with font breadcrumbs (KCD-QW)', () => {
+	const translatorEvent = {
+		exception: {
+			values: [
+				{
+					type: 'RangeError',
+					value: 'Maximum call stack size exceeded.',
+					stacktrace: {
+						frames: [{ filename: 'undefined' }],
+					},
+				},
+			],
+		},
+		breadcrumbs: [
+			{
+				category: 'ui.click',
+				message: 'ul > li > a > font > font',
+			},
+		],
+	}
+
+	expect(hasOnlyUnusableStackFrames(translatorEvent)).toBe(true)
+	expect(
+		isPageTranslatorCallStackOverflow(translatorEvent, {
+			pageTranslated: false,
+		}),
+	).toBe(true)
+	expect(
+		shouldDropSentryEvent(translatorEvent, { pageTranslated: false }),
+	).toBe(true)
+
+	// Real app frames must still alert even if a translator mutated the DOM.
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [{ filename: '/assets/entry.client.js' }],
+							},
+						},
+					],
+				},
+				breadcrumbs: [
+					{
+						category: 'ui.click',
+						message: 'ul > li > a > font > font',
+					},
+				],
+			},
+			{ pageTranslated: true },
+		),
+	).toBe(false)
+
+	// Unattributed stack overflow without translator evidence stays reportable.
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [{ filename: 'undefined' }],
+							},
+						},
+					],
+				},
+			},
+			{ pageTranslated: false },
+		),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [{ filename: 'undefined' }],
+							},
+						},
+					],
+				},
+			},
+			{ pageTranslated: true },
+		),
+	).toBe(true)
+
+	expect(
+		isHtmlPageTranslated({
+			documentElement: { className: 'translated-ltr' },
+		}),
+	).toBe(true)
+	expect(
+		isHtmlPageTranslated({
+			documentElement: { className: 'dark' },
 		}),
 	).toBe(false)
 })

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -70,12 +70,22 @@ type RouteErrorResponseExtra = {
 	data?: unknown
 }
 
+type SentryBreadcrumbLike = {
+	category?: string | null
+	message?: string | null
+}
+
 type SentryEventLike = {
 	message?: string | null
 	request?: { url?: string | null } | null
 	exception?: { values?: Array<SentryExceptionValue> | null } | null
 	extra?: { route_error_response?: RouteErrorResponseExtra | null } | null
+	breadcrumbs?: Array<SentryBreadcrumbLike> | null
 }
+
+// Google Translate / browser page-translate wraps text in nested <font> tags.
+const TRANSLATOR_FONT_SELECTOR = /(?:^|>)\s*font\s*>\s*font\b/i
+const CALL_STACK_OVERFLOW = /Maximum call stack size exceeded/i
 
 const WALLET_PROVIDER_STACK =
 	/metamask|coinbase|rainbow|walletconnect|phantom|ethereum|eip-1193|inpage\.js|nkbihfbeogaeaoehlefnkodbefgpgknn/i
@@ -263,9 +273,73 @@ export function isInjectedBlobAddListenerError(
 	return urls.length > 0 && urls.every((url) => /^blob:/i.test(url))
 }
 
+function isCallStackOverflow(event: SentryEventLike): boolean {
+	return eventMessages(event).some((message) => CALL_STACK_OVERFLOW.test(message))
+}
+
+function exceptionFrames(event: SentryEventLike) {
+	return (event.exception?.values ?? []).flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+}
+
+/**
+ * Real app recursion still attributes frames to bundle URLs. Translator and
+ * other injected scripts often report a single unusable "undefined" filename
+ * via window.onerror (KCD-QW).
+ */
+export function hasOnlyUnusableStackFrames(event: SentryEventLike): boolean {
+	const frames = exceptionFrames(event)
+	if (frames.length === 0) return true
+	return frames.every((frame) => {
+		const filename = frame.filename
+		return (
+			filename == null ||
+			filename === '' ||
+			filename === 'undefined' ||
+			filename === 'null'
+		)
+	})
+}
+
+function hasTranslatorFontBreadcrumb(event: SentryEventLike): boolean {
+	return (event.breadcrumbs ?? []).some(
+		(breadcrumb) =>
+			breadcrumb.category === 'ui.click' &&
+			TRANSLATOR_FONT_SELECTOR.test(breadcrumb.message ?? ''),
+	)
+}
+
+/** Live marker Google/Chrome page translate adds to <html>. */
+export function isHtmlPageTranslated(
+	doc: { documentElement?: { className?: string } | null } | null | undefined =
+		typeof document === 'undefined' ? undefined : document,
+): boolean {
+	const className = doc?.documentElement?.className
+	if (typeof className !== 'string') return false
+	return /\btranslated-(?:ltr|rtl)\b/.test(className)
+}
+
+/**
+ * Page translators (Google Translate / Chrome Translate) mutate React's DOM
+ * with nested <font> tags and can recurse until RangeError. Only drop when the
+ * stack is unattributed and translator evidence is present (KCD-QW).
+ */
+export function isPageTranslatorCallStackOverflow(
+	event: SentryEventLike,
+	options: { pageTranslated?: boolean } = {},
+): boolean {
+	if (!isCallStackOverflow(event)) return false
+	if (!hasOnlyUnusableStackFrames(event)) return false
+	if (hasTranslatorFontBreadcrumb(event)) return true
+	if (options.pageTranslated === true) return true
+	if (options.pageTranslated === false) return false
+	return isHtmlPageTranslated()
+}
+
 export function shouldDropSentryEvent(
 	event: SentryEventLike,
-	hint: { originalException?: unknown } = {},
+	hint: { originalException?: unknown; pageTranslated?: boolean } = {},
 ): boolean {
 	if (isBrowserExtensionError(hint.originalException)) return true
 	if (isWalletUserRejection(event, hint)) return true
@@ -275,5 +349,12 @@ export function shouldDropSentryEvent(
 	if (isReactRouterEdgeHttpStatusError(event, hint)) return true
 	if (event.request?.url?.includes('/lookout')) return true
 	if (event.request?.url?.includes('translate-pa.googleapis.com')) return true
+	if (
+		isPageTranslatorCallStackOverflow(event, {
+			pageTranslated: hint.pageTranslated,
+		})
+	) {
+		return true
+	}
 	return false
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Sentry [KCD-QW](https://kent-c-dodds-tech-llc.sentry.io/issues/6732789152/)** reports `RangeError: Maximum call stack size exceeded` on blog pages (and `/`) with an unattributed `filename: "undefined"` stack.
- Events with UI breadcrumbs show Google/Chrome Translate’s nested `<font>` selectors (`ul > li > a > font > font`). The site never emits `<font>` tags; this is translator DOM mutation against React, not an app recursion bug.
- Narrow client filter in `sentry-noise.ts`: drop only when the error is a call-stack overflow, the stack is unusable, **and** translator evidence is present (`font > font` breadcrumbs or `html.translated-ltr` / `translated-rtl`). Real app frames still alert.
- Rebased onto main after #862 and #866 (same `sentry-noise.ts` surface).

## Test plan

- [x] `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/sentry-noise.test.ts` (20 tests)
- [ ] CI green after latest rebase
- After merge: mark KCD-QW ignored in Sentry (filter outcome; not a code fix of app logic).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae69be1d-6bf5-483a-99da-bbe2042fa7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae69be1d-6bf5-483a-99da-bbe2042fa7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry noise filtering to detect call stack overflows triggered by page translation tools.
  * Suppresses only translator-attributed overflows, while preserving reports with meaningful application stack frames.
  * Adds an optional hint to ensure translation context is respected when deciding whether to drop events.
* **Documentation**
  * Updated Sentry triage guidance with specific instructions for handling translation-related call stack overflows.
* **Tests**
  * Expanded coverage for translation-attribution scenarios and the “only unusable stack frames” determination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->