### PR TITLE
Filter React Firefox scheduler re-entrancy Sentry noise (KCD-YT)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -87,8 +87,8 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   `performWorkOnRootViaSchedulerTask`) is Firefox MessageChannel re-entrancy
   during blocking APIs (facebook/react#17355, Bugzilla 758004) — not an app
   bug. Filter via `isReactSchedulerAlreadyWorkingNoise` only when the exact
-  message has that scheduler/react-dom stack and no in-app frames (KCD-YT).
-  Do not ignore the phrase alone.
+  message has an exclusively scheduler/react-dom stack (every frame) and no
+  in-app frames (KCD-YT). Do not ignore the phrase alone.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -30,7 +30,7 @@ fixes it.
   an external source (distinctive third-party signature, extension/IAB URL, or
   provider error code such as EIP-1193 `4001`) — never a generic phrase alone.
 - Server: React Router `throwIfPotentialCSRFAttack` aborts (`…from a forwarded
-  action request. Aborting the action.`, invalid/`missing host` Origin variants)
+action request. Aborting the action.`, invalid/`missing host` Origin variants)
   are expected 400s for mismatched Origin probes. Skip Sentry in
   `entry.server.tsx` `handleError` via `isReactRouterCsrfAbortError` (KCD-YN);
   do not weaken CSRF checks to silence the alert.
@@ -82,6 +82,13 @@ fixes it.
   same. Only filter via `isBrokenClientFetchContractError` when trailing
   console breadcrumbs are the injected interceptor's adjacent `URL:` →
   `Options:` sequence (KCD-ZY / KCD-ZX); otherwise retain for triage.
+- Client `Error: Should not already be working.` from React's scheduler →
+  `react-dom` work loop (`performWorkUntilDeadline` /
+  `performWorkOnRootViaSchedulerTask`) is Firefox MessageChannel re-entrancy
+  during blocking APIs (facebook/react#17355, Bugzilla 758004) — not an app
+  bug. Filter via `isReactSchedulerAlreadyWorkingNoise` only when the exact
+  message has that scheduler/react-dom stack and no in-app frames (KCD-YT).
+  Do not ignore the phrase alone.
 - A stack trace that predates a platform migration may still describe a live
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -205,6 +205,35 @@ test('filters React Firefox scheduler re-entrancy (KCD-YT)', () => {
 		}),
 	).toBe(false)
 
+	// Mixed stack with an unrelated non-app frame must stay reportable.
+	expect(
+		isReactSchedulerAlreadyWorkingNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Should not already be working.',
+						stacktrace: {
+							frames: [
+								{
+									filename: 'https://cdn.example.com/injected.js',
+									function: 'hijack',
+									inApp: false,
+								},
+								{
+									filename:
+										'../../../node_modules/react-dom/cjs/react-dom-client.production.js',
+									function: 'performWorkOnRootViaSchedulerTask',
+									inApp: false,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
 	// In-app frames mean a real app re-entrancy bug — keep reporting.
 	expect(
 		isReactSchedulerAlreadyWorkingNoise({

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -15,6 +15,7 @@ import {
 	isReactRouterCsrfAbortError,
 	isReactRouterDataProtocolNoise,
 	isReactRouterEdgeHttpStatusError,
+	isReactSchedulerAlreadyWorkingNoise,
 	isTranslatorDomMutationNoise,
 	isWalletUserRejection,
 	shouldDropSentryEvent,
@@ -160,6 +161,80 @@ test('filters injected elem.firstChild parsers (KCD-ZZ)', () => {
 	).toBe(true)
 })
 
+test('filters React Firefox scheduler re-entrancy (KCD-YT)', () => {
+	const firefoxSchedulerEvent = {
+		exception: {
+			values: [
+				{
+					type: 'Error',
+					value: 'Should not already be working.',
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'../../../node_modules/scheduler/cjs/scheduler.production.js',
+								function: 'performWorkUntilDeadline',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../node_modules/react-dom/cjs/react-dom-client.production.js',
+								function: 'performWorkOnRootViaSchedulerTask',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isReactSchedulerAlreadyWorkingNoise(firefoxSchedulerEvent)).toBe(true)
+	expect(shouldDropSentryEvent(firefoxSchedulerEvent)).toBe(true)
+
+	// Exact phrase alone (no scheduler/react-dom stack) must not drop.
+	expect(
+		isReactSchedulerAlreadyWorkingNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Should not already be working.',
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// In-app frames mean a real app re-entrancy bug — keep reporting.
+	expect(
+		isReactSchedulerAlreadyWorkingNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: 'Should not already be working.',
+						stacktrace: {
+							frames: [
+								{
+									filename: '/app/routes/blog_/$slug.tsx',
+									function: 'Blog',
+									inApp: true,
+								},
+								{
+									filename:
+										'../../../node_modules/react-dom/cjs/react-dom-client.production.js',
+									function: 'performWorkOnRootViaSchedulerTask',
+									inApp: false,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+})
+
 test('filters translator DOM mutation NotFoundError (KCD-S5 / KCD-XQ / KCD-ZE)', () => {
 	const chromeRemoveChild = {
 		exception: {
@@ -262,9 +337,7 @@ test('filters React Router single-fetch routeId skew (KCD-VP family)', () => {
 		matchesIgnoreError('No result found for routeId "routes/courses"'),
 	).toBe(true)
 	expect(
-		matchesIgnoreError(
-			'No result found for routeId "routes/blog_/$slug"',
-		),
+		matchesIgnoreError('No result found for routeId "routes/blog_/$slug"'),
 	).toBe(true)
 	expect(
 		matchesIgnoreError(
@@ -305,9 +378,11 @@ test('filters Sentry Replay cross-origin iframe Element probes (KCD-TF)', () => 
 })
 
 test('drops extension blob-script addListener noise (KCD-Z7)', () => {
-	expect(matchesIgnoreError("Cannot read properties of undefined (reading 'addListener')")).toBe(
-		false,
-	)
+	expect(
+		matchesIgnoreError(
+			"Cannot read properties of undefined (reading 'addListener')",
+		),
+	).toBe(false)
 
 	expect(
 		isInjectedBlobAddListenerError({
@@ -315,7 +390,8 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 				values: [
 					{
 						type: 'TypeError',
-						value: "Cannot read properties of undefined (reading 'addListener')",
+						value:
+							"Cannot read properties of undefined (reading 'addListener')",
 						stacktrace: {
 							frames: [
 								{
@@ -340,7 +416,8 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 				values: [
 					{
 						type: 'TypeError',
-						value: "Cannot read properties of undefined (reading 'addListener')",
+						value:
+							"Cannot read properties of undefined (reading 'addListener')",
 						stacktrace: {
 							frames: [{ filename: '/assets/app-abc123.js' }],
 						},
@@ -356,7 +433,8 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 				values: [
 					{
 						type: 'TypeError',
-						value: "Cannot read properties of undefined (reading 'addListener')",
+						value:
+							"Cannot read properties of undefined (reading 'addListener')",
 						stacktrace: {
 							frames: [
 								{
@@ -499,7 +577,9 @@ test('filters React Router manifest-patch edge HTTP status errors (KCD-ZH/YD/YF)
 						type: 'Error',
 						value: '502 ',
 						stacktrace: {
-							frames: [{ filename: '/app/routes/blog.tsx', function: 'loader' }],
+							frames: [
+								{ filename: '/app/routes/blog.tsx', function: 'loader' },
+							],
 						},
 					},
 				],

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -156,6 +156,16 @@ const TRANSLATOR_DOM_MUTATION_MESSAGE =
 const REACT_DOM_MUTATION_STACK =
 	/react-dom|commitDeletionEffects|commitMutationEffects|removeChild|insertBefore/i
 
+/**
+ * React Fiber invariant when Firefox fires MessageChannel during a blocking
+ * API (`alert` / `confirm` / `prompt` / nested work) while the scheduler is
+ * already in render/commit (facebook/react#17355, Bugzilla 758004). KCD-YT.
+ */
+const REACT_SCHEDULER_ALREADY_WORKING = /^Should not already be working\.?$/i
+
+const REACT_SCHEDULER_REENTRANCY_STACK =
+	/performWorkUntilDeadline|performWorkOnRootViaSchedulerTask|performSyncWorkOnRoot|scheduler(?:\.production)?(?:\.min)?\.js|react-dom(?:-client)?(?:\.production)?(?:\.min)?\.js/i
+
 export function isBrowserExtensionError(exception: unknown): boolean {
 	if (!(exception instanceof Error) || !exception.stack) return false
 	return /chrome-extension:|moz-extension:|safari-web-extension:|safari-extension:|webkit-masked-url:|iabjs:/i.test(
@@ -313,7 +323,9 @@ function routeErrorExtra(
 	return event.extra?.route_error_response ?? null
 }
 
-export function isCloudflareEdgeRouteErrorEvent(event: SentryEventLike): boolean {
+export function isCloudflareEdgeRouteErrorEvent(
+	event: SentryEventLike,
+): boolean {
 	const route = routeErrorExtra(event)
 	if (!route || typeof route.status !== 'number') return false
 
@@ -337,7 +349,11 @@ export function isReactRouterEdgeHttpStatusError(
 	const original = hint.originalException
 	if (original instanceof Error) messages.push(original.message)
 
-	if (!messages.some((message) => REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE.test(message))) {
+	if (
+		!messages.some((message) =>
+			REACT_ROUTER_EDGE_HTTP_STATUS_MESSAGE.test(message),
+		)
+	) {
 		return false
 	}
 
@@ -355,6 +371,46 @@ function exceptionMessage(exception: unknown): string {
 		return (exception as { message: string }).message
 	}
 	return ''
+}
+
+/**
+ * Drop React's "Should not already be working" invariant when the stack is
+ * exclusively the scheduler → react-dom work loop (Firefox MessageChannel
+ * re-entrancy during blocking APIs). Require the exact message plus that
+ * stack with no in-app frames — never the phrase alone (KCD-YT /
+ * facebook/react#17355).
+ */
+export function isReactSchedulerAlreadyWorkingNoise(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const original = hint.originalException
+	const messageMatches = eventMessages(event).some((message) =>
+		REACT_SCHEDULER_ALREADY_WORKING.test(message.trim()),
+	)
+	if (
+		!messageMatches &&
+		!REACT_SCHEDULER_ALREADY_WORKING.test(exceptionMessage(original).trim())
+	) {
+		return false
+	}
+
+	const frames = (event.exception?.values ?? []).flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+	if (frames.some((frame) => frame.inApp)) return false
+
+	const frameBlob = frames
+		.map((frame) => `${frame.filename ?? ''} ${frame.function ?? ''}`)
+		.join('\n')
+	const blob = `${frameBlob}\n${stackBlob(event, original)}`
+	if (!REACT_SCHEDULER_REENTRANCY_STACK.test(blob)) return false
+
+	// Bundled/minified stacks without sourcemaps still count when the only
+	// frames are scheduler / react-dom — reject app route paths.
+	if (/\/app\/|\/routes\/|components\//i.test(blob)) return false
+
+	return true
 }
 
 /**
@@ -384,7 +440,8 @@ export function isTranslatorDomMutationNoise(
 	)
 	const originalIsNotFound =
 		(original instanceof Error &&
-			(original.name === 'NotFoundError' || original.name === 'DOMException')) ||
+			(original.name === 'NotFoundError' ||
+				original.name === 'DOMException')) ||
 		(typeof DOMException !== 'undefined' && original instanceof DOMException)
 	if (!namedNotFound && !originalIsNotFound) return false
 
@@ -505,9 +562,7 @@ export function isInjectedBlobAddListenerError(
 	const frames = (event.exception?.values ?? []).flatMap(
 		(value) => value.stacktrace?.frames ?? [],
 	)
-	const filenames = frames
-		.map((frame) => frame.filename ?? '')
-		.filter(Boolean)
+	const filenames = frames.map((frame) => frame.filename ?? '').filter(Boolean)
 	if (filenames.length > 0) {
 		return filenames.every((filename) => /^blob:/i.test(filename))
 	}
@@ -519,7 +574,9 @@ export function isInjectedBlobAddListenerError(
 }
 
 function isCallStackOverflow(event: SentryEventLike): boolean {
-	return eventMessages(event).some((message) => CALL_STACK_OVERFLOW.test(message))
+	return eventMessages(event).some((message) =>
+		CALL_STACK_OVERFLOW.test(message),
+	)
 }
 
 function exceptionFrames(event: SentryEventLike) {
@@ -557,8 +614,10 @@ function hasTranslatorFontBreadcrumb(event: SentryEventLike): boolean {
 
 /** Live marker Google/Chrome page translate adds to <html>. */
 export function isHtmlPageTranslated(
-	doc: { documentElement?: { className?: string } | null } | null | undefined =
-		typeof document === 'undefined' ? undefined : document,
+	doc:
+		| { documentElement?: { className?: string } | null }
+		| null
+		| undefined = typeof document === 'undefined' ? undefined : document,
 ): boolean {
 	const className = doc?.documentElement?.className
 	if (typeof className !== 'string') return false
@@ -588,6 +647,7 @@ export function shouldDropSentryEvent(
 ): boolean {
 	if (isBrowserExtensionError(hint.originalException)) return true
 	if (isTranslatorDomMutationNoise(event, hint)) return true
+	if (isReactSchedulerAlreadyWorkingNoise(event, hint)) return true
 	if (isWalletUserRejection(event, hint)) return true
 	if (isBrokenClientFetchContractError(event, hint)) return true
 	if (isInjectedBlobAddListenerError(event, hint)) return true

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -163,8 +163,17 @@ const REACT_DOM_MUTATION_STACK =
  */
 const REACT_SCHEDULER_ALREADY_WORKING = /^Should not already be working\.?$/i
 
-const REACT_SCHEDULER_REENTRANCY_STACK =
+const REACT_SCHEDULER_REENTRANCY_FRAME =
 	/performWorkUntilDeadline|performWorkOnRootViaSchedulerTask|performSyncWorkOnRoot|scheduler(?:\.production)?(?:\.min)?\.js|react-dom(?:-client)?(?:\.production)?(?:\.min)?\.js/i
+
+function isReactSchedulerReentrancyFrame(frame: {
+	filename?: string | null
+	function?: string | null
+}): boolean {
+	return REACT_SCHEDULER_REENTRANCY_FRAME.test(
+		`${frame.filename ?? ''} ${frame.function ?? ''}`,
+	)
+}
 
 export function isBrowserExtensionError(exception: unknown): boolean {
 	if (!(exception instanceof Error) || !exception.stack) return false
@@ -398,14 +407,15 @@ export function isReactSchedulerAlreadyWorkingNoise(
 	const frames = (event.exception?.values ?? []).flatMap(
 		(value) => value.stacktrace?.frames ?? [],
 	)
+	// Need attributed frames so we can prove exclusivity — message alone is
+	// not enough, and mixed third-party frames must stay reportable.
+	if (frames.length === 0) return false
 	if (frames.some((frame) => frame.inApp)) return false
+	if (!frames.every(isReactSchedulerReentrancyFrame)) return false
 
-	const frameBlob = frames
+	const blob = `${frames
 		.map((frame) => `${frame.filename ?? ''} ${frame.function ?? ''}`)
-		.join('\n')
-	const blob = `${frameBlob}\n${stackBlob(event, original)}`
-	if (!REACT_SCHEDULER_REENTRANCY_STACK.test(blob)) return false
-
+		.join('\n')}\n${stackBlob(event, original)}`
 	// Bundled/minified stacks without sourcemaps still count when the only
 	// frames are scheduler / react-dom — reject app route paths.
 	if (/\/app\/|\/routes\/|components\//i.test(blob)) return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Filters client Sentry `Error: Should not already be working.` when **every** stack frame is React's scheduler → `react-dom` work loop (`performWorkUntilDeadline` / `performWorkOnRootViaSchedulerTask`) with no in-app frames.
- That signature is the known Firefox MessageChannel re-entrancy during blocking APIs ([facebook/react#17355](https://github.com/facebook/react/issues/17355), Bugzilla 758004), not an app bug (Sentry [KCD-YT](https://kent-c-dodds-tech-llc.sentry.io/issues/7481214799/)).
- Phrase-alone, mixed third-party, and in-app-frame cases stay reportable; docs updated in `bugfix-workflow.md`.

## Status

Merged and deployed (`50904fc9`). Sentry issue ignored; triage outcome recorded as **filtered**.

## Test plan

- [x] Unit coverage in `sentry-noise.test.ts` for drop / keep / mixed-stack cases
- [x] CI green
- [x] Deploy Site Worker succeeded
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d60c5de-12ce-4968-a3c3-d9b56bc9e82c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d60c5de-12ce-4968-a3c3-d9b56bc9e82c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Sentry noise for the Firefox “Should not already be working” React scheduler re-entrancy error by filtering it only when the stack is exclusively React scheduler/react-dom work-loop frames and matches the intended conditions.
  * Kept reporting when the event includes application code or relevant app path evidence.
* **Documentation**
  * Refreshed Sentry triage guidance with the refined filtering rule and an added note about not ignoring the phrase without the required stack context.
* **Tests**
  * Added/extended tests to confirm both matching (dropped) and non-matching (reported) events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->