### PR TITLE
Add Singapore 2027 TBD talks

### DIFF
--- a/services/site/content/data/talks.yml
+++ b/services/site/content/data/talks.yml
@@ -4,6 +4,10 @@
       date: 2026-09-24
     - event: '[React Summit US](https://reactsummit.us/)'
       date: 2026-11-17
+    - event: '[React Summit Asia](https://reactsummit.asia/)'
+      date: 2027-04-15
+    - event: '[AI Coding Summit Asia](https://aicodingsummit.com/asia/)'
+      date: 2027-04-16
 
 - title: 'Closing the Agentic Loop'
   deliveries:


### PR DESCRIPTION
## Summary
- Add React Summit Asia (2027-04-15) under TBD
- Add AI Coding Summit Asia (2027-04-16) under TBD

## Test plan
- [ ] `/talks` TBD section lists both Singapore events with correct dates/links


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added React Summit Asia on April 15, 2027, to the talks schedule.
  * Added AI Coding Summit Asia on April 16, 2027, to the talks schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->