### PR TITLE
Filter React translator DOM mutation NotFoundError noise (KCD-S5)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -34,6 +34,12 @@ fixes it.
   `filename: "undefined"` frame plus UI breadcrumbs like `a > font > font`, or
   `html.translated-ltr` / `translated-rtl`. Do not broadly ignore call-stack
   overflows — require that unusable stack plus translator evidence (KCD-QW).
+- The same translators also cause React `NotFoundError` on `removeChild` /
+  `insertBefore` (Chrome) or Safari `The object can not be found here.` during
+  `react-dom` deletion (facebook/react#11538). Filter via
+  `isTranslatorDomMutationNoise` only when the stack is react-dom/native with no
+  in-app frames — do not add `Node.prototype` monkey-patches for triage
+  (KCD-S5 / KCD-XQ / KCD-ZE).
 - Client `RouteErrorResponse: 502/503/524 Route Error` (from
   `useCapturedRouteError` / `getRouteErrorResponseException`) often wraps
   Cloudflare's generic edge HTML (`<title>… | 502: Bad gateway</title>`,

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -11,6 +11,7 @@ import {
 	isInjectedBlobAddListenerError,
 	isPageTranslatorCallStackOverflow,
 	isReactRouterEdgeHttpStatusError,
+	isTranslatorDomMutationNoise,
 	isWalletUserRejection,
 	shouldDropSentryEvent,
 } from '../sentry-noise.ts'
@@ -134,6 +135,103 @@ test('filters injected elem.firstChild parsers (KCD-ZZ)', () => {
 			"undefined is not an object (evaluating 'elem.firstChild')",
 		),
 	).toBe(true)
+})
+
+test('filters translator DOM mutation NotFoundError (KCD-S5 / KCD-XQ / KCD-ZE)', () => {
+	const chromeRemoveChild = {
+		exception: {
+			values: [
+				{
+					type: 'NotFoundError',
+					value:
+						"Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'../../../../../node_modules/react-dom/cjs/react-dom-client.production.js',
+								function: 'commitDeletionEffectsOnFiber',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isTranslatorDomMutationNoise(chromeRemoveChild)).toBe(true)
+	expect(shouldDropSentryEvent(chromeRemoveChild)).toBe(true)
+
+	const safariObjectNotFound = {
+		exception: {
+			values: [
+				{
+					type: 'NotFoundError',
+					value: 'The object can not be found here.',
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'../../../../../node_modules/react-dom/cjs/react-dom-client.production.js',
+								function: 'commitDeletionEffectsOnFiber',
+								inApp: false,
+							},
+							{
+								filename: '[native code]',
+								function: 'removeChild',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isTranslatorDomMutationNoise(safariObjectNotFound)).toBe(true)
+
+	// Safari phrase alone (no react-dom stack) must not drop — too generic.
+	expect(
+		isTranslatorDomMutationNoise({
+			exception: {
+				values: [
+					{
+						type: 'NotFoundError',
+						value: 'The object can not be found here.',
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// In-app frames mean a real app DOM bug — keep reporting.
+	expect(
+		isTranslatorDomMutationNoise({
+			exception: {
+				values: [
+					{
+						type: 'NotFoundError',
+						value:
+							"Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+						stacktrace: {
+							frames: [
+								{
+									filename: '/app/routes/blog.tsx',
+									function: 'Blog',
+									inApp: true,
+								},
+								{
+									filename:
+										'../../../../../node_modules/react-dom/cjs/react-dom-client.production.js',
+									function: 'commitDeletionEffectsOnFiber',
+									inApp: false,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
 })
 
 test('filters React Router single-fetch routeId skew (KCD-VP family)', () => {

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -64,6 +64,7 @@ type SentryExceptionValue = {
 		frames?: Array<{
 			filename?: string | null
 			function?: string | null
+			inApp?: boolean | null
 		}> | null
 	} | null
 }
@@ -103,6 +104,18 @@ const CLOUDFLARE_EDGE_STATUSES = new Set([502, 503, 524])
 const REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE = /^5(?:02|03|24)\s*$/
 
 const REACT_ROUTER_MANIFEST_PATCH_STACK = /fetchAndApplyManifestPatches/
+
+/**
+ * Chrome / Chromium Google Translate (and similar DOM mutators) reparent text
+ * nodes so React's next removeChild/insertBefore throws NotFoundError.
+ * Safari Translate surfaces the same DOMException as a shorter message.
+ * Distinctive signatures from KCD-S5 / KCD-XQ / KCD-ZE (facebook/react#11538).
+ */
+const TRANSLATOR_DOM_MUTATION_MESSAGE =
+	/Failed to execute '(?:removeChild|insertBefore)' on 'Node': The node (?:to be removed|before which the new node is to be inserted) is not a child of this node\.|The object can not be found here\./i
+
+const REACT_DOM_MUTATION_STACK =
+	/react-dom|commitDeletionEffects|commitMutationEffects|removeChild|insertBefore/i
 
 export function isBrowserExtensionError(exception: unknown): boolean {
 	if (!(exception instanceof Error) || !exception.stack) return false
@@ -205,6 +218,68 @@ export function isReactRouterEdgeHttpStatusError(
 	}
 
 	return REACT_ROUTER_MANIFEST_PATCH_STACK.test(stackBlob(event, original))
+}
+
+function exceptionMessage(exception: unknown): string {
+	if (exception instanceof Error) return exception.message
+	if (
+		typeof exception === 'object' &&
+		exception &&
+		'message' in exception &&
+		typeof (exception as { message?: unknown }).message === 'string'
+	) {
+		return (exception as { message: string }).message
+	}
+	return ''
+}
+
+/**
+ * Drop React NotFoundError noise caused by in-page translators / extensions
+ * mutating the DOM under React. Require the distinctive message plus a
+ * react-dom/native mutation stack with no in-app frames — never the Safari
+ * phrase alone.
+ */
+export function isTranslatorDomMutationNoise(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const original = hint.originalException
+	const exceptionValues = event.exception?.values ?? []
+	const messageMatches = eventMessages(event).some((message) =>
+		TRANSLATOR_DOM_MUTATION_MESSAGE.test(message),
+	)
+	if (
+		!messageMatches &&
+		!TRANSLATOR_DOM_MUTATION_MESSAGE.test(exceptionMessage(original))
+	) {
+		return false
+	}
+
+	const namedNotFound = exceptionValues.some(
+		(value) => value.type === 'NotFoundError' || value.type === 'DOMException',
+	)
+	const originalIsNotFound =
+		(original instanceof Error &&
+			(original.name === 'NotFoundError' || original.name === 'DOMException')) ||
+		(typeof DOMException !== 'undefined' && original instanceof DOMException)
+	if (!namedNotFound && !originalIsNotFound) return false
+
+	const frames = exceptionValues.flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+	if (frames.some((frame) => frame.inApp)) return false
+
+	const frameBlob = frames
+		.map((frame) => `${frame.filename ?? ''} ${frame.function ?? ''}`)
+		.join('\n')
+	const blob = `${frameBlob}\n${stackBlob(event, original)}`
+	if (!REACT_DOM_MUTATION_STACK.test(blob)) return false
+
+	// Bundled/minified stacks without sourcemaps still count when the only
+	// frames are entry.client / react-dom / native — reject app route paths.
+	if (/\/app\/|\/routes\/|components\//i.test(blob)) return false
+
+	return true
 }
 
 /**
@@ -346,6 +421,7 @@ export function shouldDropSentryEvent(
 	hint: { originalException?: unknown; pageTranslated?: boolean } = {},
 ): boolean {
 	if (isBrowserExtensionError(hint.originalException)) return true
+	if (isTranslatorDomMutationNoise(event, hint)) return true
 	if (isWalletUserRejection(event, hint)) return true
 	if (isInjectedBlobAddListenerError(event, hint)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters client Sentry noise from in-page translators / extensions that mutate the DOM under React (classic [facebook/react#11538](https://github.com/facebook/react/issues/11538) `removeChild` NotFoundError). Complements the existing page-translator call-stack filter (KCD-QW).

**Sentry issues**
- [KCD-S5](https://kent-c-dodds-tech-llc.sentry.io/issues/6912380644/) — Chrome `Failed to execute 'removeChild'…` (~194 events, many routes)
- [KCD-XQ](https://kent-c-dodds-tech-llc.sentry.io/issues/7367506894/) — same signature (duplicate grouping)
- [KCD-ZE](https://kent-c-dodds-tech-llc.sentry.io/issues/7547106220/) — Safari `The object can not be found here.` (`removeChild` native + react-dom; includes `locale: ja` / Tokyo)

**Evidence**
- Stacks are exclusively `react-dom` deletion/mutation (zero in-app frames)
- Cross-route, not page-specific
- Non-English locales on sampled events (`ja`, `es-ES`) consistent with browser translation
- Not reasonably fixable in app code; workflow prefers filtering over `Node.prototype` monkey-patches

**Change**
- `isTranslatorDomMutationNoise` in `sentry-noise.ts`: require distinctive NotFoundError message **and** react-dom/native mutation stack with no in-app frames (Safari phrase alone is not enough)
- Tests + triage note in `docs/agents/bugfix-workflow.md`
- Rebased onto latest `main` (after parallel sentry-noise triage merges)

## Test plan
- [x] `vitest run app/utils/__tests__/sentry-noise.test.ts` (22 passed)
- [x] `npm run typecheck` / `npm run lint` locally on Node 26
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f606411b-36fb-4373-9ff9-ee53ecbb8024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f606411b-36fb-4373-9ff9-ee53ecbb8024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry noise filtering by detecting specific React `NotFoundError` DOM-mutation failures triggered by browser translation tools and similar extensions, while avoiding drops for genuine in-app DOM errors.
* **Tests**
  * Added coverage to ensure translator-related Sentry events are correctly identified and filtered, including positive and negative scenarios.
* **Documentation**
  * Updated the Sentry triage workflow with safer guidance for handling translator-related DOM mutation noise and avoiding unnecessary triage workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->