### PR TITLE
Swallow markAsRead network failures (KCD-FY family)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -29,8 +29,20 @@ fixes it.
   errors — those can hide real outages. Message/stack drop rules must establish
   an external source (distinctive third-party signature, extension/IAB URL, or
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
+- Client `TypeError: Failed to fetch` / Firefox `NetworkError when attempting to
+fetch resource` / Safari `Load failed` with React Router stacks
+  (`fetchAndDecodeViaTurboStream`, `fetchAndApplyManifestPatches`) and a
+  failing `.data` / `__manifest` breadcrumb **without** `status_code` are
+  browser network-layer failures during SPA nav (idle tab, offline, flaky
+  mobile) — not an app throw. Live endpoints often still return 200. Do not
+  broadly `ignoreErrors` these (KCD-XZ / KCD-QG family); optional product UX is
+  a hard-reload fallback on nav TypeError.
+- Blog `markAsRead()` (`routes/action/mark-as-read.tsx`) is best-effort read
+  tracking. Uncaught `fetch` rejections from that path are app noise: keep the
+  catch inside `markAsRead` (KCD-FY / KCD-1R / KCD-ZW / KCD-WV), do not filter
+  generic network strings in `sentry-noise.ts`.
 - Server: React Router `throwIfPotentialCSRFAttack` aborts (`…from a forwarded
-  action request. Aborting the action.`, invalid/`missing host` Origin variants)
+action request. Aborting the action.`, invalid/`missing host` Origin variants)
   are expected 400s for mismatched Origin probes. Skip Sentry in
   `entry.server.tsx` `handleError` via `isReactRouterCsrfAbortError` (KCD-YN);
   do not weaken CSRF checks to silence the alert.

--- a/services/site/app/routes/action/__tests__/mark-as-read.test.ts
+++ b/services/site/app/routes/action/__tests__/mark-as-read.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { markAsRead } from '../mark-as-read.tsx'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+})
+
+test('markAsRead posts the slug to the mark-as-read action', async () => {
+	const fetchMock = vi
+		.fn()
+		.mockResolvedValue(new Response(null, { status: 200 }))
+	vi.stubGlobal('fetch', fetchMock)
+
+	const response = await markAsRead({ slug: 'some-post' })
+
+	expect(response?.status).toBe(200)
+	expect(fetchMock).toHaveBeenCalledOnce()
+	expect(fetchMock.mock.calls[0]?.[0]).toBe('/action/mark-as-read')
+	expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: 'POST' })
+	const body = fetchMock.mock.calls[0]?.[1]?.body
+	expect(body).toBeInstanceOf(URLSearchParams)
+	expect(String(body)).toBe('slug=some-post')
+})
+
+test('markAsRead swallows network TypeErrors so void callers stay quiet', async () => {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+	)
+
+	await expect(markAsRead({ slug: 'offline-post' })).resolves.toBeUndefined()
+})

--- a/services/site/app/routes/action/mark-as-read.tsx
+++ b/services/site/app/routes/action/mark-as-read.tsx
@@ -75,9 +75,19 @@ export async function action({ request }: Route.ActionArgs) {
 	return json({ success: true })
 }
 
+/**
+ * Best-effort read tracking. Offline / tab-close / flaky mobile networks reject
+ * `fetch` with TypeError (Chrome "Failed to fetch", Safari "Load failed",
+ * Firefox "NetworkError…") — catch so callers' `void markAsRead()` does not
+ * surface as onunhandledrejection (KCD-FY / KCD-1R / KCD-ZW / KCD-WV).
+ */
 export async function markAsRead({ slug }: { slug: string }) {
-	return fetch('/action/mark-as-read', {
-		method: 'POST',
-		body: new URLSearchParams({ slug }),
-	})
+	try {
+		return await fetch('/action/mark-as-read', {
+			method: 'POST',
+			body: new URLSearchParams({ slug }),
+		})
+	} catch {
+		return undefined
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry backfill for the client network-noise family (KCD-QG) found two distinct root causes:

1. **React Router SPA nav network failures** (KCD-QG / KCD-XZ family) — `Failed to fetch` / Firefox `NetworkError` / Safari `Load failed` from `fetchAndDecodeViaTurboStream` / `fetchAndApplyManifestPatches` with a `.data`/`__manifest` breadcrumb and **no** `status_code`. Browser network-layer flakiness; do **not** broadly filter (can hide real outages). Optional product UX: hard-reload on nav TypeError. Documented in `docs/agents/bugfix-workflow.md`.

2. **Uncaught `markAsRead()` rejections** (KCD-FY / KCD-1R / KCD-ZW / KCD-WV) — blog read tracking fires `fetch('/action/mark-as-read')` via `void markAsRead(...)`, so offline/tab-close TypeErrors become `onunhandledrejection`. This PR catches inside `markAsRead` (best-effort analytics).

## Test plan

- [x] Unit tests for successful POST body and swallowed network TypeError
- [ ] CI green

## Siblings

- Resolve after merge: KCD-FY, KCD-1R, KCD-ZW, KCD-WV
- Leave open (recommendation, same as KCD-XZ): KCD-QG, KCD-Y0, KCD-YC, KCD-XB, KCD-X1, KCD-ZK, KCD-ZP, KCD-Z8
- Ignore one-off: KCD-Z4 (`AbortError` interrupted navigation, count 1)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bfa491a-9c41-4249-bf08-ae35ba8edda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bfa491a-9c41-4249-bf08-ae35ba8edda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when marking blog posts as read during offline periods, tab closures, or unstable network conditions.
  * Prevented background network failures from surfacing as unhandled errors.
* **Documentation**
  * Expanded guidance for distinguishing expected browser and network noise from actionable errors during navigation and post interactions.
* **Tests**
  * Added coverage for successful mark-as-read requests and graceful handling of network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->