### PR TITLE
Add Cloudflare Connect talk: I Built Your Personal Software Ecosystem

### DIFF
--- a/services/site/content/data/talks.yml
+++ b/services/site/content/data/talks.yml
@@ -9,6 +9,38 @@
     - event: '[React Summit US](https://reactsummit.us/)'
       date: 2026-11-17
 
+- title: 'I Built Your Personal Software Ecosystem'
+  deliveries:
+    - event: '[Cloudflare Connect](https://www.cloudflare.com/connect/)'
+      date: 2026-10-19
+  tags:
+    - cloudflare
+    - ai
+    - architecture
+  description: >-
+    What if you had your own npm registry, your own GitHub, your own cron
+    system, your own email address, and your own database? And what if your
+    favorite AI assistant could build software with all of it on your behalf?
+
+
+    That's Kody: a personal assistant platform where every user gets a fully
+    isolated software ecosystem. Your AI writes packages into your own git
+    repos, publishes them to your personal package registry with real versioned
+    imports, schedules your jobs, runs your long-lived services and workflows,
+    receives email at your own address, and stores everything in storage only
+    you can touch.
+
+
+    I built this entirely on Cloudflare, because Cloudflare is the only place it
+    could be built. This is a technical deep dive into what happens when you
+    take the newest parts of the developer platform to their limits: sandboxing
+    AI-authored user code with Worker Loaders, per-user git hosting with
+    Artifacts, modeling "one of everything per user" with namespaced Durable
+    Objects, and composing D1, KV, R2, Vectorize, Queues, Workflows, and Email
+    Routing into a true multi-tenant platform. If AI agents are going to build
+    and run software for everyone, this is what the infrastructure underneath
+    looks like. You can start building it today.
+
 - title: 'The Last Software Engineer'
   resources:
     - '[article](https://www.epicproduct.engineer/the-last-software-engineer)'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add the upcoming talk **I Built Your Personal Software Ecosystem** to `services/site/content/data/talks.yml`.
- Delivery: Cloudflare Connect (official event page), using the verified conference start date `2026-10-19` from [cloudflare.com/connect](https://www.cloudflare.com/connect/) (Oct 19-21, 2026). No city field and no invented session day.
- Tags: `cloudflare`, `ai`, `architecture`. No resources (optional in schema).

## Testing
- Parsed `talks.yml` with the repo `yaml` package and asserted the new talk title, delivery, date, tags, and description (verbatim aside from YAML folding whitespace; ASCII punctuation only).
- `npm exec prettier -- --check services/site/content/data/talks.yml`
- Pre-push gate: workspace tests passed (`test:backend` 359 passed; `test:browser` 17 passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b0cd335-6fd5-49c8-b4af-5eb3c3abc55b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b0cd335-6fd5-49c8-b4af-5eb3c3abc55b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added the talk “I Built Your Personal Software Ecosystem,” scheduled for October 19, 2026.
  * Included event details, description, and topics covering Cloudflare, AI, and software architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->