### PR TITLE
ci: upload source maps to Sentry on production site deploys

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -148,6 +148,12 @@ jobs:
 
       - name: 🏗️ Build site client + server bundles
         run: npm run build --workspace kentcdodds.com
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: kent-c-dodds-tech-llc
+          SENTRY_PROJECT: kcd
+          SENTRY_UPLOAD: ${{ secrets.SENTRY_AUTH_TOKEN != '' && 'true' || 'false' }}
+          COMMIT_SHA: ${{ github.sha }}
 
       # Persistent MDX compile cache: unchanged documents are reused instead of
       # recompiled, and resolved embeds (tweets, oEmbed, mermaid SVGs) persist

--- a/docs/agents/cloudflare-worker-architecture.md
+++ b/docs/agents/cloudflare-worker-architecture.md
@@ -627,6 +627,11 @@ writes `generated-wrangler.jsonc` with production bindings + `BUILD_SHA`.
 The repo `CLOUDFLARE_API_TOKEN` can deploy worker scripts and upload secrets
 but **cannot** list/create D1/KV/R2 (auth error 10000). Therefore:
 
+Production site builds upload source maps to Sentry when the repo secret
+`SENTRY_AUTH_TOKEN` is set (org auth token with `sntrys_` prefix from Sentry
+**Settings → Auth Tokens**). Until that secret exists, `SENTRY_UPLOAD` stays
+off and deploys continue without upload.
+
 - Resource IDs are committed in `services/site-worker/wrangler.jsonc`; `npm run
 provision:production` skips Cloudflare API calls when IDs are present (use
   `--force-ensure` for fresh environments with a privileged token).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production site builds now pass Sentry upload env vars into the `deploy-site.yml` build step so `@sentry/vite-plugin` can upload source maps during deploys.

## Changes

- **`.github/workflows/deploy-site.yml`**: The site build step sets:
  - `SENTRY_AUTH_TOKEN` from repo secrets
  - `SENTRY_ORG`: `kent-c-dodds-tech-llc`
  - `SENTRY_PROJECT`: `kcd`
  - `SENTRY_UPLOAD`: `'true'` only when `SENTRY_AUTH_TOKEN` is non-empty (otherwise `'false'`)
  - `COMMIT_SHA`: `${{ github.sha }}` (required by `vite.config.ts` when upload is enabled; also used for Sentry release/commit association)

- **`docs/agents/cloudflare-worker-architecture.md`**: Notes that `SENTRY_AUTH_TOKEN` should be a Sentry org auth token (`sntrys_` prefix) from **Settings → Auth Tokens**.

## Release / source map matching

No runtime changes needed. The site's Sentry client init (`monitoring.client.tsx`) does not set a `release` option. `@sentry/vite-plugin` v5 injects debug IDs by default, which is how uploaded source maps match events. The plugin's `release.name = COMMIT_SHA` + `setCommits.auto` is for Sentry release/commit metadata only.

## Required follow-up

Add the **`SENTRY_AUTH_TOKEN`** repository secret (org auth token with `sntrys_` prefix) for uploads to activate. Until then, `SENTRY_UPLOAD` stays `'false'` and deploys remain unchanged.

## Validation

- Parsed `.github/workflows/deploy-site.yml` with Python `yaml.safe_load` (valid YAML).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0498f1f9-9e5c-4ba3-b6d5-c29761724500?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0498f1f9-9e5c-4ba3-b6d5-c29761724500&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Production builds now support optional Sentry source-map uploads when configured.
  * Deployments continue normally with source-map uploads disabled if no Sentry authorization is provided.

* **Documentation**
  * Added guidance on configuring Sentry source-map uploads for production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->