### PR TITLE
Fix blank trailing pages when printing the resume

### DIFF
--- a/services/site/app/styles/resume.css
+++ b/services/site/app/styles/resume.css
@@ -332,6 +332,11 @@ html.light .resume-bullets li::marker {
 
 	main.resume-main {
 		color: #000000;
+		/* Pin metric-compatible fonts (Arial on Windows, Helvetica on macOS,
+		   Liberation Sans on Linux) so pagination is stable across machines.
+		   Wider system-font fallbacks (e.g. DejaVu Sans) push the one-page
+		   view onto a second page. */
+		font-family: Arial, Helvetica, 'Liberation Sans', sans-serif;
 	}
 
 	.resume-photo {

--- a/services/site/app/styles/resume.css
+++ b/services/site/app/styles/resume.css
@@ -318,21 +318,19 @@ html.light .resume-bullets li::marker {
 		margin: 0.6in;
 	}
 
-	body * {
-		visibility: hidden;
+	/* Remove the site chrome (navbar, spacer, footer) from the layout entirely.
+	   Hiding it with `visibility: hidden` kept its height in the document flow,
+	   which produced blank trailing pages in the printout. */
+	body > :not(.resume-page) {
+		display: none;
 	}
 
-	main.resume-main,
-	main.resume-main * {
-		visibility: visible;
+	.resume-page {
+		max-width: none;
+		padding: 0;
 	}
 
 	main.resume-main {
-		position: absolute;
-		left: 0;
-		top: 0;
-		width: 100%;
-		padding: 0;
 		color: #000000;
 	}
 

--- a/services/site/e2e/resume-print.spec.ts
+++ b/services/site/e2e/resume-print.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test, type Page } from '@playwright/test'
+
+// Chromium writes an uncompressed page-tree object, so the page count is
+// readable directly from the PDF bytes (`/Count N` on the `/Pages` node).
+function getPdfPageCount(pdf: Buffer) {
+	const counts = [...pdf.toString('latin1').matchAll(/\/Count (\d+)/g)].map(
+		(match) => Number(match[1]),
+	)
+	if (counts.length === 0) {
+		throw new Error('No /Count entry found in PDF')
+	}
+	return Math.max(...counts)
+}
+
+async function printResumeToPdf(page: Page, url: string) {
+	await page.goto(url)
+	await expect(page.locator('main.resume-main')).toBeVisible()
+	await page.evaluate(() => document.fonts.ready)
+	return page.pdf({ preferCSSPageSize: true })
+}
+
+test('short resume prints to a single page', async ({ page }) => {
+	const pdf = await printResumeToPdf(page, '/resume?view=short')
+	expect(getPdfPageCount(pdf)).toBe(1)
+})
+
+test('full resume prints without trailing blank pages', async ({ page }) => {
+	const pdf = await printResumeToPdf(page, '/resume')
+	// The full resume content currently fills two pages. Hidden site chrome
+	// (navbar/footer) used to add blank trailing pages beyond the content; if
+	// this assertion fails, check the printout for blank pages before bumping
+	// the expected count.
+	expect(getPdfPageCount(pdf)).toBe(2)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Printing `/resume` produced blank trailing pages — the "Short (1 page)" view printed on multiple pages (reported as 3 pages in the wild), and the full view also picked up a blank page at the end.

The suspicion that print was rendering the long version was not it: the `?view=short` toggle carries through to print correctly (verified via printed PDFs — the short printout contains the 3-job one-pager content).

## Root causes

Two separate issues combined to produce the reported 3 pages:

1. **Blank trailing pages.** The print stylesheet hid everything outside the resume with `visibility: hidden` and overlaid the resume content with `position: absolute`. But `visibility: hidden` keeps elements in the document flow, so the hidden navbar, spacer, and footer still contributed their full height to the printed document — stretching it across additional blank pages.
2. **Font-dependent pagination.** The resume inherits the system font stack, so print metrics vary by machine. Wider fallbacks (e.g. DejaVu Sans, the default on GitHub runners and many Linux distros) pushed the short view's content onto a second page. Verified empirically: with DejaVu Sans forced, the short view prints 2 pages; with Arial-metric fonts it prints 1.

## Fix

- In `@media print`, remove the site chrome from the layout entirely with `display: none` on `body > :not(.resume-page)` (the resume page is a direct child of `body`), dropping the `visibility`/absolute-positioning trick.
- Pin a metric-compatible print font stack (`Arial, Helvetica, 'Liberation Sans', sans-serif` — metrically equivalent across Windows/macOS/Linux) so the one-page view paginates stably everywhere.

## Verification

Printed both views to PDF with headless Chromium (honoring the CSS `@page` rule) before and after:

| View | Before | After |
|------|--------|-------|
| Short | 2–3 pages (content + blank) | 1 page |
| Full | content + blank-page risk | 2 pages, both with content |

Also verified page counts across a font matrix (default/Noto, DejaVu Sans, Liberation Sans, Arial stack): short = 1 page and full = 2 pages for all fonts with the fix.

Before — short view printed a blank second page:

![Short resume before fix, page 1](https://cursor.com/artifacts/c/art-192e1cce-e5ce-4b94-b997-dbcb7ab02d42)
![Short resume before fix, blank page 2](https://cursor.com/artifacts/c/art-009b5166-d5dd-4a4d-8dac-eeefd07acd95)

After — short view is a single page:

![Short resume after fix, single page in print font](https://cursor.com/artifacts/c/art-2642aafe-6a39-45cc-9b0a-0f7bf39b3b15)

## Regression test

Added `services/site/e2e/resume-print.spec.ts`: prints both views to PDF via Playwright and asserts the page counts (short = 1, full = 2). Verified the short-view assertion fails against the old CSS and both tests pass with the fix — including on CI's font stack, which caught the font-fallback pagination issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f228ec93-62e8-4021-92f1-736038a8bc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f228ec93-62e8-4021-92f1-736038a8bc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume print layouts by removing unnecessary page space and using the full available width.
  * Prevented hidden site elements from affecting printed resume page dimensions.
  * Resolved issues that could cause unexpected blank pages in resume PDFs.

* **Tests**
  * Added coverage to verify one-page and two-page resume PDFs render correctly without trailing blank pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->