### PR TITLE
Filter wallet disconnect and CustomEvent Sentry noise (KCD-YX/S8)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -30,7 +30,7 @@ fixes it.
   an external source (distinctive third-party signature, extension/IAB URL, or
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
 - Server: React Router `throwIfPotentialCSRFAttack` aborts (`…from a forwarded
-  action request. Aborting the action.`, invalid/`missing host` Origin variants)
+action request. Aborting the action.`, invalid/`missing host` Origin variants)
   are expected 400s for mismatched Origin probes. Skip Sentry in
   `entry.server.tsx` `handleError` via `isReactRouterCsrfAbortError` (KCD-YN);
   do not weaken CSRF checks to silence the alert.
@@ -75,6 +75,15 @@ fixes it.
   (DOCTYPE payload signature; turbo-stream / Safari pattern require RR stack
   or `.data`/`__manifest` breadcrumbs). Do not broaden to generic
   `Failed to fetch`.
+- Client `<unknown>` unhandledrejection titles with empty stacks are often
+  non-Error rejections. Inspect the event JSON `extra.__serialized__` before
+  filtering: EIP-1193 wallet disconnect uses code `4900` /
+  "The provider is disconnected from all chains." with
+  `chrome-extension://…/background.js` stacks (KCD-YX — extend
+  `isWalletUserRejection`); Safari/extension
+  `Event \`CustomEvent\` (type=unhandledrejection) captured as promise rejection`
+  is external CustomEvent wrapping (KCD-S8). Never drop bare
+  "Object captured as promise rejection with keys…" without a provider signal.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -6,6 +6,7 @@ import {
 	isBrowserExtensionError,
 	isCloudflareEdgeErrorHtml,
 	isCloudflareEdgeRouteError,
+	isCustomEventUnhandledRejectionNoise,
 	isDegradedUiPerformanceEvent,
 	isHtmlPageTranslated,
 	isInjectedBlobAddListenerError,
@@ -111,6 +112,108 @@ test('scopes EIP-1193 wallet user rejection (KCD-ZV)', () => {
 				originalException: { code: 4001, message: 'User rejected the request' },
 			},
 		),
+	).toBe(true)
+})
+
+test('filters EIP-1193 provider disconnect non-Error rejection (KCD-YX)', () => {
+	const objectCaptured =
+		'Object captured as promise rejection with keys: code, message, stack'
+	expect(matchesIgnoreError(objectCaptured)).toBe(false)
+
+	expect(
+		isWalletUserRejection({
+			exception: {
+				values: [{ type: 'UnhandledRejection', value: objectCaptured }],
+			},
+			extra: {
+				__serialized__: {
+					code: 4900,
+					message: 'The provider is disconnected from all chains.',
+					stack:
+						'Error: The provider is disconnected from all chains.\n    at chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:4:7655111',
+				},
+			},
+		}),
+	).toBe(true)
+
+	expect(
+		isWalletUserRejection(
+			{
+				exception: {
+					values: [{ type: 'UnhandledRejection', value: objectCaptured }],
+				},
+			},
+			{
+				originalException: {
+					code: 4900,
+					message: 'The provider is disconnected from all chains.',
+				},
+			},
+		),
+	).toBe(true)
+
+	// Generic object-captured noise without provider signal must stay.
+	expect(
+		isWalletUserRejection({
+			exception: {
+				values: [{ type: 'UnhandledRejection', value: objectCaptured }],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent({
+			exception: {
+				values: [{ type: 'UnhandledRejection', value: objectCaptured }],
+			},
+			extra: {
+				__serialized__: {
+					code: 4900,
+					message: 'The provider is disconnected from all chains.',
+					stack:
+						'Error: The provider is disconnected from all chains.\n    at chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/background.js:141:142584',
+				},
+			},
+		}),
+	).toBe(true)
+})
+
+test('filters Safari CustomEvent unhandledrejection noise (KCD-S8)', () => {
+	const customEventMessage =
+		'Event `CustomEvent` (type=unhandledrejection) captured as promise rejection'
+	expect(matchesIgnoreError(customEventMessage)).toBe(true)
+
+	expect(
+		isCustomEventUnhandledRejectionNoise({
+			exception: {
+				values: [{ type: 'CustomEvent', value: customEventMessage }],
+			},
+			extra: {
+				__serialized__: {
+					type: 'unhandledrejection',
+					isTrusted: false,
+					detail: null,
+					target: '[object Window]',
+					currentTarget: '[object Window]',
+				},
+			},
+		}),
+	).toBe(true)
+
+	expect(
+		isCustomEventUnhandledRejectionNoise({
+			exception: {
+				values: [{ type: 'Error', value: 'real app failure' }],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent({
+			exception: {
+				values: [{ type: 'CustomEvent', value: customEventMessage }],
+			},
+		}),
 	).toBe(true)
 })
 
@@ -241,9 +344,7 @@ test('filters React Router single-fetch routeId skew (KCD-VP family)', () => {
 		matchesIgnoreError('No result found for routeId "routes/courses"'),
 	).toBe(true)
 	expect(
-		matchesIgnoreError(
-			'No result found for routeId "routes/blog_/$slug"',
-		),
+		matchesIgnoreError('No result found for routeId "routes/blog_/$slug"'),
 	).toBe(true)
 	expect(
 		matchesIgnoreError(
@@ -284,9 +385,11 @@ test('filters Sentry Replay cross-origin iframe Element probes (KCD-TF)', () => 
 })
 
 test('drops extension blob-script addListener noise (KCD-Z7)', () => {
-	expect(matchesIgnoreError("Cannot read properties of undefined (reading 'addListener')")).toBe(
-		false,
-	)
+	expect(
+		matchesIgnoreError(
+			"Cannot read properties of undefined (reading 'addListener')",
+		),
+	).toBe(false)
 
 	expect(
 		isInjectedBlobAddListenerError({
@@ -294,7 +397,8 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 				values: [
 					{
 						type: 'TypeError',
-						value: "Cannot read properties of undefined (reading 'addListener')",
+						value:
+							"Cannot read properties of undefined (reading 'addListener')",
 						stacktrace: {
 							frames: [
 								{
@@ -319,7 +423,8 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 				values: [
 					{
 						type: 'TypeError',
-						value: "Cannot read properties of undefined (reading 'addListener')",
+						value:
+							"Cannot read properties of undefined (reading 'addListener')",
 						stacktrace: {
 							frames: [{ filename: '/assets/app-abc123.js' }],
 						},
@@ -335,7 +440,8 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 				values: [
 					{
 						type: 'TypeError',
-						value: "Cannot read properties of undefined (reading 'addListener')",
+						value:
+							"Cannot read properties of undefined (reading 'addListener')",
 						stacktrace: {
 							frames: [
 								{
@@ -478,7 +584,9 @@ test('filters React Router manifest-patch edge HTTP status errors (KCD-ZH/YD/YF)
 						type: 'Error',
 						value: '502 ',
 						stacktrace: {
-							frames: [{ filename: '/app/routes/blog.tsx', function: 'loader' }],
+							frames: [
+								{ filename: '/app/routes/blog.tsx', function: 'loader' },
+							],
 						},
 					},
 				],

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -80,6 +80,9 @@ export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	// HTML document body parsed as JSON — distinctive "<!DOCTYPE" payload
 	// (KCD-ZJ / __manifest edge HTML).
 	HTML_AS_JSON_ERROR,
+	// Safari / extension CustomEvent wrapping unhandledrejection (KCD-S8).
+	// Sentry serializes the Event itself when it is the rejection reason.
+	/Event `CustomEvent` \(type=unhandledrejection\) captured as promise rejection/,
 ]
 
 export const SENTRY_DENY_URLS: Array<RegExp> = [
@@ -116,11 +119,25 @@ type SentryBreadcrumbLike = {
 	data?: { url?: string | null } | null
 }
 
+type SerializedRejectionExtra = {
+	code?: unknown
+	message?: unknown
+	stack?: unknown
+	type?: unknown
+	isTrusted?: unknown
+	detail?: unknown
+	target?: unknown
+	currentTarget?: unknown
+}
+
 type SentryEventLike = {
 	message?: string | null
 	request?: { url?: string | null } | null
 	exception?: { values?: Array<SentryExceptionValue> | null } | null
-	extra?: { route_error_response?: RouteErrorResponseExtra | null } | null
+	extra?: {
+		route_error_response?: RouteErrorResponseExtra | null
+		__serialized__?: SerializedRejectionExtra | null
+	} | null
 	breadcrumbs?: Array<SentryBreadcrumbLike> | null
 }
 
@@ -234,7 +251,9 @@ function routeErrorExtra(
 	return event.extra?.route_error_response ?? null
 }
 
-export function isCloudflareEdgeRouteErrorEvent(event: SentryEventLike): boolean {
+export function isCloudflareEdgeRouteErrorEvent(
+	event: SentryEventLike,
+): boolean {
 	const route = routeErrorExtra(event)
 	if (!route || typeof route.status !== 'number') return false
 
@@ -258,7 +277,11 @@ export function isReactRouterEdgeHttpStatusError(
 	const original = hint.originalException
 	if (original instanceof Error) messages.push(original.message)
 
-	if (!messages.some((message) => REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE.test(message))) {
+	if (
+		!messages.some((message) =>
+			REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE.test(message),
+		)
+	) {
 		return false
 	}
 
@@ -305,7 +328,8 @@ export function isTranslatorDomMutationNoise(
 	)
 	const originalIsNotFound =
 		(original instanceof Error &&
-			(original.name === 'NotFoundError' || original.name === 'DOMException')) ||
+			(original.name === 'NotFoundError' ||
+				original.name === 'DOMException')) ||
 		(typeof DOMException !== 'undefined' && original instanceof DOMException)
 	if (!namedNotFound && !originalIsNotFound) return false
 
@@ -370,24 +394,77 @@ export function isReactRouterDataProtocolNoise(
 }
 
 /**
- * EIP-1193 wallet extensions reject with code 4001 / "user rejected the
- * request". Only drop when that provider signal is present — never on the
- * phrase alone.
+ * EIP-1193 wallet-extension ProviderRpcError codes that this site never emits.
+ * 4001 user-rejected (KCD-ZV); 4900/4901 provider/chain disconnected (KCD-YX)
+ * with chrome-extension stacks in `__serialized__.stack`.
+ */
+const WALLET_PROVIDER_DISCONNECT_MESSAGE =
+	/provider is disconnected from (?:all chains|the requested chain)/i
+
+function isEip1193ProviderNoiseCode(code: unknown): boolean {
+	return (
+		code === 4001 ||
+		code === '4001' ||
+		code === 4900 ||
+		code === '4900' ||
+		code === 4901 ||
+		code === '4901'
+	)
+}
+
+function providerCodeFrom(value: unknown): unknown {
+	if (!value || typeof value !== 'object' || !('code' in value))
+		return undefined
+	return (value as { code?: unknown }).code
+}
+
+function serializedRejection(
+	event: SentryEventLike,
+): SerializedRejectionExtra | null {
+	return event.extra?.__serialized__ ?? null
+}
+
+/**
+ * EIP-1193 wallet extensions reject with provider codes / phrases. Only drop
+ * when that provider signal is present — never on a generic non-Error object
+ * message alone.
  */
 export function isWalletUserRejection(
 	event: SentryEventLike,
 	hint: { originalException?: unknown } = {},
 ): boolean {
 	const original = hint.originalException
-	if (original && typeof original === 'object' && 'code' in original) {
-		const code = (original as { code?: unknown }).code
-		if (code === 4001 || code === '4001') return true
+	const serialized = serializedRejection(event)
+	const code = providerCodeFrom(original) ?? providerCodeFrom(serialized)
+	if (isEip1193ProviderNoiseCode(code)) {
+		return true
 	}
+
+	const originalMessage = exceptionMessage(original)
+	const serializedMessage =
+		typeof serialized?.message === 'string' ? serialized.message : ''
+	const serializedStack =
+		typeof serialized?.stack === 'string' ? serialized.stack : ''
 
 	const looksLikeUserRejection = eventMessages(event).some((message) =>
 		/user rejected the request/i.test(message),
 	)
-	if (!looksLikeUserRejection) return false
+	const looksLikeProviderDisconnect =
+		WALLET_PROVIDER_DISCONNECT_MESSAGE.test(originalMessage) ||
+		WALLET_PROVIDER_DISCONNECT_MESSAGE.test(serializedMessage) ||
+		eventMessages(event).some((message) =>
+			WALLET_PROVIDER_DISCONNECT_MESSAGE.test(message),
+		)
+
+	if (!looksLikeUserRejection && !looksLikeProviderDisconnect) return false
+
+	// Extension background stacks are conclusive even without event frames.
+	if (
+		WALLET_PROVIDER_STACK.test(serializedStack) ||
+		/chrome-extension:|moz-extension:/i.test(serializedStack)
+	) {
+		return true
+	}
 
 	// Non-Error wallet rejections often have zero frames; require a provider
 	// marker whenever any stack evidence exists.
@@ -398,7 +475,52 @@ export function isWalletUserRejection(
 	return (event.exception?.values ?? []).some(
 		(value) =>
 			value.type === 'UnhandledRejection' ||
-			/Non-Error promise rejection/i.test(value.value ?? ''),
+			/Non-Error promise rejection/i.test(value.value ?? '') ||
+			/Object captured as promise rejection with keys:/i.test(
+				value.value ?? '',
+			),
+	)
+}
+
+/**
+ * Safari / injected scripts sometimes reject with a CustomEvent whose type is
+ * `unhandledrejection` (detail often null, isTrusted false). Sentry titles
+ * these `<unknown>` with zero frames (KCD-S8). Distinctive SDK message +
+ * CustomEvent type — not a generic Event filter.
+ */
+export function isCustomEventUnhandledRejectionNoise(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const customEventMessage =
+		/Event `CustomEvent` \(type=unhandledrejection\) captured as promise rejection/i
+	if (
+		eventMessages(event).some((message) => customEventMessage.test(message))
+	) {
+		return true
+	}
+
+	const namedCustomEvent = (event.exception?.values ?? []).some(
+		(value) => value.type === 'CustomEvent',
+	)
+	const original = hint.originalException
+	const originalIsCustomEvent =
+		(typeof CustomEvent !== 'undefined' && original instanceof CustomEvent) ||
+		(typeof original === 'object' &&
+			original != null &&
+			(original as { constructor?: { name?: string } }).constructor?.name ===
+				'CustomEvent')
+
+	if (!namedCustomEvent && !originalIsCustomEvent) return false
+
+	const serialized = serializedRejection(event)
+	const originalType =
+		original && typeof original === 'object' && 'type' in original
+			? (original as { type?: unknown }).type
+			: undefined
+	return (
+		originalType === 'unhandledrejection' ||
+		serialized?.type === 'unhandledrejection'
 	)
 }
 
@@ -426,9 +548,7 @@ export function isInjectedBlobAddListenerError(
 	const frames = (event.exception?.values ?? []).flatMap(
 		(value) => value.stacktrace?.frames ?? [],
 	)
-	const filenames = frames
-		.map((frame) => frame.filename ?? '')
-		.filter(Boolean)
+	const filenames = frames.map((frame) => frame.filename ?? '').filter(Boolean)
 	if (filenames.length > 0) {
 		return filenames.every((filename) => /^blob:/i.test(filename))
 	}
@@ -440,7 +560,9 @@ export function isInjectedBlobAddListenerError(
 }
 
 function isCallStackOverflow(event: SentryEventLike): boolean {
-	return eventMessages(event).some((message) => CALL_STACK_OVERFLOW.test(message))
+	return eventMessages(event).some((message) =>
+		CALL_STACK_OVERFLOW.test(message),
+	)
 }
 
 function exceptionFrames(event: SentryEventLike) {
@@ -478,8 +600,10 @@ function hasTranslatorFontBreadcrumb(event: SentryEventLike): boolean {
 
 /** Live marker Google/Chrome page translate adds to <html>. */
 export function isHtmlPageTranslated(
-	doc: { documentElement?: { className?: string } | null } | null | undefined =
-		typeof document === 'undefined' ? undefined : document,
+	doc:
+		| { documentElement?: { className?: string } | null }
+		| null
+		| undefined = typeof document === 'undefined' ? undefined : document,
 ): boolean {
 	const className = doc?.documentElement?.className
 	if (typeof className !== 'string') return false
@@ -510,6 +634,7 @@ export function shouldDropSentryEvent(
 	if (isBrowserExtensionError(hint.originalException)) return true
 	if (isTranslatorDomMutationNoise(event, hint)) return true
 	if (isWalletUserRejection(event, hint)) return true
+	if (isCustomEventUnhandledRejectionNoise(event, hint)) return true
 	if (isInjectedBlobAddListenerError(event, hint)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true
 	if (isCloudflareEdgeRouteErrorEvent(event)) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **KCD-YX**: Client `<unknown>` unhandled rejections were EIP-1193 wallet `ProviderRpcError` code `4900` ("The provider is disconnected from all chains.") from chrome-extension background scripts. Extended `isWalletUserRejection` to drop `4900`/`4901` via `hint.originalException` / `extra.__serialized__` (never bare "Object captured as promise rejection…").
- **KCD-S8** (backfill sibling): Safari `CustomEvent` (type=`unhandledrejection`) rejections with empty stacks — filtered via distinctive Sentry message + `isCustomEventUnhandledRejectionNoise`.
- Documented the `__serialized__` inspection pattern in `docs/agents/bugfix-workflow.md`.

## Test plan

- [x] `vitest` `sentry-noise.test.ts` (provider disconnect + CustomEvent cases; negative path for bare object-captured)
- [x] Pre-commit lint/typecheck/build + pre-push test suite

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20624688-37fc-40e7-90af-536128a7a267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20624688-37fc-40e7-90af-536128a7a267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry unhandledrejection filtering to ignore Safari/extension `CustomEvent` noise and reduce misleading wallet-extension reports.
  * Better recognition of wallet/provider disconnect and “user rejected” cases using available rejection details.
  * Preserves genuine unhandled-rejection reports and avoids dropping generic “object captured” noise unless provider signals are present.
* **Documentation**
  * Updated the Sentry triage workflow with added guidance for client `"<unknown>"` unhandledrejection events that include empty stacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->