### PR TITLE
Fix homepage years-teaching crash from date-fns constructFrom (KCD-100)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -114,3 +114,10 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   bug. Before writing an issue off as stale, reproduce it against the current
   runtime (Sentry KCD-XP looked like dead Fly/Express noise but reproduced on
   workerd).
+- Client `TypeError: …constructor is not a constructor` from date-fns
+  `constructFrom` (`normalizeDates` → `Array.map` → `new date.constructor`)
+  means the browser environment made `Date.constructor` non-constructable
+  (extensions/polyfills). Stack often lands in homepage
+  `ProblemSolutionSection` via `differenceInYears`. Prefer plain calendar-year
+  math (`getYearsTeaching` in `utils/years-teaching.ts`) for static marketing
+  copy — do not filter the generic constructor TypeError (KCD-100).

--- a/services/site/app/components/sections/problem-solution-section.tsx
+++ b/services/site/app/components/sections/problem-solution-section.tsx
@@ -6,13 +6,13 @@ import {
 	Tabs,
 	type TabProps,
 } from '@reach/tabs'
-import { differenceInYears } from 'date-fns'
 import { AnimatePresence, motion } from 'framer-motion'
 import * as React from 'react'
 import { Link } from 'react-router'
 import { getImgProps, images, type ImageBuilder } from '#app/images.tsx'
 import { type Team } from '#app/types.ts'
 import { teamTextColorClasses } from '#app/utils/misc.ts'
+import { getYearsTeaching } from '#app/utils/years-teaching.ts'
 import { ArrowLink } from '../arrow-button.tsx'
 import { Grid } from '../grid.tsx'
 import { ArrowIcon } from '../icons.tsx'
@@ -176,10 +176,7 @@ function ProblemSolutionSection({
 					<Paragraph className="mt-8">
 						{`
               I've been teaching people just like you how to build better
-              software for over ${differenceInYears(
-								Date.now(),
-								new Date(2014, 0, 0),
-							)}
+              software for over ${getYearsTeaching()}
               years. My current focus is `}
 						<a
 							href="https://www.epicproduct.engineer"

--- a/services/site/app/utils/__tests__/years-teaching.test.ts
+++ b/services/site/app/utils/__tests__/years-teaching.test.ts
@@ -1,0 +1,21 @@
+import { constructFrom } from 'date-fns'
+import { expect, test } from 'vitest'
+import {
+	getYearsTeaching,
+	TEACHING_STARTED_YEAR,
+} from '#app/utils/years-teaching.ts'
+
+test('getYearsTeaching returns calendar years since teaching start', () => {
+	expect(getYearsTeaching(new Date(`${TEACHING_STARTED_YEAR}-06-01`))).toBe(0)
+	expect(getYearsTeaching(new Date('2026-07-28'))).toBe(12)
+})
+
+test('getYearsTeaching avoids date-fns constructFrom Date.constructor path (KCD-100)', () => {
+	const brokenDate = new Date(TEACHING_STARTED_YEAR, 0, 0)
+	Object.defineProperty(brokenDate, 'constructor', { value: undefined })
+	expect(() => constructFrom(brokenDate, Date.now())).toThrow(
+		/not a constructor/,
+	)
+
+	expect(getYearsTeaching(new Date('2026-07-28'))).toBe(12)
+})

--- a/services/site/app/utils/__tests__/years-teaching.test.ts
+++ b/services/site/app/utils/__tests__/years-teaching.test.ts
@@ -11,11 +11,11 @@ test('getYearsTeaching returns calendar years since teaching start', () => {
 })
 
 test('getYearsTeaching avoids date-fns constructFrom Date.constructor path (KCD-100)', () => {
-	const brokenDate = new Date(TEACHING_STARTED_YEAR, 0, 0)
+	const brokenDate = new Date('2026-07-28')
 	Object.defineProperty(brokenDate, 'constructor', { value: undefined })
 	expect(() => constructFrom(brokenDate, Date.now())).toThrow(
 		/not a constructor/,
 	)
 
-	expect(getYearsTeaching(new Date('2026-07-28'))).toBe(12)
+	expect(getYearsTeaching(brokenDate)).toBe(12)
 })

--- a/services/site/app/utils/years-teaching.ts
+++ b/services/site/app/utils/years-teaching.ts
@@ -1,0 +1,10 @@
+const TEACHING_STARTED_YEAR = 2014
+
+// Avoid date-fns differenceInYears: its constructFrom path does
+// `new date.constructor(...)`, which throws when Date.constructor is
+// non-constructable in some browser environments (KCD-100).
+function getYearsTeaching(now: Date = new Date()) {
+	return now.getFullYear() - TEACHING_STARTED_YEAR
+}
+
+export { getYearsTeaching, TEACHING_STARTED_YEAR }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sentry [KCD-100](https://kent-c-dodds-tech-llc.sentry.io/issues/7615671404/): `TypeError: e.constructor is not a constructor` on the homepage `ProblemSolutionSection` courses tab.
- Root cause: `differenceInYears(Date.now(), new Date(2014, 0, 0))` goes through date-fns `normalizeDates` → `constructFrom`, which does `new date.constructor(value)`. Some browser environments leave `Date.constructor` non-constructable (extensions/polyfills), crashing render.
- Fix: replace with plain calendar-year math via `getYearsTeaching()` (`utils/years-teaching.ts`). Added a regression test that reproduces the broken-constructor path against date-fns and asserts our helper still works.
- Sibling unresolved network `Failed to fetch` issues do not share this root cause and were left alone.

## Test plan

- [x] `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/years-teaching.test.ts`
- [x] Pre-commit lint/typecheck/build and pre-push test suite
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a244ce-9cda-4ea3-962e-8b126ab720e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a244ce-9cda-4ea3-962e-8b126ab720e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the teaching-years count in browsers with unusual `Date` constructor behavior.
  - Switched the “Courses” tab’s year display to consistent calendar-year math.
- **Tests**
  - Added unit tests for the teaching-years calculation, including a regression covering broken `Date` construction.
- **Documentation**
  - Updated Sentry triage guidance to help interpret `date-fns` constructor-related `TypeError` reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->