### PR TITLE
Add AI Coding Summit NYC to talks

### DIFF
--- a/services/site/content/data/talks.yml
+++ b/services/site/content/data/talks.yml
@@ -40,10 +40,15 @@
   deliveries:
     - event: '[Cloudflare Connect](https://www.cloudflare.com/connect/)'
       date: 2026-10-19
+    - event: '[AI Coding Summit NYC](https://aicodingsummit.com/nyc/)'
+      date: 2026-11-16
   tags:
     - cloudflare
     - ai
     - architecture
+    - assistant
+    - agent
+    - infrastructure
   description: >-
     What if you had your own npm registry, your own GitHub, your own cron
     system, your own email address, and your own database? And what if your


### PR DESCRIPTION
## Summary
- Add AI Coding Summit NYC (2026-11-16) as a delivery of *I Built Your Personal Software Ecosystem*
- Leave React Summit US under TBD (topic not locked)

## Test plan
- [ ] Confirm `/talks` lists AI Coding Summit NYC under that talk
- [ ] Confirm React Summit US still appears under TBD


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an AI Coding Summit NYC delivery date for the “I Built Your Personal Software Ecosystem” talk.
  * Expanded the talk’s tags to include assistant, agent, and infrastructure topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->