### PR TITLE
Filter Check Point Zero Phishing zp_token Sentry noise (KCD-102)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -121,3 +121,7 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   `ProblemSolutionSection` via `differenceInYears`. Prefer plain calendar-year
   math (`getYearsTeaching` in `utils/years-teaching.ts`) for static marketing
   copy — do not filter the generic constructor TypeError (KCD-100).
+- Client `ReferenceError: zp_token is not defined` from `/3/zp.js` is Check
+  Point Zero Phishing (`zerophishing.iaas.checkpoint.com`) injected into the
+  visitor's browser — not site code. Filter via `denyUrls` for that host plus
+  the distinctive `zp_token` ignoreErrors (KCD-102); do not chase app fixes.

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -493,6 +493,15 @@ test('filters javascript-obfuscator a0_0x injectors (KCD-ZG)', () => {
 	expect(matchesIgnoreError('myHelper is not defined')).toBe(false)
 })
 
+test('filters Check Point Zero Phishing zp_token inject (KCD-102)', () => {
+	expect(matchesIgnoreError('zp_token is not defined')).toBe(true)
+	expect(matchesIgnoreError("Can't find variable: zp_token")).toBe(true)
+	expect(matchesIgnoreError('auth_token is not defined')).toBe(false)
+	expect(
+		matchesDenyUrl('https://zerophishing.iaas.checkpoint.com/3/zp.js'),
+	).toBe(true)
+})
+
 test('filters WKWebView invalid-frame native errors (KCD-YV)', () => {
 	expect(
 		matchesIgnoreError(

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -500,6 +500,11 @@ test('filters Check Point Zero Phishing zp_token inject (KCD-102)', () => {
 	expect(
 		matchesDenyUrl('https://zerophishing.iaas.checkpoint.com/3/zp.js'),
 	).toBe(true)
+	expect(
+		matchesDenyUrl(
+			'https://evil.example/zerophishing.iaas.checkpoint.com/payload.js',
+		),
+	).toBe(false)
 })
 
 test('filters WKWebView invalid-frame native errors (KCD-YV)', () => {

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -73,6 +73,10 @@ export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	/window\.webkit\.messageHandlers/,
 	// javascript-obfuscator-style injected scripts (KCD-ZG).
 	/a0_0x[0-9a-f]+ is not defined/,
+	// Check Point Zero Phishing injected zp.js (KCD-102). Distinctive
+	// undefined token from zerophishing.iaas.checkpoint.com — not app code.
+	/Can't find variable: zp_token/,
+	/zp_token is not defined/,
 	// WKWebView native bridge rejecting script into a missing frame (KCD-YV).
 	/WKErrorDomain Code=12/,
 	// Sentry Session Replay probing cross-origin iframes (KCD-TF).
@@ -97,6 +101,8 @@ export const SENTRY_DENY_URLS: Array<RegExp> = [
 	/webkit-masked-url:\/\//i,
 	// Android in-app browser injected scripts (Instagram, etc.).
 	/iabjs:/i,
+	// Check Point Zero Phishing corporate security inject (KCD-102).
+	/zerophishing\.iaas\.checkpoint\.com/i,
 ]
 
 type SentryExceptionValue = {

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -102,7 +102,7 @@ export const SENTRY_DENY_URLS: Array<RegExp> = [
 	// Android in-app browser injected scripts (Instagram, etc.).
 	/iabjs:/i,
 	// Check Point Zero Phishing corporate security inject (KCD-102).
-	/zerophishing\.iaas\.checkpoint\.com/i,
+	/(?:^|\/\/)zerophishing\.iaas\.checkpoint\.com(?::\d+)?(?:\/|$|\?)/i,
 ]
 
 type SentryExceptionValue = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `ReferenceError: zp_token is not defined` (Sentry [KCD-102](https://kent-c-dodds-tech-llc.sentry.io/issues/7639673924/)) is not site code — the stack points at injected Check Point Zero Phishing `https://zerophishing.iaas.checkpoint.com/3/zp.js`.
- Add that host to `SENTRY_DENY_URLS` and ignore the distinctive `zp_token` undefined messages (Chrome + Safari wording).
- Document the signature in `docs/agents/bugfix-workflow.md` and cover with unit tests.

## Outcome

**filtered** — external corporate security inject; no app fix needed. Sibling unresolved issues are generic `Failed to fetch` / network errors and are unrelated.

## Test plan

- [x] `npm run test:backend -- app/utils/__tests__/sentry-noise.test.ts`
- [x] Pre-commit validate (lint/typecheck/build) and pre-push test:all

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-139a9ac2-1b4f-4136-a96b-21e2605ae84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-139a9ac2-1b4f-4136-a96b-21e2605ae84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced misleading Sentry noise caused by Check Point Zero Phishing by filtering injected `zp_token` undefined-variable errors and denying related injected script URLs.
* **Documentation**
  * Updated the Sentry triage checklist with guidance to recognize this browser-noise signature and avoid code-level fixes for it.
* **Tests**
  * Added coverage to verify ignore-error and deny-URL behavior for the affected phishing noise patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->