### PR TITLE
Attribute Laracon and AgentConf talk deliveries

### DIFF
--- a/services/site/content/data/talks.yml
+++ b/services/site/content/data/talks.yml
@@ -1,9 +1,5 @@
 - title: TBD
   deliveries:
-    - event: '[Laracon 2026](https://laracon.us/)'
-      date: 2026-07-28
-    - event: '[AgentConf 2026](https://agent.sh/)'
-      date: 2026-09-17
     - event: '[Nerdearla Argentina 2026](https://nerdearla.com/en/argentina/)'
       date: 2026-09-24
     - event: '[React Summit US](https://reactsummit.us/)'
@@ -38,6 +34,8 @@
 
 - title: 'I Built Your Personal Software Ecosystem'
   deliveries:
+    - event: '[AgentConf 2026](https://agent.sh/)'
+      date: 2026-09-17
     - event: '[Cloudflare Connect](https://www.cloudflare.com/connect/)'
       date: 2026-10-19
     - event: '[AI Coding Summit NYC](https://aicodingsummit.com/nyc/)'
@@ -83,6 +81,8 @@
         '[WeAreDevelopers World
         Congress](https://www.wearedevelopers.com/world-congress)'
       date: 2026-07-09
+    - event: '[Laracon 2026](https://laracon.us/)'
+      date: 2026-07-28
   tags:
     - ai
     - product engineering


### PR DESCRIPTION
## Summary
- Move Laracon 2026 (2026-07-28) from TBD to *The Last Software Engineer*
- Move AgentConf 2026 (2026-09-17) from TBD to *I Built Your Personal Software Ecosystem*
- Leave Nerdearla and React Summit US under TBD

## Test plan
- [ ] `/talks` shows Laracon under The Last Software Engineer
- [ ] `/talks` shows AgentConf under I Built Your Personal Software Ecosystem
- [ ] Neither appears under TBD


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Added 2026 delivery details for “I Built Your Personal Software Ecosystem” at AgentConf.
  * Added 2026 delivery details for “The Last Software Engineer” at Laracon 2026.
  * Updated the talks listing to reflect the revised event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->