### PR TITLE
Filter Firefox HTML-as-script SyntaxError Sentry noise (KCD-105)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -100,6 +100,14 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   (DOCTYPE payload signature; turbo-stream / Safari pattern require RR stack
   or `.data`/`__manifest` breadcrumbs). Do not broaden to generic
   `Failed to fetch`.
+- Client Firefox `SyntaxError: illegal character U+XXXX` with the HTML page
+  URL as the script filename (often `<!DOCTYPE` in frame context) is the same
+  HTML-where-JS-expected class as Chrome's DOCTYPE JSON SyntaxError, but
+  Firefox reports a C1/control codepoint instead of `Unexpected token '<'`
+  (KCD-105). Filter via `isHtmlDocumentAsScriptNoise` only with that message
+  plus HTML-document evidence (document-path filename or DOCTYPE context) —
+  never the illegal-character phrase alone (a real `.js` bundle with C1
+  controls should still alert).
 - Client `TypeError: … reading 'ok'|'status'` from React Router's
   `fetchAndApplyManifestPatches` / `fetchAndDecodeViaTurboStream` means
   `fetch` resolved to `undefined` (native `fetch` never does). That signature

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -954,8 +954,8 @@ test('filters Firefox HTML-document-as-script illegal character (KCD-105)', () =
 									[
 										1,
 										'<!DOCTYPE html><html lang="en"><head><meta name="viewport"',
-									],
-									[2, '// client hints check'],
+									] as [number, string],
+									[2, '// client hints check'] as [number, string],
 								],
 							},
 						],
@@ -981,6 +981,55 @@ test('filters Firefox HTML-document-as-script illegal character (KCD-105)', () =
 								{
 									filename:
 										'https://kentcdodds.com/blog/how-i-built-a-modern-website-in-2021',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	// absPath fallback when filename is missing.
+	expect(
+		isHtmlDocumentAsScriptNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value: message,
+						stacktrace: {
+							frames: [
+								{
+									absPath:
+										'https://kentcdodds.com/blog/how-i-built-a-modern-website-in-2021',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	// DOCTYPE context alone is enough even if filename looks like an asset.
+	expect(
+		isHtmlDocumentAsScriptNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value: message,
+						stacktrace: {
+							frames: [
+								{
+									filename: '/assets/entry.client-abc123.js',
+									context: [
+										[
+											1,
+											'<!DOCTYPE html><html lang="en"><head>',
+										] as [number, string],
+									],
 								},
 							],
 						},

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -10,6 +10,8 @@ import {
 	isCloudflareEdgeRouteError,
 	isCustomEventUnhandledRejectionNoise,
 	isDegradedUiPerformanceEvent,
+	isHtmlDocumentAsScriptNoise,
+	isHtmlDocumentScriptFilename,
 	isHtmlPageTranslated,
 	isInjectedBlobAddListenerError,
 	isPageTranslatorCallStackOverflow,
@@ -921,6 +923,122 @@ test('filters HTML-as-JSON manifest/data protocol noise (KCD-ZJ)', () => {
 			exception: { values: [{ type: 'SyntaxError', value: message }] },
 		}),
 	).toBe(true)
+})
+
+test('filters Firefox HTML-document-as-script illegal character (KCD-105)', () => {
+	const message = 'illegal character U+009E'
+	expect(matchesIgnoreError(message)).toBe(false)
+	expect(isHtmlDocumentScriptFilename('/blog/how-i-built-a-modern-website-in-2021')).toBe(
+		true,
+	)
+	expect(
+		isHtmlDocumentScriptFilename(
+			'https://kentcdodds.com/assets/entry.client-abc123.js',
+		),
+	).toBe(false)
+
+	const htmlDocumentEvent = {
+		exception: {
+			values: [
+				{
+					type: 'SyntaxError',
+					value: message,
+					stacktrace: {
+						frames: [
+							{
+								filename: '/blog/how-i-built-a-modern-website-in-2021',
+								absPath:
+									'https://kentcdodds.com/blog/how-i-built-a-modern-website-in-2021',
+								inApp: true,
+								context: [
+									[
+										1,
+										'<!DOCTYPE html><html lang="en"><head><meta name="viewport"',
+									],
+									[2, '// client hints check'],
+								],
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+
+	expect(isHtmlDocumentAsScriptNoise(htmlDocumentEvent)).toBe(true)
+	expect(shouldDropSentryEvent(htmlDocumentEvent)).toBe(true)
+
+	// Filename alone (no context) is enough when it is clearly an HTML route.
+	expect(
+		isHtmlDocumentAsScriptNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value: 'illegal character U+009F',
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'https://kentcdodds.com/blog/how-i-built-a-modern-website-in-2021',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(true)
+
+	// Real bundle SyntaxError with the same message must still alert.
+	expect(
+		isHtmlDocumentAsScriptNoise({
+			exception: {
+				values: [
+					{
+						type: 'SyntaxError',
+						value: message,
+						stacktrace: {
+							frames: [
+								{
+									filename: '/assets/entry.client-abc123.js',
+									function: 'moduleEvaluation',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// Message alone / no frames — not enough.
+	expect(
+		isHtmlDocumentAsScriptNoise({
+			exception: {
+				values: [{ type: 'SyntaxError', value: message }],
+			},
+		}),
+	).toBe(false)
+
+	// Non-SyntaxError must not match.
+	expect(
+		isHtmlDocumentAsScriptNoise({
+			exception: {
+				values: [
+					{
+						type: 'Error',
+						value: message,
+						stacktrace: {
+							frames: [
+								{ filename: '/blog/how-i-built-a-modern-website-in-2021' },
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
 })
 
 test('scopes Safari JSON pattern errors to manifest protocol (KCD-XG/X3)', () => {

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -35,6 +35,16 @@ const TURBO_STREAM_DECODE_ERROR = 'Unable to decode turbo-stream response'
 const HTML_AS_JSON_ERROR = /Unexpected token '<',\s*"<!DOCTYPE/i
 const SAFARI_JSON_PATTERN_ERROR =
 	/^The string did not match the expected pattern\.?$/i
+/**
+ * Firefox reports C1/control codepoints this way when an HTML document is
+ * parsed as a script (KCD-105). Chrome's sibling is HTML_AS_JSON_ERROR.
+ */
+const FIREFOX_ILLEGAL_CHARACTER_SYNTAX =
+	/^illegal character U\+[0-9A-Fa-f]+$/i
+const HTML_DOCTYPE_SOURCE_LINE = /^\s*<!DOCTYPE\b/i
+/** Real script/module/asset filenames — never treat these as HTML documents. */
+const SCRIPT_OR_ASSET_FILENAME =
+	/\.(?:m?[jt]sx?|cjs|css|json|map|wasm)(?:\?|#|$)/i
 const REACT_ROUTER_TURBO_STREAM_STACK = /fetchAndDecodeViaTurboStream/
 const REACT_ROUTER_DATA_PROTOCOL_MANIFEST_STACK =
 	/fetchAndApplyManifestPatches|Failed to fetch manifest patches/i
@@ -111,8 +121,11 @@ type SentryExceptionValue = {
 	stacktrace?: {
 		frames?: Array<{
 			filename?: string | null
+			absPath?: string | null
 			function?: string | null
 			inApp?: boolean | null
+			/** Sentry source context: [lineNo, lineText] pairs when available. */
+			context?: Array<[number, string] | { line?: number; value?: string }> | null
 		}> | null
 	} | null
 }
@@ -500,6 +513,89 @@ export function isTranslatorDomMutationNoise(
 	return true
 }
 
+function frameContextLines(
+	frame: NonNullable<
+		NonNullable<SentryExceptionValue['stacktrace']>['frames']
+	>[number],
+): Array<string> {
+	const lines: Array<string> = []
+	for (const entry of frame.context ?? []) {
+		if (Array.isArray(entry)) {
+			const line = entry[1]
+			if (typeof line === 'string') lines.push(line)
+			continue
+		}
+		if (entry && typeof entry.value === 'string') lines.push(entry.value)
+	}
+	return lines
+}
+
+/**
+ * True when a stack filename is a document URL (HTML route) rather than a
+ * bundled script/module asset. Used to prove HTML-was-parsed-as-JS.
+ */
+export function isHtmlDocumentScriptFilename(filename: string): boolean {
+	const value = filename.trim()
+	if (!value) return false
+	if (
+		/^(?:blob:|data:|webpack:|chrome-extension:|moz-extension:|safari-web-extension:|safari-extension:|webkit-masked-url:|iabjs:)/i.test(
+			value,
+		)
+	) {
+		return false
+	}
+	if (value === '[native code]' || value === '<anonymous>') return false
+	if (SCRIPT_OR_ASSET_FILENAME.test(value)) return false
+	if (/\/assets\//i.test(value)) return false
+	// Document paths: "/blog/...", "https://host/blog/...", sometimes bare host URLs.
+	return /^(?:https?:\/\/[^/]+)?\/(?!node_modules\/)/i.test(value)
+}
+
+/**
+ * Firefox HTML-document-as-script SyntaxError (KCD-105).
+ *
+ * When a browser loads an HTML page URL as a script, Chrome surfaces
+ * `Unexpected token '<', "<!DOCTYPE"` (ignoreErrors). Firefox instead throws
+ * `illegal character U+XXXX` for a C1/control codepoint in that HTML, with the
+ * document URL as the only stack filename and often `<!DOCTYPE` in frame
+ * context. Require the Firefox message plus HTML-document evidence — never the
+ * illegal-character phrase alone (a real bundle containing C1 controls should
+ * still alert).
+ */
+export function isHtmlDocumentAsScriptNoise(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const original = hint.originalException
+	const messages = eventMessages(event)
+	if (original instanceof Error) messages.push(original.message)
+
+	const firefoxIllegal = messages.some((message) =>
+		FIREFOX_ILLEGAL_CHARACTER_SYNTAX.test(message.trim()),
+	)
+	if (!firefoxIllegal) return false
+
+	const namedSyntaxError = (event.exception?.values ?? []).some(
+		(value) => value.type === 'SyntaxError',
+	)
+	const originalIsSyntaxError =
+		original instanceof Error && original.name === 'SyntaxError'
+	if (!namedSyntaxError && !originalIsSyntaxError) return false
+
+	const frames = (event.exception?.values ?? []).flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+	if (frames.length === 0) return false
+
+	return frames.some((frame) => {
+		if (frameContextLines(frame).some((line) => HTML_DOCTYPE_SOURCE_LINE.test(line))) {
+			return true
+		}
+		const filename = frame.filename ?? frame.absPath ?? ''
+		return isHtmlDocumentScriptFilename(filename)
+	})
+}
+
 /**
  * React Router client data-protocol failures when `.data` / `__manifest`
  * responses are HTML, empty, or truncated (edge/intermediary), not app throws.
@@ -508,6 +604,8 @@ export function isTranslatorDomMutationNoise(
  * - Turbo-stream decode requires RR single-fetch stack or `.data`/`__manifest`
  *   breadcrumb evidence — never the message alone (KCD-XF/YY/Y8).
  * - Safari pattern SyntaxError is scoped to manifest patch fetches (KCD-XG/X3).
+ * - Firefox `illegal character U+XXXX` when an HTML document URL is the script
+ *   source is handled by `isHtmlDocumentAsScriptNoise` (KCD-105).
  */
 export function isReactRouterDataProtocolNoise(
 	event: SentryEventLike,
@@ -833,6 +931,7 @@ export function shouldDropSentryEvent(
 	if (isCloudflareEdgeRouteErrorEvent(event)) return true
 	if (isReactRouterEdgeHttpStatusError(event, hint)) return true
 	if (isReactRouterDataProtocolNoise(event, hint)) return true
+	if (isHtmlDocumentAsScriptNoise(event, hint)) return true
 	if (isReactRouterSanitizedServerError(event, hint)) return true
 	if (event.request?.url?.includes('/lookout')) return true
 	if (event.request?.url?.includes('translate-pa.googleapis.com')) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry **KCD-105** (`SyntaxError: illegal character U+009E` on `/blog/how-i-built-a-modern-website-in-2021`, Firefox 153) is HTML-document-as-script noise — the same class as Chrome's `Unexpected token '<', "<!DOCTYPE"` filter, not an app SyntaxError in a real bundle.

Evidence from the event:
- Stack filename is the HTML page URL itself (`/blog/how-i-built-a-modern-website-in-2021`)
- Frame context line 1 is `<!DOCTYPE html>…`
- Mechanism `auto.browser.global_handlers.onerror`, single frame, no RR `.data`/`__manifest` breadcrumbs
- Current blog HTML has no U+009E — chasing a content “fix” is the wrong lever; Firefox surfaces a C1/control codepoint when parsing HTML as JS

### Change
- Add `isHtmlDocumentAsScriptNoise` in `sentry-noise.ts`
  - Requires Firefox `illegal character U+XXXX` + `SyntaxError`
  - Plus HTML-document evidence (document-path filename or `<!DOCTYPE` frame context)
  - Never the illegal-character phrase alone (a real `.js` asset with C1 controls still alerts)
- Unit tests for KCD-105 shape + negative cases
- bugfix-workflow Sentry triage callout

## Deploy impact
Client Sentry `beforeSend` filter + agent docs only. Low risk; no auth/payment/data changes.

## Test plan
- [x] `npm run test:backend --workspace kentcdodds.com -- app/utils/__tests__/sentry-noise.test.ts` (33 passed)
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a54e91e-2fc7-4ac6-bdee-5af45a29ad9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a54e91e-2fc7-4ac6-bdee-5af45a29ad9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced incorrect error reports for Firefox syntax errors caused by HTML pages being interpreted as JavaScript.
  * Continued reporting genuine JavaScript bundle errors and unrelated syntax errors.

* **Documentation**
  * Added guidance for identifying and triaging these Firefox errors.

* **Tests**
  * Added coverage for HTML-document detection and safeguards against filtering legitimate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->