### PR TITLE
Add persistent MDX compile cache for deploys

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -149,6 +149,18 @@ jobs:
       - name: 🏗️ Build site client + server bundles
         run: npm run build --workspace kentcdodds.com
 
+      # Persistent MDX compile cache: unchanged documents are reused instead of
+      # recompiled, and resolved embeds (tweets, oEmbed, mermaid SVGs) persist
+      # across runs. Keyed by sha so every run saves an updated cache; restore
+      # falls back to the most recent previous run.
+      - name: 🧰 Cache MDX compile artifacts
+        uses: actions/cache@v5
+        with:
+          path: services/site/node_modules/.cache/mdx-artifacts
+          key: mdx-artifacts-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            mdx-artifacts-${{ runner.os }}-
+
       - name: 📦 Compile MDX artifacts
         run: npm run mdx:compile --workspace kentcdodds.com -- --out /tmp/mdx-bundle.json
 

--- a/.github/workflows/refresh-content.yml
+++ b/.github/workflows/refresh-content.yml
@@ -49,6 +49,16 @@ jobs:
       - name: 📥 Install dependencies
         run: npm ci --workspace=kentcdodds.com --include-workspace-root
 
+      # Shares the mdx-artifacts-* cache family with deploy-site.yml so a
+      # content-only refresh reuses documents compiled during the last deploy.
+      - name: 🧰 Cache MDX compile artifacts
+        uses: actions/cache@v5
+        with:
+          path: services/site/node_modules/.cache/mdx-artifacts
+          key: mdx-artifacts-${{ runner.os }}-refresh-${{ inputs.current_commit_sha || github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            mdx-artifacts-${{ runner.os }}-
+
       - name: 🥬 Refresh changed content
         run:
           node ./other/refresh-changed-content.ts ${{ inputs.current_commit_sha

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -89,6 +89,30 @@ Produced by `npm run mdx:compile --workspace kentcdodds.com` (Node), published
 by CI to R2 + KV. Format (JSON, schema in
 `services/site/types/mdx-artifacts.ts`):
 
+### Persistent compile cache
+
+`mdx:compile` keeps a persistent cache in `node_modules/.cache/mdx-artifacts`
+(override with `--cache-dir`, disable with `--no-cache`); CI restores/saves it
+via `actions/cache` (`mdx-artifacts-*` key family, shared by `deploy-site.yml`
+and `refresh-content.yml`):
+
+- `documents/{contentDir}/{slug}.json` — full compiled documents keyed by the
+  per-document input hash (`document-input-hash.ts`: compiler version + the
+  document's files + parent dir listing — the same hash the dev watcher uses).
+  Unchanged documents are reused without recompiling; a warm full compile takes
+  ~1s instead of ~90s.
+- `cachified/` — a disk-backed cachified store (`disk-cache-rpc.ts`) registered
+  as the `CACHE_RPC` runtime binding in `compile-mdx-artifacts.ts` and
+  `dev-watcher.ts`. Tweet embed HTML (`tweet:embed:*`), oEmbed responses, and
+  mermaid SVGs (`mermaid:svg:*`) persist across runs, so recompiling a changed
+  document reuses resolved embeds instead of re-fetching them (normal cachified
+  TTL/SWR semantics still refresh stale entries).
+
+Sharp edge: cached documents bake in their resolved embed HTML, so an embed
+provider change only shows up when the document's input hash changes. Bump
+`ARTIFACT_COMPILER_VERSION` when the compile pipeline changes — that already
+invalidates this cache (the input hash includes it).
+
 ```jsonc
 {
 	"schemaVersion": 1,

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -113,9 +113,14 @@ provider change only shows up when the document's input hash changes. Bump
 `ARTIFACT_COMPILER_VERSION` when the compile pipeline changes — that already
 invalidates this cache (the input hash includes it).
 
-Sharp edge: `--allow-embed-fallback` runs read the document cache but never
-write to it — a fallback compile can bake plain links in place of failed
-embeds, and a strict run must never reuse that degraded output.
+Sharp edge: degraded compiles never enter the caches. A document whose compile
+hit any embed degradation (failed tweet callout, remark-embedder error HTML,
+mermaid render failure, `--allow-embed-fallback` plain link) is used for that
+run's bundle (pre-existing behavior) but is not written to the document cache,
+and `tweet:embed:*` failure placeholders are never stored in the cachified
+store (`checkValue` + throw-on-failure in `x.server.ts`), so transient
+provider failures heal on the next compile instead of persisting for months.
+Track degradations via `embedDegradations` in the compile summary output.
 
 ```jsonc
 {

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -113,6 +113,10 @@ provider change only shows up when the document's input hash changes. Bump
 `ARTIFACT_COMPILER_VERSION` when the compile pipeline changes — that already
 invalidates this cache (the input hash includes it).
 
+Sharp edge: `--allow-embed-fallback` runs read the document cache but never
+write to it — a fallback compile can bake plain links in place of failed
+embeds, and a strict run must never reuse that degraded output.
+
 ```jsonc
 {
 	"schemaVersion": 1,

--- a/services/site/app/utils/compile-mdx.server.ts
+++ b/services/site/app/utils/compile-mdx.server.ts
@@ -22,6 +22,7 @@ import { v4 as uuid } from 'uuid'
 import { type GitHubFile } from '#app/types.ts'
 import { buildMediaUrl } from '#app/utils/media.ts'
 import { cache, cachified } from './cache.server.ts'
+import { recordEmbedDegradation } from './embed-degradation.server.ts'
 import * as x from './x.server.ts'
 
 const MDX_ESM_EXTERNALS = [
@@ -67,7 +68,7 @@ export function getEmbedFallbackCount() {
 
 function recordEmbedFallback(url: string, reason: string) {
 	embedFallbackCount++
-	console.warn(`[mdx:embed-fallback] ${url} (${reason})`)
+	recordEmbedDegradation(url, `fallback: ${reason}`)
 }
 
 function wrapEmbedTransformer<T extends EmbedTransformer>(transformer: T): T {
@@ -107,6 +108,8 @@ type MdxJsxFlowElement = {
 function handleEmbedderError({ url }: { url: string }) {
 	if (allowEmbedFallback) {
 		recordEmbedFallback(url, 'remark-embedder handleError')
+	} else {
+		recordEmbedDegradation(url, 'remark-embedder handleError')
 	}
 	return `<p>Error embedding <a href="${url}">${url}</a></p>.`
 }
@@ -332,9 +335,13 @@ async function getMermaidSvg({
 				typeof value === 'string' && value.startsWith('<svg'),
 			getFreshValue: () => fetchMermaidSvg({ code: trimmed, theme }),
 		})
-	} catch {
+	} catch (error: unknown) {
 		// If we can't render at compile time, the caller keeps the original code
 		// block so it still shows up as text (and nothing gets cached).
+		recordEmbedDegradation(
+			`mermaid:${theme}:${codeHash}`,
+			error instanceof Error ? error.message : String(error),
+		)
 		return null
 	}
 }

--- a/services/site/app/utils/compile-mdx.server.ts
+++ b/services/site/app/utils/compile-mdx.server.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import path from 'node:path'
 import { NodeResolvePlugin } from '@esbuild-plugins/node-resolve'
 import { rehypeCodeBlocksShiki } from '@kentcdodds/md-temp'
@@ -20,6 +21,7 @@ import { visit } from 'unist-util-visit'
 import { v4 as uuid } from 'uuid'
 import { type GitHubFile } from '#app/types.ts'
 import { buildMediaUrl } from '#app/utils/media.ts'
+import { cache, cachified } from './cache.server.ts'
 import * as x from './x.server.ts'
 
 const MDX_ESM_EXTERNALS = [
@@ -164,7 +166,6 @@ function trimCodeBlocks() {
 	}
 }
 
-
 const twitterTransformer = {
 	shouldTransform: x.isXUrl,
 	getHTML: x.getTweetEmbedHTML,
@@ -282,6 +283,31 @@ function mdxStringExpressionAttribute(
 	}
 }
 
+async function fetchMermaidSvg({
+	code,
+	theme,
+}: {
+	code: string
+	theme: MermaidTheme
+}): Promise<string> {
+	const compressed = lz.compressToEncodedURIComponent(code)
+	if (!compressed) throw new Error('mermaid code could not be compressed')
+
+	const url = new URL('https://mermaid-to-svg.kentcdodds.workers.dev/svg')
+	url.searchParams.set('mermaid', compressed)
+	url.searchParams.set('theme', theme)
+
+	const response = await fetch(url)
+	if (!response.ok) {
+		throw new Error(`mermaid render failed with status ${response.status}`)
+	}
+	const svgText = await response.text()
+	if (!svgText.startsWith('<svg')) {
+		throw new Error('mermaid render returned non-svg output')
+	}
+	return svgText
+}
+
 async function getMermaidSvg({
 	code,
 	theme,
@@ -292,20 +318,23 @@ async function getMermaidSvg({
 	const trimmed = code.trim()
 	if (!trimmed) return null
 
-	const compressed = lz.compressToEncodedURIComponent(trimmed)
-	if (!compressed) return null
-
-	const url = new URL('https://mermaid-to-svg.kentcdodds.workers.dev/svg')
-	url.searchParams.set('mermaid', compressed)
-	url.searchParams.set('theme', theme)
-
+	const codeHash = createHash('sha256')
+		.update(trimmed)
+		.digest('hex')
+		.slice(0, 16)
 	try {
-		const response = await fetch(url)
-		if (!response.ok) return null
-		const svgText = await response.text()
-		if (!svgText || !svgText.startsWith('<svg')) return null
-		return svgText
+		return await cachified({
+			key: `mermaid:svg:${theme}:${codeHash}`,
+			cache,
+			ttl: 1000 * 60 * 60 * 24 * 30,
+			staleWhileRevalidate: 1000 * 60 * 60 * 24 * 30 * 6,
+			checkValue: (value) =>
+				typeof value === 'string' && value.startsWith('<svg'),
+			getFreshValue: () => fetchMermaidSvg({ code: trimmed, theme }),
+		})
 	} catch {
+		// If we can't render at compile time, the caller keeps the original code
+		// block so it still shows up as text (and nothing gets cached).
 		return null
 	}
 }

--- a/services/site/app/utils/embed-degradation.server.ts
+++ b/services/site/app/utils/embed-degradation.server.ts
@@ -1,0 +1,18 @@
+/**
+ * Tracks embed degradations during MDX compilation: a tweet that could not be
+ * fetched (baked as a callout), a remark-embedder error (baked as an error
+ * paragraph), a mermaid render failure (kept as a plain code block), or a
+ * fallback plain link. The compile CLI skips persistent document-cache writes
+ * for documents that degraded, so transient provider failures heal on the
+ * next compile instead of being served from cache for months.
+ */
+let embedDegradationCount = 0
+
+export function recordEmbedDegradation(url: string, reason: string) {
+	embedDegradationCount++
+	console.warn(`[mdx:embed-degraded] ${url} (${reason})`)
+}
+
+export function getEmbedDegradationCount() {
+	return embedDegradationCount
+}

--- a/services/site/app/utils/x.server.ts
+++ b/services/site/app/utils/x.server.ts
@@ -5,6 +5,7 @@ import rehypeParse from 'rehype-parse'
 import { unified } from 'unified'
 import { visit } from 'unist-util-visit'
 import { cache, lruCache } from './cache.server.ts'
+import { recordEmbedDegradation } from './embed-degradation.server.ts'
 import { getEnv } from './env.server.ts'
 import { fetchWithTimeout } from './fetch-with-timeout.server.ts'
 import { formatDate, formatNumber, typedBoolean } from './misc.ts'
@@ -423,16 +424,29 @@ async function buildTweetHTML(tweet: Tweet, expandQuotedTweet: boolean) {
 }
 
 async function getTweetEmbedHTML(urlString: string) {
-	return cachified(
-		{
-			key: `tweet:embed:${urlString}`,
-			ttl: 1000 * 60 * 60 * 24,
-			cache,
-			staleWhileRevalidate: 1000 * 60 * 60 * 24 * 30 * 6,
-			getFreshValue: () => getTweetEmbedHTMLImpl(urlString),
-		},
-		verboseReporter(),
-	)
+	try {
+		return await cachified(
+			{
+				key: `tweet:embed:${urlString}`,
+				ttl: 1000 * 60 * 60 * 24,
+				cache,
+				staleWhileRevalidate: 1000 * 60 * 60 * 24 * 30 * 6,
+				// Failure placeholders must never be cached (or reused from older
+				// cache entries): a transient 𝕏 API failure would otherwise be
+				// served from the persistent cache until the entry expires.
+				checkValue: (value) =>
+					typeof value === 'string' &&
+					value.length > 0 &&
+					!value.includes('<callout-danger'),
+				getFreshValue: () => getTweetEmbedHTMLImpl(urlString),
+			},
+			verboseReporter(),
+		)
+	} catch (error: unknown) {
+		console.error('Error processing tweet', { urlString, error })
+		recordEmbedDegradation(urlString, '𝕏 post data not available')
+		return `<callout-danger>𝕏 post data not available: <a href="${urlString}">${urlString}</a></callout-danger>`
+	}
 }
 
 async function getTweetEmbedHTMLImpl(urlString: string) {
@@ -440,27 +454,13 @@ async function getTweetEmbedHTMLImpl(urlString: string) {
 	const tweetId = url.pathname.split('/').pop()
 
 	if (!tweetId) {
-		console.error('TWEET ID NOT FOUND', urlString, tweetId)
-		return ''
+		throw new Error(`Tweet ID not found in ${urlString}`)
 	}
-	let tweet: Awaited<ReturnType<typeof getTweet>> = null
-	const failureHtml = `<callout-danger>𝕏 post data not available: <a href="${urlString}">${urlString}</a></callout-danger>`
-	try {
-		tweet = await getTweetCached(tweetId)
-		if (!tweet) {
-			return failureHtml
-		}
-		const html = await buildTweetHTML(tweet, true)
-		return html
-	} catch (error: unknown) {
-		console.error('Error processing tweet', {
-			urlString,
-			tweetId,
-			error,
-			tweet,
-		})
-		return failureHtml
+	const tweet = await getTweetCached(tweetId)
+	if (!tweet) {
+		throw new Error(`𝕏 post data not available: ${urlString}`)
 	}
+	return buildTweetHTML(tweet, true)
 }
 
 function isXUrl(urlString: string) {

--- a/services/site/other/mdx-artifacts/__tests__/compile-cache.test.ts
+++ b/services/site/other/mdx-artifacts/__tests__/compile-cache.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { expect, test } from 'vitest'
 import { type MdxArtifactDocument } from '../../../types/mdx-artifacts.ts'
 import {
+	getOrCompileCachedDocument,
 	pruneCompiledDocumentCache,
 	readCachedCompiledDocument,
 	writeCachedCompiledDocument,
@@ -72,6 +73,48 @@ test('compile cache misses when nothing was written', async () => {
 		inputHash: 'hash-1',
 	})
 	expect(cached).toBeNull()
+})
+
+test('embed-fallback compiles are not written to the document cache', async () => {
+	await using cache = createTempCacheDir()
+	const fallbackResult = await getOrCompileCachedDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+		allowCacheWrite: false,
+		compile: async () => createDocument('my-post'),
+	})
+	expect(fallbackResult.reused).toBe(false)
+
+	// A later strict run must not reuse fallback-mode output.
+	const cached = await readCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+	})
+	expect(cached).toBeNull()
+})
+
+test('strict compiles are reused by later runs, including fallback runs', async () => {
+	await using cache = createTempCacheDir()
+	const document = createDocument('my-post')
+	await getOrCompileCachedDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+		allowCacheWrite: true,
+		compile: async () => document,
+	})
+	const rerun = await getOrCompileCachedDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+		allowCacheWrite: false,
+		compile: async () => {
+			throw new Error('should not recompile a cached document')
+		},
+	})
+	expect(rerun).toEqual({ document, reused: true })
 })
 
 test('prune removes documents whose keys no longer exist', async () => {

--- a/services/site/other/mdx-artifacts/__tests__/compile-cache.test.ts
+++ b/services/site/other/mdx-artifacts/__tests__/compile-cache.test.ts
@@ -75,18 +75,20 @@ test('compile cache misses when nothing was written', async () => {
 	expect(cached).toBeNull()
 })
 
-test('embed-fallback compiles are not written to the document cache', async () => {
+test('degraded compiles are not written to the document cache', async () => {
 	await using cache = createTempCacheDir()
-	const fallbackResult = await getOrCompileCachedDocument({
+	const degradedResult = await getOrCompileCachedDocument({
 		cacheDir: cache.dir,
 		key: 'blog/my-post',
 		inputHash: 'hash-1',
-		allowCacheWrite: false,
-		compile: async () => createDocument('my-post'),
+		compile: async () => ({
+			document: createDocument('my-post'),
+			cacheable: false,
+		}),
 	})
-	expect(fallbackResult.reused).toBe(false)
+	expect(degradedResult.reused).toBe(false)
 
-	// A later strict run must not reuse fallback-mode output.
+	// A later run must not reuse degraded output — it recompiles so it heals.
 	const cached = await readCachedCompiledDocument({
 		cacheDir: cache.dir,
 		key: 'blog/my-post',
@@ -95,21 +97,19 @@ test('embed-fallback compiles are not written to the document cache', async () =
 	expect(cached).toBeNull()
 })
 
-test('strict compiles are reused by later runs, including fallback runs', async () => {
+test('clean compiles are written and reused by later runs', async () => {
 	await using cache = createTempCacheDir()
 	const document = createDocument('my-post')
 	await getOrCompileCachedDocument({
 		cacheDir: cache.dir,
 		key: 'blog/my-post',
 		inputHash: 'hash-1',
-		allowCacheWrite: true,
-		compile: async () => document,
+		compile: async () => ({ document, cacheable: true }),
 	})
 	const rerun = await getOrCompileCachedDocument({
 		cacheDir: cache.dir,
 		key: 'blog/my-post',
 		inputHash: 'hash-1',
-		allowCacheWrite: false,
 		compile: async () => {
 			throw new Error('should not recompile a cached document')
 		},

--- a/services/site/other/mdx-artifacts/__tests__/compile-cache.test.ts
+++ b/services/site/other/mdx-artifacts/__tests__/compile-cache.test.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { type MdxArtifactDocument } from '../../../types/mdx-artifacts.ts'
+import {
+	pruneCompiledDocumentCache,
+	readCachedCompiledDocument,
+	writeCachedCompiledDocument,
+} from '../compile-cache.ts'
+
+function createTempCacheDir() {
+	const dir = path.join(os.tmpdir(), `mdx-compile-cache-${crypto.randomUUID()}`)
+	return {
+		dir,
+		async [Symbol.asyncDispose]() {
+			await fs.rm(dir, { recursive: true, force: true })
+		},
+	}
+}
+
+function createDocument(slug: string): MdxArtifactDocument {
+	return {
+		contentDir: 'blog',
+		slug,
+		code: `var Component = () => null // ${slug}`,
+		esm: `export default () => null // ${slug}`,
+		githubResolvable: true,
+		frontmatter: { title: slug },
+		editLink: `https://example.com/edit/${slug}`,
+	}
+}
+
+test('compile cache round-trips a document for a matching input hash', async () => {
+	await using cache = createTempCacheDir()
+	const document = createDocument('my-post')
+	await writeCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+		document,
+	})
+	const cached = await readCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+	})
+	expect(cached).toEqual(document)
+})
+
+test('compile cache misses when the input hash changed', async () => {
+	await using cache = createTempCacheDir()
+	await writeCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-1',
+		document: createDocument('my-post'),
+	})
+	const cached = await readCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/my-post',
+		inputHash: 'hash-2',
+	})
+	expect(cached).toBeNull()
+})
+
+test('compile cache misses when nothing was written', async () => {
+	await using cache = createTempCacheDir()
+	const cached = await readCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/never-written',
+		inputHash: 'hash-1',
+	})
+	expect(cached).toBeNull()
+})
+
+test('prune removes documents whose keys no longer exist', async () => {
+	await using cache = createTempCacheDir()
+	await writeCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/keep-me',
+		inputHash: 'hash-1',
+		document: createDocument('keep-me'),
+	})
+	await writeCachedCompiledDocument({
+		cacheDir: cache.dir,
+		key: 'blog/delete-me',
+		inputHash: 'hash-1',
+		document: createDocument('delete-me'),
+	})
+
+	await pruneCompiledDocumentCache({
+		cacheDir: cache.dir,
+		validKeys: ['blog/keep-me'],
+	})
+
+	expect(
+		await readCachedCompiledDocument({
+			cacheDir: cache.dir,
+			key: 'blog/keep-me',
+			inputHash: 'hash-1',
+		}),
+	).not.toBeNull()
+	expect(
+		await readCachedCompiledDocument({
+			cacheDir: cache.dir,
+			key: 'blog/delete-me',
+			inputHash: 'hash-1',
+		}),
+	).toBeNull()
+})

--- a/services/site/other/mdx-artifacts/__tests__/disk-cache-rpc.test.ts
+++ b/services/site/other/mdx-artifacts/__tests__/disk-cache-rpc.test.ts
@@ -74,6 +74,19 @@ test('disk cache keys filters by prefix', async () => {
 	])
 })
 
+test('disk cache handles concurrent sets for the same key', async () => {
+	await using store = createTempStore()
+	const metadata = { createdTime: Date.now(), ttl: 60_000, swr: 0 }
+	await Promise.all(
+		Array.from({ length: 10 }, (_, index) =>
+			store.rpc.set('tweet:embed:contended', { value: index, metadata }),
+		),
+	)
+	const cached = await store.rpc.get('tweet:embed:contended')
+	expect(cached).not.toBeNull()
+	expect(typeof cached?.value).toBe('number')
+})
+
 test('disk cache survives a corrupt entry file', async () => {
 	await using store = createTempStore()
 	await fs.mkdir(store.dir, { recursive: true })

--- a/services/site/other/mdx-artifacts/__tests__/disk-cache-rpc.test.ts
+++ b/services/site/other/mdx-artifacts/__tests__/disk-cache-rpc.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { createDiskCacheRpc } from '../disk-cache-rpc.ts'
+
+function createTempStore() {
+	const dir = path.join(os.tmpdir(), `mdx-disk-cache-${crypto.randomUUID()}`)
+	return {
+		rpc: createDiskCacheRpc(dir),
+		dir,
+		async [Symbol.asyncDispose]() {
+			await fs.rm(dir, { recursive: true, force: true })
+		},
+	}
+}
+
+test('disk cache round-trips a cachified entry', async () => {
+	await using store = createTempStore()
+	const entry = {
+		value: { html: '<blockquote>tweet</blockquote>' },
+		metadata: { createdTime: Date.now(), ttl: 60_000, swr: 120_000 },
+	}
+	await store.rpc.set('tweet:embed:https://x.com/kentcdodds/status/1', entry)
+	const cached = await store.rpc.get(
+		'tweet:embed:https://x.com/kentcdodds/status/1',
+	)
+	expect(cached).toEqual(entry)
+})
+
+test('disk cache returns null for a missing key', async () => {
+	await using store = createTempStore()
+	expect(await store.rpc.get('tweet:embed:missing')).toBeNull()
+})
+
+test('disk cache drops entries past their total ttl', async () => {
+	await using store = createTempStore()
+	await store.rpc.set('tweet:embed:expired', {
+		value: 'stale',
+		metadata: { createdTime: Date.now() - 10_000, ttl: 1_000, swr: 1_000 },
+	})
+	expect(await store.rpc.get('tweet:embed:expired')).toBeNull()
+})
+
+test('disk cache keeps entries that are stale but within swr', async () => {
+	await using store = createTempStore()
+	const entry = {
+		value: 'stale-but-usable',
+		metadata: { createdTime: Date.now() - 10_000, ttl: 1_000, swr: 60_000 },
+	}
+	await store.rpc.set('tweet:embed:swr', entry)
+	expect(await store.rpc.get('tweet:embed:swr')).toEqual(entry)
+})
+
+test('disk cache delete removes the entry', async () => {
+	await using store = createTempStore()
+	await store.rpc.set('mermaid:svg:default:abc', {
+		value: '<svg></svg>',
+		metadata: { createdTime: Date.now(), ttl: 60_000, swr: 0 },
+	})
+	await store.rpc.delete('mermaid:svg:default:abc')
+	expect(await store.rpc.get('mermaid:svg:default:abc')).toBeNull()
+})
+
+test('disk cache keys filters by prefix', async () => {
+	await using store = createTempStore()
+	const metadata = { createdTime: Date.now(), ttl: 60_000, swr: 0 }
+	await store.rpc.set('tweet:embed:a', { value: 1, metadata })
+	await store.rpc.set('tweet:embed:b', { value: 2, metadata })
+	await store.rpc.set('mermaid:svg:default:c', { value: 3, metadata })
+	expect(await store.rpc.keys('tweet:embed:')).toEqual([
+		'tweet:embed:a',
+		'tweet:embed:b',
+	])
+})
+
+test('disk cache survives a corrupt entry file', async () => {
+	await using store = createTempStore()
+	await fs.mkdir(store.dir, { recursive: true })
+	await fs.writeFile(path.join(store.dir, 'corrupt.json'), '{not json', 'utf8')
+	expect(await store.rpc.get('anything')).toBeNull()
+	expect(await store.rpc.keys()).toEqual([])
+})

--- a/services/site/other/mdx-artifacts/compile-cache.ts
+++ b/services/site/other/mdx-artifacts/compile-cache.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { type MdxArtifactDocument } from '../../types/mdx-artifacts.ts'
+
+/**
+ * Persistent per-document compile cache for the production MDX compiler.
+ * Each document is stored as documents/{contentDir}/{slug}.json alongside the
+ * input hash that produced it (see document-input-hash.ts). Unchanged
+ * documents are reused instead of recompiled — including their baked-in
+ * resolved embeds — which is what makes warm deploy compiles fast.
+ */
+type CachedCompiledDocument = {
+	inputHash: string
+	document: MdxArtifactDocument
+}
+
+function documentCachePath(cacheDir: string, key: string) {
+	return path.join(cacheDir, 'documents', `${key}.json`)
+}
+
+export async function readCachedCompiledDocument({
+	cacheDir,
+	key,
+	inputHash,
+}: {
+	cacheDir: string
+	key: string
+	inputHash: string
+}): Promise<MdxArtifactDocument | null> {
+	let stored: CachedCompiledDocument | null
+	try {
+		stored = JSON.parse(
+			await fs.readFile(documentCachePath(cacheDir, key), 'utf8'),
+		) as CachedCompiledDocument | null
+	} catch {
+		return null
+	}
+	if (!stored || stored.inputHash !== inputHash) return null
+	const document = stored.document
+	if (
+		!document ||
+		typeof document.code !== 'string' ||
+		typeof document.esm !== 'string' ||
+		typeof document.slug !== 'string'
+	) {
+		return null
+	}
+	return document
+}
+
+export async function writeCachedCompiledDocument({
+	cacheDir,
+	key,
+	inputHash,
+	document,
+}: {
+	cacheDir: string
+	key: string
+	inputHash: string
+	document: MdxArtifactDocument
+}) {
+	const filePath = documentCachePath(cacheDir, key)
+	await fs.mkdir(path.dirname(filePath), { recursive: true })
+	const stored: CachedCompiledDocument = { inputHash, document }
+	const tempPath = `${filePath}.${process.pid}.tmp`
+	await fs.writeFile(tempPath, JSON.stringify(stored), 'utf8')
+	await fs.rename(tempPath, filePath)
+}
+
+/** Remove cached documents whose keys no longer exist (deleted posts). */
+export async function pruneCompiledDocumentCache({
+	cacheDir,
+	validKeys,
+}: {
+	cacheDir: string
+	validKeys: Array<string>
+}) {
+	const documentsDir = path.join(cacheDir, 'documents')
+	const valid = new Set(validKeys)
+	let contentDirs: Array<string>
+	try {
+		contentDirs = await fs.readdir(documentsDir)
+	} catch {
+		return
+	}
+	for (const contentDir of contentDirs) {
+		let fileNames: Array<string>
+		try {
+			fileNames = await fs.readdir(path.join(documentsDir, contentDir))
+		} catch {
+			continue
+		}
+		for (const fileName of fileNames) {
+			if (!fileName.endsWith('.json')) continue
+			const key = `${contentDir}/${fileName.slice(0, -'.json'.length)}`
+			if (valid.has(key)) continue
+			await fs.rm(path.join(documentsDir, contentDir, fileName), {
+				force: true,
+			})
+		}
+	}
+}

--- a/services/site/other/mdx-artifacts/compile-cache.ts
+++ b/services/site/other/mdx-artifacts/compile-cache.ts
@@ -73,29 +73,28 @@ export async function writeCachedCompiledDocument({
 }
 
 /**
- * Cache-or-compile for one document. Cache writes are skipped in embed
- * fallback mode: a fallback compile can bake plain links in place of failed
- * embeds, and a later strict run must never reuse that degraded output.
- * Reads stay enabled — everything already in the cache was written by a
- * strict compile.
+ * Cache-or-compile for one document. The compile callback reports whether its
+ * output is safe to persist (`cacheable: false` when any embed degraded
+ * during the compile — failed tweet callout, remark-embedder error HTML,
+ * mermaid render failure, fallback plain link — or when the document's inputs
+ * changed mid-compile). Degraded output is still used for this run's bundle
+ * (pre-existing behavior) but is recompiled next run so it can heal.
  */
 export async function getOrCompileCachedDocument({
 	cacheDir,
 	key,
 	inputHash,
-	allowCacheWrite,
 	compile,
 }: {
 	cacheDir: string
 	key: string
 	inputHash: string
-	allowCacheWrite: boolean
-	compile: () => Promise<MdxArtifactDocument>
+	compile: () => Promise<{ document: MdxArtifactDocument; cacheable: boolean }>
 }): Promise<{ document: MdxArtifactDocument; reused: boolean }> {
 	const cached = await readCachedCompiledDocument({ cacheDir, key, inputHash })
 	if (cached) return { document: cached, reused: true }
-	const document = await compile()
-	if (allowCacheWrite) {
+	const { document, cacheable } = await compile()
+	if (cacheable) {
 		await writeCachedCompiledDocument({ cacheDir, key, inputHash, document })
 	}
 	return { document, reused: false }

--- a/services/site/other/mdx-artifacts/compile-cache.ts
+++ b/services/site/other/mdx-artifacts/compile-cache.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { type MdxArtifactDocument } from '../../types/mdx-artifacts.ts'
@@ -62,9 +63,42 @@ export async function writeCachedCompiledDocument({
 	const filePath = documentCachePath(cacheDir, key)
 	await fs.mkdir(path.dirname(filePath), { recursive: true })
 	const stored: CachedCompiledDocument = { inputHash, document }
-	const tempPath = `${filePath}.${process.pid}.tmp`
-	await fs.writeFile(tempPath, JSON.stringify(stored), 'utf8')
-	await fs.rename(tempPath, filePath)
+	const tempPath = `${filePath}.${randomUUID()}.tmp`
+	try {
+		await fs.writeFile(tempPath, JSON.stringify(stored), 'utf8')
+		await fs.rename(tempPath, filePath)
+	} finally {
+		await fs.rm(tempPath, { force: true })
+	}
+}
+
+/**
+ * Cache-or-compile for one document. Cache writes are skipped in embed
+ * fallback mode: a fallback compile can bake plain links in place of failed
+ * embeds, and a later strict run must never reuse that degraded output.
+ * Reads stay enabled — everything already in the cache was written by a
+ * strict compile.
+ */
+export async function getOrCompileCachedDocument({
+	cacheDir,
+	key,
+	inputHash,
+	allowCacheWrite,
+	compile,
+}: {
+	cacheDir: string
+	key: string
+	inputHash: string
+	allowCacheWrite: boolean
+	compile: () => Promise<MdxArtifactDocument>
+}): Promise<{ document: MdxArtifactDocument; reused: boolean }> {
+	const cached = await readCachedCompiledDocument({ cacheDir, key, inputHash })
+	if (cached) return { document: cached, reused: true }
+	const document = await compile()
+	if (allowCacheWrite) {
+		await writeCachedCompiledDocument({ cacheDir, key, inputHash, document })
+	}
+	return { document, reused: false }
 }
 
 /** Remove cached documents whose keys no longer exist (deleted posts). */

--- a/services/site/other/mdx-artifacts/compile-mdx-artifacts.ts
+++ b/services/site/other/mdx-artifacts/compile-mdx-artifacts.ts
@@ -14,9 +14,8 @@ import {
 import { setRuntimeBindingSource } from '#app/utils/runtime-bindings.server.ts'
 import { type MdxArtifactBundle } from '../../types/mdx-artifacts.ts'
 import {
+	getOrCompileCachedDocument,
 	pruneCompiledDocumentCache,
-	readCachedCompiledDocument,
-	writeCachedCompiledDocument,
 } from './compile-cache.ts'
 import { compileMdxArtifactDocument } from './compile-document.ts'
 import { computeContentVersion } from './content-version.ts'
@@ -120,9 +119,11 @@ function filterDocuments(
 async function compileDocumentWithCache({
 	document,
 	cacheDir,
+	allowEmbedFallback,
 }: {
 	document: MdxDocumentRef
 	cacheDir: string | null
+	allowEmbedFallback: boolean
 }) {
 	if (!cacheDir) {
 		return {
@@ -131,20 +132,13 @@ async function compileDocumentWithCache({
 		}
 	}
 	const inputHash = await computeDocumentInputHash(document)
-	const cached = await readCachedCompiledDocument({
+	return getOrCompileCachedDocument({
 		cacheDir,
 		key: document.key,
 		inputHash,
+		allowCacheWrite: !allowEmbedFallback,
+		compile: () => compileMdxArtifactDocument(document),
 	})
-	if (cached) return { document: cached, reused: true }
-	const compiled = await compileMdxArtifactDocument(document)
-	await writeCachedCompiledDocument({
-		cacheDir,
-		key: document.key,
-		inputHash,
-		document: compiled,
-	})
-	return { document: compiled, reused: false }
 }
 
 async function main() {
@@ -174,7 +168,11 @@ async function main() {
 			limit(async () => {
 				try {
 					const { document: compiled, reused } = await compileDocumentWithCache(
-						{ document, cacheDir: options.cacheDir },
+						{
+							document,
+							cacheDir: options.cacheDir,
+							allowEmbedFallback: options.allowEmbedFallback,
+						},
 					)
 					if (reused) reusedCount++
 					return [document.key, compiled] as const

--- a/services/site/other/mdx-artifacts/compile-mdx-artifacts.ts
+++ b/services/site/other/mdx-artifacts/compile-mdx-artifacts.ts
@@ -7,6 +7,7 @@ import {
 	configureMdxCompileOptions,
 	getEmbedFallbackCount,
 } from '#app/utils/compile-mdx.server.ts'
+import { getEmbedDegradationCount } from '#app/utils/embed-degradation.server.ts'
 import {
 	getLocalBlogMdxListItemsUncached,
 	getLocalMdxDirList,
@@ -119,11 +120,9 @@ function filterDocuments(
 async function compileDocumentWithCache({
 	document,
 	cacheDir,
-	allowEmbedFallback,
 }: {
 	document: MdxDocumentRef
 	cacheDir: string | null
-	allowEmbedFallback: boolean
 }) {
 	if (!cacheDir) {
 		return {
@@ -136,8 +135,29 @@ async function compileDocumentWithCache({
 		cacheDir,
 		key: document.key,
 		inputHash,
-		allowCacheWrite: !allowEmbedFallback,
-		compile: () => compileMdxArtifactDocument(document),
+		compile: async () => {
+			// The degradation counter is global, so under --concurrency > 1 a
+			// degradation in an overlapping compile can also mark this document
+			// uncacheable. That only causes a recompile next run — never a
+			// degraded document persisted in the cache.
+			const degradationsBefore = getEmbedDegradationCount()
+			const compiled = await compileMdxArtifactDocument(document)
+			const degraded = getEmbedDegradationCount() > degradationsBefore
+			// Guard against inputs changing mid-compile (mirrors the dev
+			// watcher): never store output under a hash it may not match.
+			const inputsChanged =
+				(await computeDocumentInputHash(document)) !== inputHash
+			if (degraded || inputsChanged) {
+				console.warn(
+					`[mdx:compile-cache] not caching ${document.key} (${
+						degraded
+							? 'embeds degraded during compile'
+							: 'inputs changed mid-compile'
+					})`,
+				)
+			}
+			return { document: compiled, cacheable: !degraded && !inputsChanged }
+		},
 	})
 }
 
@@ -168,11 +188,7 @@ async function main() {
 			limit(async () => {
 				try {
 					const { document: compiled, reused } = await compileDocumentWithCache(
-						{
-							document,
-							cacheDir: options.cacheDir,
-							allowEmbedFallback: options.allowEmbedFallback,
-						},
+						{ document, cacheDir: options.cacheDir },
 					)
 					if (reused) reusedCount++
 					return [document.key, compiled] as const
@@ -248,6 +264,7 @@ async function main() {
 				compiled: documents.length - reusedCount,
 				failures: failures.length,
 				embedFallbacks: getEmbedFallbackCount(),
+				embedDegradations: getEmbedDegradationCount(),
 				bundleBytes: Buffer.byteLength(serialized, 'utf8'),
 				elapsedMs,
 				largestDocs: docSizes.slice(0, 10),

--- a/services/site/other/mdx-artifacts/compile-mdx-artifacts.ts
+++ b/services/site/other/mdx-artifacts/compile-mdx-artifacts.ts
@@ -11,9 +11,17 @@ import {
 	getLocalBlogMdxListItemsUncached,
 	getLocalMdxDirList,
 } from '#app/utils/mdx.server.ts'
+import { setRuntimeBindingSource } from '#app/utils/runtime-bindings.server.ts'
 import { type MdxArtifactBundle } from '../../types/mdx-artifacts.ts'
+import {
+	pruneCompiledDocumentCache,
+	readCachedCompiledDocument,
+	writeCachedCompiledDocument,
+} from './compile-cache.ts'
 import { compileMdxArtifactDocument } from './compile-document.ts'
 import { computeContentVersion } from './content-version.ts'
+import { createDiskCacheRpc } from './disk-cache-rpc.ts'
+import { computeDocumentInputHash } from './document-input-hash.ts'
 import {
 	collectContentInputFiles,
 	discoverLocalMdxDocuments,
@@ -26,6 +34,7 @@ type CliOptions = {
 	concurrency: number
 	only: Array<string> | null
 	allowEmbedFallback: boolean
+	cacheDir: string | null
 }
 
 function parseArgs(argv: Array<string>): CliOptions {
@@ -33,11 +42,25 @@ function parseArgs(argv: Array<string>): CliOptions {
 	let concurrency = 1
 	let only: Array<string> | null = null
 	let allowEmbedFallback = false
+	let cacheDir: string | null = path.join(
+		process.cwd(),
+		'node_modules/.cache/mdx-artifacts',
+	)
 
 	for (let index = 0; index < argv.length; index++) {
 		const arg = argv[index]
 		if (arg === '--out') {
 			out = argv[++index] ?? out
+			continue
+		}
+		if (arg === '--cache-dir') {
+			const value = argv[++index]
+			if (!value) throw new Error('--cache-dir requires a path')
+			cacheDir = path.resolve(value)
+			continue
+		}
+		if (arg === '--no-cache') {
+			cacheDir = null
 			continue
 		}
 		if (arg === '--concurrency') {
@@ -68,7 +91,7 @@ function parseArgs(argv: Array<string>): CliOptions {
 		throw new Error(`Unknown argument: ${arg}`)
 	}
 
-	return { out, concurrency, only, allowEmbedFallback }
+	return { out, concurrency, only, allowEmbedFallback, cacheDir }
 }
 
 function printHelp() {
@@ -79,6 +102,9 @@ Options:
   --concurrency <n>      Parallel compile workers (default: 1)
   --only <keys>          Comma-separated document keys (e.g. blog/foo,pages/uses)
   --allow-embed-fallback Log and continue when embed network calls fail (plain link)
+  --cache-dir <path>     Persistent compile cache directory
+                         (default: node_modules/.cache/mdx-artifacts)
+  --no-cache             Disable the persistent compile cache
 `)
 }
 
@@ -91,10 +117,48 @@ function filterDocuments(
 	return documents.filter((document) => allowed.has(document.key))
 }
 
+async function compileDocumentWithCache({
+	document,
+	cacheDir,
+}: {
+	document: MdxDocumentRef
+	cacheDir: string | null
+}) {
+	if (!cacheDir) {
+		return {
+			document: await compileMdxArtifactDocument(document),
+			reused: false,
+		}
+	}
+	const inputHash = await computeDocumentInputHash(document)
+	const cached = await readCachedCompiledDocument({
+		cacheDir,
+		key: document.key,
+		inputHash,
+	})
+	if (cached) return { document: cached, reused: true }
+	const compiled = await compileMdxArtifactDocument(document)
+	await writeCachedCompiledDocument({
+		cacheDir,
+		key: document.key,
+		inputHash,
+		document: compiled,
+	})
+	return { document: compiled, reused: false }
+}
+
 async function main() {
 	const startedAt = Date.now()
 	const options = parseArgs(process.argv.slice(2))
 	configureMdxCompileOptions({ allowEmbedFallback: options.allowEmbedFallback })
+	if (options.cacheDir) {
+		// Persist cachified values (tweet embed HTML, oEmbed responses, mermaid
+		// SVGs) to disk so recompiles of changed documents reuse resolved embeds
+		// instead of re-fetching them.
+		setRuntimeBindingSource({
+			CACHE_RPC: createDiskCacheRpc(path.join(options.cacheDir, 'cachified')),
+		})
+	}
 	const allDocuments = await discoverLocalMdxDocuments()
 	const documents = filterDocuments(allDocuments, options.only)
 
@@ -104,11 +168,15 @@ async function main() {
 
 	const limit = pLimit(options.concurrency)
 	const failures: Array<{ key: string; error: string }> = []
+	let reusedCount = 0
 	const compiledEntries = await Promise.all(
 		documents.map((document) =>
 			limit(async () => {
 				try {
-					const compiled = await compileMdxArtifactDocument(document)
+					const { document: compiled, reused } = await compileDocumentWithCache(
+						{ document, cacheDir: options.cacheDir },
+					)
+					if (reused) reusedCount++
 					return [document.key, compiled] as const
 				} catch (error: unknown) {
 					const message = error instanceof Error ? error.message : String(error)
@@ -124,6 +192,13 @@ async function main() {
 			console.error(`FAILED ${failure.key}: ${failure.error}`)
 		}
 		throw new Error(`${failures.length} document(s) failed to compile`)
+	}
+
+	if (options.cacheDir) {
+		await pruneCompiledDocumentCache({
+			cacheDir: options.cacheDir,
+			validKeys: allDocuments.map((document) => document.key),
+		})
 	}
 
 	const bundleDocuments: MdxArtifactBundle['documents'] = {}
@@ -171,6 +246,8 @@ async function main() {
 		JSON.stringify(
 			{
 				documents: documents.length,
+				reusedFromCache: reusedCount,
+				compiled: documents.length - reusedCount,
 				failures: failures.length,
 				embedFallbacks: getEmbedFallbackCount(),
 				bundleBytes: Buffer.byteLength(serialized, 'utf8'),

--- a/services/site/other/mdx-artifacts/dev-watcher.ts
+++ b/services/site/other/mdx-artifacts/dev-watcher.ts
@@ -14,17 +14,15 @@ import {
 	getLocalBlogMdxListItemsUncached,
 	getLocalMdxDirList,
 } from '#app/utils/mdx.server.ts'
+import { setRuntimeBindingSource } from '#app/utils/runtime-bindings.server.ts'
 import { type MdxArtifactBundle } from '../../types/mdx-artifacts.ts'
 import { compileMdxArtifactDocument } from './compile-document.ts'
-import {
-	ARTIFACT_COMPILER_VERSION,
-	computeContentVersion,
-} from './content-version.ts'
+import { computeContentVersion } from './content-version.ts'
+import { createDiskCacheRpc } from './disk-cache-rpc.ts'
+import { computeDocumentInputHash } from './document-input-hash.ts'
 import {
 	collectContentInputFiles,
 	discoverLocalMdxDocuments,
-	readLocalMdxFiles,
-	readLocalMdxParentDirList,
 	readLocalDataFiles,
 	type MdxDocumentRef,
 } from './local-content.ts'
@@ -178,41 +176,6 @@ async function writeManifest(
 		`export default ${JSON.stringify(manifest)}`,
 		'utf8',
 	)
-}
-
-async function computeDocumentInputHash(document: MdxDocumentRef) {
-	const [download, parentDirList] = await Promise.all([
-		readLocalMdxFiles(document.contentDir, document.slug),
-		readLocalMdxParentDirList(document.contentDir),
-	])
-	if (!download) {
-		throw new Error(`Missing local MDX content for ${document.key}`)
-	}
-
-	const hash = createHash('sha256')
-	hash.update(`compiler:${ARTIFACT_COMPILER_VERSION}`)
-	hash.update('\0')
-	hash.update(document.key)
-	hash.update('\0')
-	hash.update(download.entry)
-	hash.update('\0')
-	for (const file of [...download.files].sort((a, b) =>
-		a.path.localeCompare(b.path),
-	)) {
-		hash.update(file.path)
-		hash.update('\0')
-		hash.update(file.content)
-		hash.update('\0')
-	}
-	for (const entry of [...parentDirList].sort((a, b) =>
-		a.name.localeCompare(b.name),
-	)) {
-		hash.update(entry.name)
-		hash.update('\0')
-		hash.update(entry.type)
-		hash.update('\0')
-	}
-	return hash.digest('hex')
 }
 
 async function compileDocument(document: MdxDocumentRef) {
@@ -488,6 +451,11 @@ async function startSidecarServer() {
 
 async function main() {
 	const startedAt = Date.now()
+	// Persist cachified values (tweet embed HTML, oEmbed responses, mermaid
+	// SVGs) to disk so recompiling a changed document reuses resolved embeds.
+	setRuntimeBindingSource({
+		CACHE_RPC: createDiskCacheRpc(path.join(CACHE_ROOT, 'cachified')),
+	})
 	const server = await startSidecarServer()
 	if (compileOnce) {
 		try {

--- a/services/site/other/mdx-artifacts/disk-cache-rpc.ts
+++ b/services/site/other/mdx-artifacts/disk-cache-rpc.ts
@@ -1,0 +1,111 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { totalTtl, type CacheEntry } from '@epic-web/cachified'
+import {
+	decodeCacheEntry,
+	encodeCacheEntry,
+} from '#app/utils/cache-encoding.server.ts'
+
+/**
+ * Disk-backed cachified store with the same interface as the production
+ * CACHE_RPC binding. The Node-only compile processes register it as their
+ * runtime binding source so every cachified call in the compile pipeline
+ * (tweet embed HTML, oEmbed responses, mermaid SVGs) persists across runs —
+ * in CI the directory is restored from the Actions cache between deploys.
+ */
+export type DiskCacheRpc = {
+	get(key: string): Promise<CacheEntry<unknown> | null>
+	set(key: string, entry: CacheEntry<unknown>): Promise<void>
+	delete(key: string): Promise<void>
+	keys(prefix?: string, limit?: number): Promise<Array<string>>
+}
+
+type StoredDiskCacheEntry = {
+	key: string
+	value: string
+	metadata: string
+}
+
+function entryFilePath(dir: string, key: string) {
+	const hash = createHash('sha256').update(key).digest('hex').slice(0, 32)
+	return path.join(dir, `${hash}.json`)
+}
+
+function isEntryExpired(entry: CacheEntry<unknown>) {
+	const ttl = totalTtl(entry.metadata)
+	if (!Number.isFinite(ttl)) return false
+	return entry.metadata.createdTime + ttl < Date.now()
+}
+
+async function readStoredEntry(filePath: string) {
+	try {
+		const stored = JSON.parse(
+			await fs.readFile(filePath, 'utf8'),
+		) as StoredDiskCacheEntry | null
+		if (
+			!stored ||
+			typeof stored.key !== 'string' ||
+			typeof stored.value !== 'string' ||
+			typeof stored.metadata !== 'string'
+		) {
+			return null
+		}
+		return stored
+	} catch {
+		return null
+	}
+}
+
+export function createDiskCacheRpc(dir: string): DiskCacheRpc {
+	return {
+		async get(key) {
+			const filePath = entryFilePath(dir, key)
+			const stored = await readStoredEntry(filePath)
+			if (!stored || stored.key !== key) return null
+			let entry: CacheEntry<unknown> | null
+			try {
+				entry = decodeCacheEntry(stored)
+			} catch {
+				entry = null
+			}
+			if (!entry || isEntryExpired(entry)) {
+				await fs.rm(filePath, { force: true })
+				return null
+			}
+			return entry
+		},
+		async set(key, entry) {
+			await fs.mkdir(dir, { recursive: true })
+			const filePath = entryFilePath(dir, key)
+			const stored: StoredDiskCacheEntry = { key, ...encodeCacheEntry(entry) }
+			// Write-then-rename so an interrupted write (e.g. a background
+			// stale-while-revalidate refresh cut off at process exit) never leaves
+			// a truncated JSON file behind.
+			const tempPath = `${filePath}.${process.pid}.tmp`
+			await fs.writeFile(tempPath, JSON.stringify(stored), 'utf8')
+			await fs.rename(tempPath, filePath)
+		},
+		async delete(key) {
+			await fs.rm(entryFilePath(dir, key), { force: true })
+		},
+		async keys(prefix, limit = 100) {
+			let fileNames: Array<string>
+			try {
+				fileNames = await fs.readdir(dir)
+			} catch {
+				return []
+			}
+			const keys: Array<string> = []
+			for (const fileName of fileNames) {
+				if (!fileName.endsWith('.json')) continue
+				const stored = await readStoredEntry(path.join(dir, fileName))
+				if (!stored) continue
+				if (prefix && !stored.key.startsWith(prefix)) continue
+				keys.push(stored.key)
+				if (keys.length >= limit) break
+			}
+			return keys.sort()
+		},
+	}
+}

--- a/services/site/other/mdx-artifacts/disk-cache-rpc.ts
+++ b/services/site/other/mdx-artifacts/disk-cache-rpc.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { totalTtl, type CacheEntry } from '@epic-web/cachified'
@@ -81,10 +81,15 @@ export function createDiskCacheRpc(dir: string): DiskCacheRpc {
 			const stored: StoredDiskCacheEntry = { key, ...encodeCacheEntry(entry) }
 			// Write-then-rename so an interrupted write (e.g. a background
 			// stale-while-revalidate refresh cut off at process exit) never leaves
-			// a truncated JSON file behind.
-			const tempPath = `${filePath}.${process.pid}.tmp`
-			await fs.writeFile(tempPath, JSON.stringify(stored), 'utf8')
-			await fs.rename(tempPath, filePath)
+			// a truncated JSON file behind. The temp name is unique per call so
+			// concurrent sets for the same key never race on the same temp file.
+			const tempPath = `${filePath}.${randomUUID()}.tmp`
+			try {
+				await fs.writeFile(tempPath, JSON.stringify(stored), 'utf8')
+				await fs.rename(tempPath, filePath)
+			} finally {
+				await fs.rm(tempPath, { force: true })
+			}
 		},
 		async delete(key) {
 			await fs.rm(entryFilePath(dir, key), { force: true })

--- a/services/site/other/mdx-artifacts/document-input-hash.ts
+++ b/services/site/other/mdx-artifacts/document-input-hash.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto'
+import { ARTIFACT_COMPILER_VERSION } from './content-version.ts'
+import {
+	readLocalMdxFiles,
+	readLocalMdxParentDirList,
+	type MdxDocumentRef,
+} from './local-content.ts'
+
+/**
+ * Hash of everything that determines a single document's compiled output:
+ * the compiler version, the document's own files, and the parent directory
+ * listing (which feeds GitHub path resolvability). Shared by the dev watcher
+ * and the production compiler so both reuse caches on the same terms.
+ */
+export async function computeDocumentInputHash(document: MdxDocumentRef) {
+	const [download, parentDirList] = await Promise.all([
+		readLocalMdxFiles(document.contentDir, document.slug),
+		readLocalMdxParentDirList(document.contentDir),
+	])
+	if (!download) {
+		throw new Error(`Missing local MDX content for ${document.key}`)
+	}
+
+	const hash = createHash('sha256')
+	hash.update(`compiler:${ARTIFACT_COMPILER_VERSION}`)
+	hash.update('\0')
+	hash.update(document.key)
+	hash.update('\0')
+	hash.update(download.entry)
+	hash.update('\0')
+	for (const file of [...download.files].sort((a, b) =>
+		a.path.localeCompare(b.path),
+	)) {
+		hash.update(file.path)
+		hash.update('\0')
+		hash.update(file.content)
+		hash.update('\0')
+	}
+	for (const entry of [...parentDirList].sort((a, b) =>
+		a.name.localeCompare(b.name),
+	)) {
+		hash.update(entry.name)
+		hash.update('\0')
+		hash.update(entry.type)
+		hash.update('\0')
+	}
+	return hash.digest('hex')
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production `mdx:compile` recompiled all ~227 MDX documents from scratch on every deploy and content refresh, re-fetching every tweet embed, oEmbed response, and mermaid SVG each time. The cachified KV cache (`tweet:embed:*` etc.) is a no-op in that Node process because no `CACHE_RPC`/`SITE_CACHE_KV` bindings exist there — only the dev watcher had a persistent disk cache.

## Changes

**Per-document compile cache** (`compile-cache.ts`): full compiled documents (IIFE + ESM + enrichment) are stored under `node_modules/.cache/mdx-artifacts/documents/{contentDir}/{slug}.json`, keyed by the same input hash the dev watcher already used (compiler version + document files + parent dir listing — extracted to a shared `document-input-hash.ts`). Unchanged documents are reused without recompiling. Stale entries for deleted posts are pruned each run. `--cache-dir` overrides the location, `--no-cache` disables it.

**Persistent embed-element cache** (`disk-cache-rpc.ts`): a disk-backed cachified store with the `CACHE_RPC` interface, registered as the runtime binding source in `compile-mdx-artifacts.ts` and `dev-watcher.ts`. Every cachified call in the compile pipeline — tweet embed HTML, oEmbed responses — now persists across runs, so a *changed* document reuses its resolved embeds instead of re-fetching them. Normal cachified TTL/SWR semantics still apply, so stale entries refresh in the background.

**Mermaid SVGs cached**: `getMermaidSvg` previously used a raw uncached fetch; it now goes through cachified (`mermaid:svg:{theme}:{hash}`) with the same failure behavior (render failure keeps the code block as text, nothing cached).

**Degraded embeds never enter the caches** (Bugbot finding): tweet failure callouts are never stored in the cachified store (`checkValue` + throw-on-failure in `x.server.ts`), and any document whose compile hit an embed degradation — failed tweet callout, remark-embedder error HTML, mermaid render failure, fallback plain link — is excluded from the document cache (tracked via `embed-degradation.server.ts`, reported as `embedDegradations` in the compile summary). Transient provider failures therefore heal on the next compile instead of persisting. Document cache writes also recompute the input hash post-compile (mirroring the dev watcher) so output is never stored under a stale hash.

**CI wiring**: `deploy-site.yml` and `refresh-content.yml` restore/save `services/site/node_modules/.cache/mdx-artifacts` via `actions/cache` (shared `mdx-artifacts-*` key family, sha-suffixed keys so every run saves an updated cache).

## Measured results (real network, no mocks)

| Run | Documents | Compile time |
| --- | --- | --- |
| Full cold compile | 227 compiled | 84–88s |
| Full warm compile | 217 reused + 10 recompiled | 4.1s |

- The 10 recompiled documents are the ones with genuinely degraded embeds in today's content (a deleted Dan Abramov tweet, dead CodeSandbox/CodePen oEmbeds — 30 degradations total); they are intentionally never cached so they can heal.
- Warm bundle is byte-identical to the cold bundle (same `version`, same documents JSON).
- Degradation wiring verified live: a nonexistent tweet returns the failure callout, records a degradation, and writes nothing to the disk store; a real tweet persists normally.
- Cache size after a full compile: ~20 MB (well within Actions cache limits).

## Correctness notes

- The input hash includes `ARTIFACT_COMPILER_VERSION`, so pipeline changes invalidate the document cache exactly like every other artifact cache layer.
- No compiler output changes for identical inputs (verified byte-identical bundles), so no compiler version bump is needed.
- Cached documents bake in resolved embed HTML — same trade-off the dev watcher and the artifact store already make; documented in `docs/agents/cloudflare-worker-architecture.md` along with the degraded-compile sharp edge.
- Disk cache writes are atomic (unique temp file + rename), safe under `--concurrency`.

## Testing

- New flat vitest coverage: `compile-cache.test.ts` (round-trip, hash mismatch, prune, degraded-compile write gating) and `disk-cache-rpc.test.ts` (round-trip, TTL expiry, SWR retention, prefix listing, concurrent same-key sets, corrupt-file resilience).
- Full backend suite: 88 files / 382 tests pass, including the MDX compile parity tests.
- `typecheck` and `lint` pass (no new warnings).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0c11850-60a7-4eff-b1a5-eb458ffb8af2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0c11850-60a7-4eff-b1a5-eb458ffb8af2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved MDX compilation speed by reusing cached compiled documents across deployments and development sessions.
  * Added caching for rendered Mermaid diagrams and embedded content while preserving expiration behavior.

* **Reliability**
  * Improved recovery from missing, expired, corrupted, or invalid cached data.
  * Mermaid rendering now handles compression, HTTP, and response-format errors gracefully.
  * Prevented degraded content from being reused as cached results.

* **Documentation**
  * Documented persistent MDX caching, invalidation, and reuse behavior.

* **Tests**
  * Added coverage for caching, expiration, cleanup, persistence, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->