### PR TITLE
Filter broken fetch monkey-patch Sentry noise (KCD-ZY)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -64,6 +64,13 @@ fixes it.
   (DOCTYPE payload signature; turbo-stream / Safari pattern require RR stack
   or `.data`/`__manifest` breadcrumbs). Do not broaden to generic
   `Failed to fetch`.
+- Client `TypeError: … reading 'ok'|'status'` from React Router's
+  `fetchAndApplyManifestPatches` / `fetchAndDecodeViaTurboStream` means
+  `fetch` resolved to `undefined` (native `fetch` never does). That signature
+  alone is not enough to drop — a first-party broken wrapper would look the
+  same. Only filter via `isBrokenClientFetchContractError` when trailing
+  console breadcrumbs are the injected interceptor's adjacent `URL:` →
+  `Options:` sequence (KCD-ZY / KCD-ZX); otherwise retain for triage.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from 'vitest'
 import {
 	SENTRY_DENY_URLS,
 	SENTRY_IGNORE_ERRORS,
+	hasInjectedFetchInterceptorBreadcrumbs,
 	hasOnlyUnusableStackFrames,
+	isBrokenClientFetchContractError,
 	isBrowserExtensionError,
 	isCloudflareEdgeErrorHtml,
 	isCloudflareEdgeRouteError,
@@ -15,6 +17,25 @@ import {
 	isWalletUserRejection,
 	shouldDropSentryEvent,
 } from '../sentry-noise.ts'
+
+const injectedFetchInterceptorBreadcrumbs = [
+	{
+		category: 'console',
+		message:
+			'URL: https://kentcdodds.com/__manifest?paths=%2Fcourses&version=abc',
+		data: {
+			arguments: [
+				'URL:',
+				'https://kentcdodds.com/__manifest?paths=%2Fcourses&version=abc',
+			],
+		},
+	},
+	{
+		category: 'console',
+		message: 'Options: [object Object]',
+		data: { arguments: ['Options:', { headers: '[Object]' }] },
+	},
+]
 
 function matchesIgnoreError(message: string) {
 	return SENTRY_IGNORE_ERRORS.some((pattern) => {
@@ -716,4 +737,114 @@ test('filters page-translator call stack overflows with font breadcrumbs (KCD-QW
 			documentElement: { className: 'dark' },
 		}),
 	).toBe(false)
+})
+
+test('filters broken fetch monkey-patch crashing React Router (KCD-ZY / KCD-ZX)', () => {
+	expect(
+		hasInjectedFetchInterceptorBreadcrumbs({
+			breadcrumbs: injectedFetchInterceptorBreadcrumbs,
+		}),
+	).toBe(true)
+
+	expect(
+		isBrokenClientFetchContractError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'ok')",
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'../../../../../node_modules/react-router/dist/development/chunk-LFPYN7LY.mjs',
+									function: 'fetchAndApplyManifestPatches',
+								},
+							],
+						},
+					},
+				],
+			},
+			breadcrumbs: injectedFetchInterceptorBreadcrumbs,
+		}),
+	).toBe(true)
+
+	expect(
+		isBrokenClientFetchContractError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'status')",
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'../../../../../node_modules/react-router/dist/development/chunk-LFPYN7LY.mjs',
+									function: 'fetchAndDecodeViaTurboStream',
+								},
+							],
+						},
+					},
+				],
+			},
+			breadcrumbs: injectedFetchInterceptorBreadcrumbs,
+		}),
+	).toBe(true)
+
+	expect(
+		isBrokenClientFetchContractError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'ok')",
+						stacktrace: {
+							frames: [{ function: 'fetchAndApplyManifestPatches' }],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		isBrokenClientFetchContractError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'ok')",
+						stacktrace: {
+							frames: [{ function: 'fetchAndApplyManifestPatches' }],
+						},
+					},
+				],
+			},
+			breadcrumbs: [
+				...injectedFetchInterceptorBreadcrumbs,
+				...Array.from({ length: 8 }, (_, index) => ({
+					category: 'console',
+					message: `unrelated console ${index}`,
+				})),
+			],
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'ok')",
+						stacktrace: {
+							frames: [{ function: 'fetchAndApplyManifestPatches' }],
+						},
+					},
+				],
+			},
+			breadcrumbs: injectedFetchInterceptorBreadcrumbs,
+		}),
+	).toBe(true)
 })

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -89,7 +89,10 @@ type RouteErrorResponseExtra = {
 type SentryBreadcrumbLike = {
 	category?: string | null
 	message?: string | null
-	data?: { url?: string | null } | null
+	data?: {
+		url?: string | null
+		arguments?: Array<unknown> | null
+	} | null
 }
 
 type SentryEventLike = {
@@ -162,6 +165,82 @@ function breadcrumbBlob(event: SentryEventLike): string {
 				`${crumb.category ?? ''}\n${crumb.message ?? ''}\n${crumb.data?.url ?? ''}`,
 		)
 		.join('\n')
+}
+
+/**
+ * Native `fetch` never resolves to `undefined`. When React Router then reads
+ * `.ok` / `.status`, that alone is not enough to drop — a first-party broken
+ * wrapper would look the same. Require the injected interceptor's adjacent
+ * trailing `URL:` → `Options:` console breadcrumbs (not in app/RR source)
+ * before classifying as extension noise (KCD-ZY / KCD-ZX).
+ */
+const UNDEFINED_FETCH_RESPONSE_PROP =
+	/Cannot read properties of undefined \(reading '(?:ok|status)'\)|undefined is not an object \(evaluating ['"].*\.(?:ok|status)['"]\)/
+
+const REACT_ROUTER_FETCH_RESPONSE_CONSUMERS =
+	/fetchAndApplyManifestPatches|fetchAndDecodeViaTurboStream|Failed to fetch manifest patches/
+
+function isUrlInterceptorMessage(message: string): boolean {
+	return message === 'URL:' || message.startsWith('URL: ')
+}
+
+function isOptionsInterceptorMessage(message: string): boolean {
+	return message === 'Options:' || message.startsWith('Options: ')
+}
+
+function crumbTexts(crumb: SentryBreadcrumbLike): Array<string> {
+	const texts: Array<string> = []
+	if (typeof crumb.message === 'string' && crumb.message) {
+		texts.push(crumb.message)
+	}
+	for (const arg of crumb.data?.arguments ?? []) {
+		if (typeof arg === 'string' && arg) texts.push(arg)
+	}
+	return texts
+}
+
+/**
+ * Injected fetch wrappers seen in KCD-ZY/ZX log `URL:` then `Options:` as
+ * adjacent trailing console breadcrumbs immediately before the broken fetch.
+ */
+export function hasInjectedFetchInterceptorBreadcrumbs(
+	event: SentryEventLike,
+): boolean {
+	const consoleCrumbs = (event.breadcrumbs ?? []).filter(
+		(crumb) => (crumb.category ?? 'console') === 'console',
+	)
+	if (consoleCrumbs.length < 2) return false
+
+	const trailing = consoleCrumbs.slice(-6)
+	for (let i = 0; i < trailing.length - 1; i++) {
+		const current = crumbTexts(trailing[i] ?? {})
+		const next = crumbTexts(trailing[i + 1] ?? {})
+		if (
+			current.some(isUrlInterceptorMessage) &&
+			next.some(isOptionsInterceptorMessage)
+		) {
+			return true
+		}
+	}
+	return false
+}
+
+export function isBrokenClientFetchContractError(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const looksLikeUndefinedResponse = eventMessages(event).some((message) =>
+		UNDEFINED_FETCH_RESPONSE_PROP.test(message),
+	)
+	if (!looksLikeUndefinedResponse) return false
+	if (
+		!REACT_ROUTER_FETCH_RESPONSE_CONSUMERS.test(
+			stackBlob(event, hint.originalException),
+		)
+	) {
+		return false
+	}
+	return hasInjectedFetchInterceptorBreadcrumbs(event)
 }
 
 export function isCloudflareEdgeErrorHtml(data: string): boolean {
@@ -411,6 +490,7 @@ export function shouldDropSentryEvent(
 ): boolean {
 	if (isBrowserExtensionError(hint.originalException)) return true
 	if (isWalletUserRejection(event, hint)) return true
+	if (isBrokenClientFetchContractError(event, hint)) return true
 	if (isInjectedBlobAddListenerError(event, hint)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true
 	if (isCloudflareEdgeRouteErrorEvent(event)) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Client `TypeError: Cannot read properties of undefined (reading 'ok'|'status')` from React Router's `fetchAndApplyManifestPatches` / `fetchAndDecodeViaTurboStream` means `fetch` resolved to `undefined`. Native `fetch` never does that.

That RR signature alone is **not** enough to drop (a first-party broken `window.fetch` wrapper would look identical). Drop only when the trailing console breadcrumbs are the injected interceptor's adjacent `URL:` → `Options:` sequence (not present in app or React Router source).

Evidence from KCD-ZY / KCD-ZX (same Chrome 150 Windows session, 2026-07-15T16:14):
- Stack entirely in `react-router`
- Trailing breadcrumbs show non-app `URL:` / `Options:` console logs around `/__manifest` and `*.data` fetches that resolve immediately to the TypeError
- No recurrence since that single session

## Changes

- Add `isBrokenClientFetchContractError` + `hasInjectedFetchInterceptorBreadcrumbs` in `sentry-noise.ts`
- Unit tests: positive (RR + trailing interceptor pair), negatives (RR alone, stale buried interceptor logs)
- Document the family in `docs/agents/bugfix-workflow.md`

## Sentry issues

- KCD-ZY (7613067664) — main (`reading 'ok'` / `/courses`)
- KCD-ZX (7613067660) — sibling (`reading 'status'` / `/talks`)

## Risk

Low — client noise filter + unit tests. No auth/billing/migration surface.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eff1d90-bcc1-474a-9e73-0a0c66947bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eff1d90-bcc1-474a-9e73-0a0c66947bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Sentry noise for React Router client-side `fetch` errors caused by browser/extension interference.
  * Improved detection by correlating specific `TypeError` patterns with stack evidence and console/breadcrumb context.
  * Added additional filtering logic to drop only the known “broken fetch contract” cases while retaining other similar errors.
* **Tests**
  * Added coverage to validate the new Sentry-noise filtering behavior across matching and non-matching scenarios.
* **Documentation**
  * Updated the bugfix workflow triage guidance with a new bullet describing the relevant error pattern and how to confirm the interceptor-related cause.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->