### PR TITLE
Filter in-app browser and injected-script Sentry noise (KCD-ZR)

### DIFF
--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -6,6 +6,7 @@ import {
 	isCloudflareEdgeErrorHtml,
 	isCloudflareEdgeRouteError,
 	isDegradedUiPerformanceEvent,
+	isInjectedBlobAddListenerError,
 	isReactRouterEdgeHttpStatusError,
 	isWalletUserRejection,
 	shouldDropSentryEvent,
@@ -128,6 +129,127 @@ test('filters injected elem.firstChild parsers (KCD-ZZ)', () => {
 	expect(
 		matchesIgnoreError(
 			"undefined is not an object (evaluating 'elem.firstChild')",
+		),
+	).toBe(true)
+})
+
+test('filters Instagram WKWebView messageHandlers bridge (KCD-ZR / KCD-ZC)', () => {
+	expect(
+		matchesIgnoreError(
+			"undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+		),
+	).toBe(true)
+})
+
+test('filters javascript-obfuscator a0_0x injectors (KCD-ZG)', () => {
+	expect(matchesIgnoreError('a0_0x3b27 is not defined')).toBe(true)
+	expect(matchesIgnoreError('a0_0xdeadbeef is not defined')).toBe(true)
+	expect(matchesIgnoreError('myHelper is not defined')).toBe(false)
+})
+
+test('filters WKWebView invalid-frame native errors (KCD-YV)', () => {
+	expect(
+		matchesIgnoreError(
+			'Error Domain=WKErrorDomain Code=12 "JavaScript execution targeted an invalid frame"',
+		),
+	).toBe(true)
+})
+
+test('filters Sentry Replay cross-origin iframe Element probes (KCD-TF)', () => {
+	expect(
+		matchesIgnoreError(
+			`Failed to read a named property 'Element' from 'Window': Blocked a frame with origin "https://kentcdodds.com" from accessing a cross-origin frame.`,
+		),
+	).toBe(true)
+})
+
+test('drops extension blob-script addListener noise (KCD-Z7)', () => {
+	expect(matchesIgnoreError("Cannot read properties of undefined (reading 'addListener')")).toBe(
+		false,
+	)
+
+	expect(
+		isInjectedBlobAddListenerError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'addListener')",
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'blob:https://kentcdodds.com/28507230-8ee6-4834-abc8-6d4c103e04f1',
+								},
+								{
+									filename:
+										'blob:https://kentcdodds.com/28507230-8ee6-4834-abc8-6d4c103e04f1',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	expect(
+		isInjectedBlobAddListenerError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'addListener')",
+						stacktrace: {
+							frames: [{ filename: '/assets/app-abc123.js' }],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'addListener')",
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'blob:https://kentcdodds.com/28507230-8ee6-4834-abc8-6d4c103e04f1',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	const blobStackError = new Error(
+		"Cannot read properties of undefined (reading 'addListener')",
+	)
+	blobStackError.stack =
+		"TypeError: Cannot read properties of undefined (reading 'addListener')\n    at blob:https://kentcdodds.com/28507230-8ee6-4834-abc8-6d4c103e04f1:14:11\n    at new s.bm (blob:https://kentcdodds.com/28507230-8ee6-4834-abc8-6d4c103e04f1:12:19003)"
+
+	expect(
+		isInjectedBlobAddListenerError(
+			{
+				exception: {
+					values: [
+						{
+							type: 'TypeError',
+							value:
+								"Cannot read properties of undefined (reading 'addListener')",
+						},
+					],
+				},
+			},
+			{ originalException: blobStackError },
 		),
 	).toBe(true)
 })

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -31,6 +31,16 @@ export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	/document\.querySelector\("meta\[property='og:type'\]"\)\.content/,
 	// Injected HTML parsers / translators mutating the DOM (KCD-ZZ).
 	/evaluating 'elem\.firstChild'/,
+	// Instagram / iOS in-app browser WKWebView bridge (KCD-ZR / KCD-ZC).
+	// Stack functions are sendDataToNative / sendPageHideMessage /
+	// setupIosCallbackHandler — not present in app code.
+	/window\.webkit\.messageHandlers/,
+	// javascript-obfuscator-style injected scripts (KCD-ZG).
+	/a0_0x[0-9a-f]+ is not defined/,
+	// WKWebView native bridge rejecting script into a missing frame (KCD-YV).
+	/WKErrorDomain Code=12/,
+	// Sentry Session Replay probing cross-origin iframes (KCD-TF).
+	/Failed to read a named property 'Element' from 'Window': Blocked a frame/,
 ]
 
 export const SENTRY_DENY_URLS: Array<RegExp> = [
@@ -216,12 +226,50 @@ export function isWalletUserRejection(
 	)
 }
 
+const STACK_SCRIPT_URL =
+	/\b(?:blob:|https?:\/\/|webkit-masked-url:|chrome-extension:|moz-extension:|safari-web-extension:|safari-extension:|iabjs:)[^\s)]+/gi
+
+function scriptUrlsFromStackBlob(stack: string): Array<string> {
+	return [...stack.matchAll(STACK_SCRIPT_URL)].map((match) => match[0] ?? '')
+}
+
+/**
+ * Extensions often inject executable blob: scripts. App createObjectURL usage
+ * is audio-only and never appears as JS stack frames, so a TypeError reading
+ * addListener with an exclusively-blob stack is external (KCD-Z7).
+ */
+export function isInjectedBlobAddListenerError(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const looksLikeAddListener = eventMessages(event).some((message) =>
+		/reading ['"]addListener['"]/.test(message),
+	)
+	if (!looksLikeAddListener) return false
+
+	const frames = (event.exception?.values ?? []).flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+	const filenames = frames
+		.map((frame) => frame.filename ?? '')
+		.filter(Boolean)
+	if (filenames.length > 0) {
+		return filenames.every((filename) => /^blob:/i.test(filename))
+	}
+
+	// No Sentry frame filenames — parse URLs out of Error.stack (stackBlob
+	// prefixes a newline, so ^blob: on the whole string would never match).
+	const urls = scriptUrlsFromStackBlob(stackBlob(event, hint.originalException))
+	return urls.length > 0 && urls.every((url) => /^blob:/i.test(url))
+}
+
 export function shouldDropSentryEvent(
 	event: SentryEventLike,
 	hint: { originalException?: unknown } = {},
 ): boolean {
 	if (isBrowserExtensionError(hint.originalException)) return true
 	if (isWalletUserRejection(event, hint)) return true
+	if (isInjectedBlobAddListenerError(event, hint)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true
 	if (isCloudflareEdgeRouteErrorEvent(event)) return true
 	if (isReactRouterEdgeHttpStatusError(event, hint)) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Client Sentry noise filters for a family of external/injected errors that are not app bugs:

- **KCD-ZR / KCD-ZC** — Instagram iOS in-app browser WKWebView bridge (`window.webkit.messageHandlers`; stacks show `sendDataToNative` / `setupIosCallbackHandler`)
- **KCD-ZG** — javascript-obfuscator-style injector (`a0_0x… is not defined`, anonymous `_0x…` frames)
- **KCD-YV** — WKWebView native `WKErrorDomain Code=12` invalid-frame rejection
- **KCD-TF** — Sentry Session Replay probing cross-origin iframes (`Failed to read a named property 'Element' from 'Window'`)
- **KCD-Z7** — extension blob: script `addListener` TypeError (only dropped when the stack is exclusively `blob:` URLs, including Error.stack fallback when Sentry omits frame filenames)

## Changes

- Narrow `ignoreErrors` / `beforeSend` signatures in `services/site/app/utils/sentry-noise.ts`
- Regression tests in `sentry-noise.test.ts`
- Rebased onto main (keeps existing Cloudflare edge / RR manifest-patch filters)

## Risk

Low — filter-only; does not change product behavior. Generic `Failed to fetch` / bare `addListener` are intentionally not ignored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4d25110-9d2a-412e-bb34-6ff2f2b85a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4d25110-9d2a-412e-bb34-6ff2f2b85a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reports from embedded browsers, injected scripts, native browser bridges, and cross-origin Session Replay probing.
  * Enhanced Sentry filtering for `addListener`-related failures tied to injected blob scripts, while keeping reports for similar errors from non-injected application code.
* **Tests**
  * Added coverage for additional “Sentry noise” patterns to ensure the improved filtering behaves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->