### PR TITLE
Fix mailto draft spaces showing as plus signs

### DIFF
--- a/services/site/app/routes/calls_.admin/$callId.tsx
+++ b/services/site/app/routes/calls_.admin/$callId.tsx
@@ -20,6 +20,7 @@ import { MailIcon } from '#app/components/icons.tsx'
 import { Spinner } from '#app/components/spinner.tsx'
 import { H4, H6, Paragraph } from '#app/components/typography.tsx'
 import { type KCDHandle } from '#app/types.ts'
+import { createMailtoHref } from '#app/utils/misc.ts'
 import { formatDate, useDoubleCheck } from '#app/utils/misc-react.tsx'
 import { db } from '#app/utils/db.server.ts'
 import {
@@ -97,10 +98,11 @@ function CallListing({ call }: { call: SerializeFrom<typeof loader>['call'] }) {
 		React.useState(callerTranscript)
 	const callerTranscriptLocked = Boolean(call.episodeDraft)
 	const callerTranscriptError = call.callerTranscriptErrorMessage
-	const mailtoHref = `mailto:${call.user.email}?${new URLSearchParams({
+	const mailtoHref = createMailtoHref({
+		email: call.user.email,
 		subject: `Re: Call Kent - ${call.title}`,
 		body: `I just wanted to talk about your call on the Call Kent podcast`,
-	}).toString()}`
+	})
 
 	React.useEffect(() => {
 		if (!audioEl) return

--- a/services/site/app/utils/__tests__/create-mailto-href.test.ts
+++ b/services/site/app/utils/__tests__/create-mailto-href.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest'
+import { createMailtoHref } from '../misc.ts'
+
+test('createMailtoHref percent-encodes spaces as %20 for email clients', () => {
+	const href = createMailtoHref({
+		email: 'caller@example.com',
+		subject: 'Re: Call Kent - This probably could be an email :)',
+		body: 'I just wanted to talk about your call on the Call Kent podcast',
+	})
+
+	expect(href).toBe(
+		'mailto:caller@example.com?subject=Re%3A%20Call%20Kent%20-%20This%20probably%20could%20be%20an%20email%20%3A)&body=I%20just%20wanted%20to%20talk%20about%20your%20call%20on%20the%20Call%20Kent%20podcast',
+	)
+	expect(href).not.toContain('+')
+})
+
+test('createMailtoHref encodes literal plus signs without turning spaces into +', () => {
+	const href = createMailtoHref({
+		email: 'caller@example.com',
+		subject: 'C++ tips',
+		body: 'a + b',
+	})
+
+	expect(href).toBe(
+		'mailto:caller@example.com?subject=C%2B%2B%20tips&body=a%20%2B%20b',
+	)
+})
+
+test('createMailtoHref omits the query when subject and body are absent', () => {
+	expect(createMailtoHref({ email: 'caller@example.com' })).toBe(
+		'mailto:caller@example.com',
+	)
+})

--- a/services/site/app/utils/misc.ts
+++ b/services/site/app/utils/misc.ts
@@ -143,6 +143,33 @@ export function getDiscordAuthorizeURL(domainUrl: string) {
 }
 
 /**
+ * Build a mailto: href with RFC 3986 percent-encoding.
+ *
+ * Do not use URLSearchParams here: it encodes spaces as `+` (form-urlencoded),
+ * and many email clients treat those as literal plus signs in subject/body.
+ */
+export function createMailtoHref({
+	email,
+	subject,
+	body,
+}: {
+	email: string
+	subject?: string
+	body?: string
+}) {
+	const params: Array<string> = []
+	if (subject !== undefined) {
+		params.push(`subject=${encodeURIComponent(subject)}`)
+	}
+	if (body !== undefined) {
+		params.push(`body=${encodeURIComponent(body)}`)
+	}
+	return params.length > 0
+		? `mailto:${email}?${params.join('&')}`
+		: `mailto:${email}`
+}
+
+/**
  * @returns domain URL (without a ending slash, like: https://kentcdodds.com)
  */
 export function getDomainUrl(request: Request) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clicking the caller email on the Call Kent admin call details page opened a draft where spaces in the subject/body were replaced with `+` (e.g. `Re:+Call+Kent+…`).

`URLSearchParams` encodes spaces as `+` (form-urlencoded). Many email clients treat those as literal plus signs in `mailto:` URLs. This switches to `encodeURIComponent` (`%20`) via a small `createMailtoHref` helper.

## Test plan

- [x] Unit tests cover `%20` encoding, literal `+` handling, and query omission
- [ ] Manually: open `/calls/admin/:callId`, click the email link, confirm subject/body have normal spaces
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-709fdc8c-bf6b-4e0c-b473-d3844733e621?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-709fdc8c-bf6b-4e0c-b473-d3844733e621&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email links so subjects and message bodies are encoded correctly, including spaces and plus signs.
  - Email links now omit empty query parameters when no subject or body is provided.

- **Tests**
  - Added coverage to verify email link formatting and parameter encoding across common scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->