### PR TITLE
Fix stale talks.yml after content-only refresh

### DIFF
--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -143,6 +143,12 @@ publishes the artifact bundle via `POST /resources/mdx-artifacts`, and records
 the commit via `POST /action/refresh-cache`. Compare SHA resolution prefers
 `/refresh-commit-sha.json`, then falls back to `/__meta.buildSha`.
 
+Sharp edge: YAML under `services/site/content/data/` is also cached in the
+application KV cache (`content:data:*`, multi-day TTL). Content refresh must
+delete those keys for changed data files before prewarming, and runtime cache
+keys are scoped by artifact `contentVersion` so a republished bundle cannot
+keep serving stale parsed YAML.
+
 ## Bootstrap ↔ app bridge (globals contract)
 
 The dynamic worker's main module (`app-worker.js`) is an esbuild bundle of

--- a/other/__tests__/content-prewarm-urls.test.ts
+++ b/other/__tests__/content-prewarm-urls.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "vitest";
-import { getContentPrewarmUrls } from "../content-prewarm-urls.ts";
+import {
+  getContentCacheKeys,
+  getContentPrewarmUrls,
+} from "../content-prewarm-urls.ts";
 
 const blogSharedUrls = [
   "/",
@@ -83,4 +86,39 @@ test("ignores content without a corresponding public route", () => {
       },
     ]),
   ).toEqual(blogSharedUrls);
+});
+
+test("maps changed data YAML files to application cache keys", () => {
+  expect(
+    getContentCacheKeys([
+      {
+        changeType: "modified",
+        filename: "services/site/content/data/talks.yml",
+      },
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/some-post.mdx",
+      },
+      {
+        changeType: "moved",
+        filename: "services/site/content/data/resume.yml",
+        previousFilename: "services/site/content/data/credits.yml",
+      },
+    ]),
+  ).toEqual([
+    "content:data:credits.yml",
+    "content:data:resume.yml",
+    "content:data:talks.yml",
+  ]);
+});
+
+test("returns no cache keys for non-data content changes", () => {
+  expect(
+    getContentCacheKeys([
+      {
+        changeType: "modified",
+        filename: "services/site/content/blog/some-post.mdx",
+      },
+    ]),
+  ).toEqual([]);
 });

--- a/other/__tests__/refresh-changed-content.test.js
+++ b/other/__tests__/refresh-changed-content.test.js
@@ -172,6 +172,61 @@ describe("refreshChangedContent", () => {
     expect(log.warn).toHaveBeenCalledTimes(1);
   });
 
+  test("deletes content data cache keys before prewarming data YAML changes", async () => {
+    const fetchJsonImpl = vi.fn(async () => ({ sha: "compare-sha" }));
+    const getChangedFilesImpl = vi.fn(async () => [
+      {
+        changeType: "modified",
+        filename: "services/site/content/data/talks.yml",
+      },
+    ]);
+    const postRefreshCacheImpl = vi.fn(async () => ({
+      ok: true,
+      pageCacheGeneration: "generation-2",
+      contentVersion: "content-v2",
+    }));
+    const prewarmPageCacheImpl = vi.fn(async () => ({
+      attempted: 2,
+      warmed: 2,
+      failed: 0,
+      results: [],
+    }));
+    const log = createLogger();
+
+    const result = await refreshChangedContent({
+      currentCommitSha: "current-sha",
+      baseUrl: "https://example.test",
+      fetchJsonImpl,
+      getChangedFilesImpl,
+      postRefreshCacheImpl,
+      prewarmPageCacheImpl,
+      prewarmBaseUrl: "https://kentcdodds.com",
+      log,
+      skipPublish: true,
+      skipPrewarm: false,
+    });
+
+    expect(postRefreshCacheImpl).toHaveBeenCalledWith({
+      http: undefined,
+      postData: {
+        commitSha: "current-sha",
+        keys: ["content:data:talks.yml"],
+      },
+      options: { hostname: "kentcdodds-com.kentcdodds.workers.dev" },
+    });
+    expect(prewarmPageCacheImpl).toHaveBeenCalledWith({
+      baseUrl: "https://kentcdodds.com",
+      paths: ["/sitemap.xml", "/talks"],
+      expectedGeneration: "generation-2",
+      expectedContentVersion: "content-v2",
+      log,
+    });
+    expect(result).toMatchObject({
+      status: "refreshed",
+      contentPaths: ["data/talks.yml"],
+    });
+  });
+
   test("prewarms affected public URLs after the final cache refresh", async () => {
     const fetchJsonImpl = vi.fn(async () => ({ sha: "compare-sha" }));
     const getChangedFilesImpl = vi.fn(async () => [

--- a/other/content-prewarm-urls.ts
+++ b/other/content-prewarm-urls.ts
@@ -15,6 +15,14 @@ const dataUrlsByFilename: Record<string, ReadonlyArray<string>> = {
   "testimonials.yml": ["/testimonials"],
 };
 
+/** Legacy/unversioned app-cache keys for YAML content data files. */
+const dataCacheKeyByFilename: Record<string, string> = {
+  "credits.yml": "content:data:credits.yml",
+  "resume.yml": "content:data:resume.yml",
+  "talks.yml": "content:data:talks.yml",
+  "testimonials.yml": "content:data:testimonials.yml",
+};
+
 export type ContentChange = {
   changeType: "added" | "deleted" | "modified" | "moved";
   filename: string;
@@ -90,4 +98,32 @@ export function getContentPrewarmUrls(changes: ReadonlyArray<ContentChange>) {
   }
 
   return Array.from(urls).sort();
+}
+
+function addDataCacheKey(keys: Set<string>, contentPath: string) {
+  if (!contentPath.startsWith("data/")) return;
+  const filename = contentPath.slice("data/".length);
+  const key = dataCacheKeyByFilename[filename];
+  if (key) keys.add(key);
+}
+
+/**
+ * Application-cache keys that must be deleted when content data YAML changes.
+ * Without this, long-TTL `content:data:*` entries can outlive republished
+ * artifacts and prewarm stale pages into a fresh page-cache generation.
+ */
+export function getContentCacheKeys(changes: ReadonlyArray<ContentChange>) {
+  const keys = new Set<string>();
+
+  for (const change of changes) {
+    const contentPath = getContentPath(change.filename);
+    if (contentPath) addDataCacheKey(keys, contentPath);
+
+    if (change.changeType === "moved" && change.previousFilename) {
+      const previousContentPath = getContentPath(change.previousFilename);
+      if (previousContentPath) addDataCacheKey(keys, previousContentPath);
+    }
+  }
+
+  return Array.from(keys).sort();
 }

--- a/other/refresh-changed-content.ts
+++ b/other/refresh-changed-content.ts
@@ -2,7 +2,10 @@
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { publishViaEndpoint as publishViaEndpointImpl } from "../services/site-worker/scripts/publish-artifacts-lib.mjs";
-import { getContentPrewarmUrls } from "./content-prewarm-urls.ts";
+import {
+  getContentCacheKeys,
+  getContentPrewarmUrls,
+} from "./content-prewarm-urls.ts";
 import { getChangedFiles, fetchJson } from "./get-changed-files.js";
 import { prewarmPageCache } from "./prewarm-page-cache.ts";
 import { resolveCompareCommitSha } from "./resolve-compare-commit-sha.ts";
@@ -200,10 +203,14 @@ export async function refreshChangedContent({
   }
 
   // Refresh the same host the artifacts were published to.
+  // Delete long-lived content:data:* keys for changed YAML so prewarm does not
+  // rebuild pages from stale parsed content.
+  const cacheKeys = getContentCacheKeys(contentChanges);
   const refreshResult = await postRefreshCacheWithRetry({
     postRefreshCacheImpl,
     postData: {
       commitSha: currentCommitSha,
+      ...(cacheKeys.length > 0 ? { keys: cacheKeys } : {}),
     },
     hostname: new URL(workerUrl).hostname,
     log,

--- a/services/site/app/utils/__tests__/content-data.server.test.ts
+++ b/services/site/app/utils/__tests__/content-data.server.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const getContentData = vi.hoisted(() => vi.fn())
+const getArtifactDataFile = vi.hoisted(() => vi.fn())
+
+vi.mock('#app/utils/content-artifacts.server.ts', () => ({
+	getContentData,
+	getArtifactDataFile,
+}))
+
+import { getContentDataCacheKey } from '../content-data.server.ts'
+
+describe('getContentDataCacheKey', () => {
+	afterEach(() => {
+		getContentData.mockReset()
+		getArtifactDataFile.mockReset()
+	})
+
+	test('uses the unversioned key when artifacts are unavailable', () => {
+		getContentData.mockReturnValue(null)
+		expect(getContentDataCacheKey('talks.yml')).toBe('content:data:talks.yml')
+	})
+
+	test('scopes the key to the artifact content version', () => {
+		getContentData.mockReturnValue({ version: 'bundle-v2' })
+		expect(getContentDataCacheKey('talks.yml')).toBe(
+			'content:data:talks.yml:bundle-v2',
+		)
+	})
+})

--- a/services/site/app/utils/__tests__/credits.server.test.ts
+++ b/services/site/app/utils/__tests__/credits.server.test.ts
@@ -25,6 +25,9 @@ vi.mock('../cache.server.ts', () => ({
 
 vi.mock('../content-data.server.ts', () => ({
 	getContentDataFile: vi.fn(async () => ''),
+	getContentDataCacheKey: vi.fn(
+		(dataFilename: string) => `content:data:${dataFilename}`,
+	),
 }))
 
 import { getPeople } from '../credits.server.ts'

--- a/services/site/app/utils/content-data.server.ts
+++ b/services/site/app/utils/content-data.server.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { getArtifactDataFile } from './content-artifacts.server.ts'
+import {
+	getArtifactDataFile,
+	getContentData,
+} from './content-artifacts.server.ts'
 
 export async function getContentDataFile(key: string): Promise<string> {
 	const artifact = getArtifactDataFile(key)
@@ -8,4 +11,16 @@ export async function getContentDataFile(key: string): Promise<string> {
 
 	const localPath = path.join(process.cwd(), 'content', key)
 	return fs.readFile(localPath, 'utf8')
+}
+
+/**
+ * Cache key for YAML content data files.
+ *
+ * Include the artifact content version so republished MDX bundles do not keep
+ * serving stale parsed YAML from the long-lived application cache.
+ */
+export function getContentDataCacheKey(dataFilename: string): string {
+	const baseKey = `content:data:${dataFilename}`
+	const version = getContentData()?.version
+	return version ? `${baseKey}:${version}` : baseKey
 }

--- a/services/site/app/utils/credits.server.ts
+++ b/services/site/app/utils/credits.server.ts
@@ -2,7 +2,10 @@ import { cachified, verboseReporter } from '@epic-web/cachified'
 import slugify from '@sindresorhus/slugify'
 import * as YAML from 'yaml'
 import { cache, shouldForceFresh } from './cache.server.ts'
-import { getContentDataFile } from './content-data.server.ts'
+import {
+	getContentDataCacheKey,
+	getContentDataFile,
+} from './content-data.server.ts'
 import { getErrorMessage, typedBoolean } from './misc.ts'
 
 export type Person = {
@@ -138,7 +141,7 @@ async function getPeople({
 	request?: Request
 	forceFresh?: boolean
 }) {
-	const key = 'content:data:credits.yml'
+	const key = getContentDataCacheKey('credits.yml')
 	try {
 		const allPeople = await cachified(
 			{

--- a/services/site/app/utils/resume.server.ts
+++ b/services/site/app/utils/resume.server.ts
@@ -1,7 +1,10 @@
 import * as YAML from 'yaml'
 import { z } from 'zod'
 import { cache, cachified } from '#app/utils/cache.server.ts'
-import { getContentDataFile } from '#app/utils/content-data.server.ts'
+import {
+	getContentDataCacheKey,
+	getContentDataFile,
+} from '#app/utils/content-data.server.ts'
 import { type Timings } from '#app/utils/timing.server.ts'
 
 const resumeLinkSchema = z.object({
@@ -63,7 +66,7 @@ async function getResumeData({
 	forceFresh?: boolean
 	timings?: Timings
 }) {
-	const key = 'content:data:resume.yml'
+	const key = getContentDataCacheKey('resume.yml')
 	try {
 		return await cachified({
 			cache,

--- a/services/site/app/utils/talks.server.ts
+++ b/services/site/app/utils/talks.server.ts
@@ -4,7 +4,10 @@ import {
 } from '@sindresorhus/slugify'
 import * as YAML from 'yaml'
 import { cache, cachified } from '#app/utils/cache.server.ts'
-import { getContentDataFile } from '#app/utils/content-data.server.ts'
+import {
+	getContentDataCacheKey,
+	getContentDataFile,
+} from '#app/utils/content-data.server.ts'
 import {
 	markdownToHtml,
 	markdownToHtmlUnwrapped,
@@ -126,7 +129,7 @@ async function getTalksAndTags({
 	const slugify = await getSlugify()
 	slugify.reset()
 
-	const key = 'content:data:talks.yml'
+	const key = getContentDataCacheKey('talks.yml')
 	try {
 		return await cachified({
 			cache,

--- a/services/site/app/utils/testimonials.server.ts
+++ b/services/site/app/utils/testimonials.server.ts
@@ -2,7 +2,10 @@ import slugify from '@sindresorhus/slugify'
 import * as YAML from 'yaml'
 import { pick } from '#app/utils/cjs/lodash.ts'
 import { cache, cachified } from './cache.server.ts'
-import { getContentDataFile } from './content-data.server.ts'
+import {
+	getContentDataCacheKey,
+	getContentDataFile,
+} from './content-data.server.ts'
 import { markdownToHtml } from './markdown.server.ts'
 import { getErrorMessage, typedBoolean } from './misc.ts'
 import { type Timings } from './timing.server.ts'
@@ -201,7 +204,7 @@ async function getAllTestimonials({
 	forceFresh?: boolean
 	timings?: Timings
 }) {
-	const key = 'content:data:testimonials.yml'
+	const key = getContentDataCacheKey('testimonials.yml')
 	try {
 		return await cachified({
 			cache,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Content-only refreshes published new `talks.yml` artifacts but left the long-TTL `content:data:talks.yml` app cache intact, so `/talks` prewarm kept serving the old list (including after #877).
- Scope YAML content data cache keys by artifact `contentVersion`, and delete legacy `content:data:*` keys for changed data files during Refresh Content before prewarm.
- Document the sharp edge in `docs/agents/cloudflare-worker-architecture.md`.

## Testing
- Targeted vitest for content prewarm/refresh/content-data/credits tests (22 passed).
- Pre-push: workspace tests passed.
- After merge/deploy: verified https://kentcdodds.com/talks and the talk slug page show **I Built Your Personal Software Ecosystem**.

## Deploy
- Merged and deployed via site pipeline: https://github.com/kentcdodds/kentcdodds.com/actions/runs/30660309349
- Production deployment: https://github.com/kentcdodds/kentcdodds.com/deployments/5697274276
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b0cd335-6fd5-49c8-b4af-5eb3c3abc55b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b0cd335-6fd5-49c8-b4af-5eb3c3abc55b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Published content updates now reliably appear after refreshes, including changes to data files and moved content.
  - Prevented outdated parsed content from being served after republishing new content versions.
  - Improved cache invalidation before content prewarming for refreshed pages and feeds.

- **Documentation**
  - Added guidance for clearing relevant application caches before prewarming content updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->