### PR TITLE
Filter translator call-stack overflows with HTML-document frames (KCD-108)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -48,9 +48,11 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   do not weaken CSRF checks to silence the alert.
 - Page-translator DOM mutation (Google/Chrome Translate) often surfaces as
   `RangeError: Maximum call stack size exceeded` with an unattributed
-  `filename: "undefined"` frame plus UI breadcrumbs like `a > font > font`, or
-  `html.translated-ltr` / `translated-rtl`. Do not broadly ignore call-stack
-  overflows — require that unusable stack plus translator evidence (KCD-QW).
+  `filename: "undefined"` frame **or** HTML-document-path frames
+  (`https://kentcdodds.com/`, `/clubs`) plus UI breadcrumbs like
+  `a > font > font` / `font > font`, or `html.translated-ltr` /
+  `translated-rtl`. Do not broadly ignore call-stack overflows — require that
+  unusable/HTML-document stack plus translator evidence (KCD-QW / KCD-108).
 - The same translators also cause React `NotFoundError` on `removeChild` /
   `insertBefore` (Chrome) or Safari `The object can not be found here.` during
   `react-dom` deletion (facebook/react#11538). Filter via

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -53,6 +53,8 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   `a > font > font` / `font > font`, or `html.translated-ltr` /
   `translated-rtl`. Do not broadly ignore call-stack overflows — require that
   unusable/HTML-document stack plus translator evidence (KCD-QW / KCD-108).
+  Check both Sentry `filename` and `absPath`: a placeholder in one field is not
+  enough when the other identifies a first-party bundle URL.
 - The same translators also cause React `NotFoundError` on `removeChild` /
   `insertBefore` (Chrome) or Safari `The object can not be found here.` during
   `react-dom` deletion (facebook/react#11538). Filter via

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -1443,6 +1443,57 @@ test('filters translator call stack overflows with HTML-document frames (KCD-108
 			{ pageTranslated: true },
 		),
 	).toBe(false)
+
+	// Placeholder filename must not hide a real bundle URL in absPath.
+	expect(
+		hasOnlyUnusableOrHtmlDocumentStackFrames({
+			exception: {
+				values: [
+					{
+						type: 'RangeError',
+						value: 'Maximum call stack size exceeded.',
+						stacktrace: {
+							frames: [
+								{
+									filename: 'undefined',
+									absPath: '/assets/entry.client-AbCd1234.js',
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [
+									{
+										filename: 'undefined',
+										absPath: '/assets/entry.client-AbCd1234.js',
+									},
+								],
+							},
+						},
+					],
+				},
+				breadcrumbs: [
+					{
+						category: 'ui.click',
+						message: 'font > font',
+					},
+				],
+			},
+			{ pageTranslated: true },
+		),
+	).toBe(false)
 })
 
 test('recognizes React Router CSRF abort messages (KCD-YN)', () => {

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -3,6 +3,7 @@ import {
 	SENTRY_DENY_URLS,
 	SENTRY_IGNORE_ERRORS,
 	hasInjectedFetchInterceptorBreadcrumbs,
+	hasOnlyUnusableOrHtmlDocumentStackFrames,
 	hasOnlyUnusableStackFrames,
 	isBrokenClientFetchContractError,
 	isBrowserExtensionError,
@@ -505,10 +506,7 @@ test('filters React Router sanitized Unexpected Server Error (KCD-SE)', () => {
 	expect(isReactRouterSanitizedServerError(emptyStackEvent)).toBe(true)
 	expect(shouldDropSentryEvent(emptyStackEvent)).toBe(true)
 	expect(
-		isReactRouterSanitizedServerError(
-			{},
-			{ originalException: sanitized },
-		),
+		isReactRouterSanitizedServerError({}, { originalException: sanitized }),
 	).toBe(true)
 
 	expect(
@@ -928,9 +926,9 @@ test('filters HTML-as-JSON manifest/data protocol noise (KCD-ZJ)', () => {
 test('filters Firefox HTML-document-as-script illegal character (KCD-105)', () => {
 	const message = 'illegal character U+009E'
 	expect(matchesIgnoreError(message)).toBe(false)
-	expect(isHtmlDocumentScriptFilename('/blog/how-i-built-a-modern-website-in-2021')).toBe(
-		true,
-	)
+	expect(
+		isHtmlDocumentScriptFilename('/blog/how-i-built-a-modern-website-in-2021'),
+	).toBe(true)
 	expect(
 		isHtmlDocumentScriptFilename(
 			'https://kentcdodds.com/assets/entry.client-abc123.js',
@@ -1025,10 +1023,10 @@ test('filters Firefox HTML-document-as-script illegal character (KCD-105)', () =
 								{
 									filename: '/assets/entry.client-abc123.js',
 									context: [
-										[
-											1,
-											'<!DOCTYPE html><html lang="en"><head>',
-										] as [number, string],
+										[1, '<!DOCTYPE html><html lang="en"><head>'] as [
+											number,
+											string,
+										],
 									],
 								},
 							],
@@ -1304,6 +1302,146 @@ test('filters page-translator call stack overflows with font breadcrumbs (KCD-QW
 		isHtmlPageTranslated({
 			documentElement: { className: 'dark' },
 		}),
+	).toBe(false)
+})
+
+test('filters translator call stack overflows with HTML-document frames (KCD-108)', () => {
+	// iOS Chrome Translate attributes minified React frames to the HTML
+	// document URL instead of filename: "undefined" (KCD-108 / KCD-107 / KCD-106).
+	const htmlDocumentTranslatorEvent = {
+		exception: {
+			values: [
+				{
+					type: 'RangeError',
+					value: 'Maximum call stack size exceeded.',
+					stacktrace: {
+						frames: [
+							{
+								function: 'Hk',
+								filename: 'https://kentcdodds.com/',
+								inApp: true,
+							},
+							{
+								function: 'Fk',
+								filename: 'https://kentcdodds.com/',
+								inApp: true,
+							},
+							{
+								filename: 'https://kentcdodds.com/',
+								inApp: true,
+							},
+						],
+					},
+				},
+			],
+		},
+		breadcrumbs: [
+			{
+				category: 'ui.click',
+				message: 'a.underline > font > font',
+			},
+			{
+				category: 'ui.click',
+				message: 'font > font',
+			},
+		],
+	}
+
+	expect(hasOnlyUnusableStackFrames(htmlDocumentTranslatorEvent)).toBe(false)
+	expect(
+		hasOnlyUnusableOrHtmlDocumentStackFrames(htmlDocumentTranslatorEvent),
+	).toBe(true)
+	expect(
+		isPageTranslatorCallStackOverflow(htmlDocumentTranslatorEvent, {
+			pageTranslated: false,
+		}),
+	).toBe(true)
+	expect(
+		shouldDropSentryEvent(htmlDocumentTranslatorEvent, {
+			pageTranslated: false,
+		}),
+	).toBe(true)
+
+	// Relative document paths (KCD-106) are the same class of noise.
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [
+									{ function: 'Fk', filename: '/clubs', inApp: true },
+									{
+										filename: 'https://kentcdodds.com/',
+										absPath: 'https://kentcdodds.com/',
+										inApp: true,
+									},
+								],
+							},
+						},
+					],
+				},
+				breadcrumbs: [
+					{
+						category: 'ui.click',
+						message: 'font > font',
+					},
+				],
+			},
+			{ pageTranslated: false },
+		),
+	).toBe(true)
+
+	// HTML-document frames without translator evidence stay reportable.
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [{ filename: 'https://kentcdodds.com/' }],
+							},
+						},
+					],
+				},
+			},
+			{ pageTranslated: false },
+		),
+	).toBe(false)
+
+	// Real bundle frames must still alert even with translator breadcrumbs.
+	expect(
+		shouldDropSentryEvent(
+			{
+				exception: {
+					values: [
+						{
+							type: 'RangeError',
+							value: 'Maximum call stack size exceeded.',
+							stacktrace: {
+								frames: [
+									{ filename: 'https://kentcdodds.com/' },
+									{ filename: '/assets/entry.client-AbCd1234.js' },
+								],
+							},
+						},
+					],
+				},
+				breadcrumbs: [
+					{
+						category: 'ui.click',
+						message: 'font > font',
+					},
+				],
+			},
+			{ pageTranslated: true },
+		),
 	).toBe(false)
 })
 

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -845,11 +845,22 @@ export function hasOnlyUnusableStackFrames(event: SentryEventLike): boolean {
 	return frames.every((frame) => isUnattributedStackFilename(frame.filename))
 }
 
+function isUnusableOrHtmlDocumentAttribution(
+	value: string | null | undefined,
+): boolean {
+	if (isUnattributedStackFilename(value)) return true
+	if (typeof value !== 'string') return false
+	return isHtmlDocumentScriptFilename(value)
+}
+
 /**
  * Translator overflows on iOS Chrome sometimes attribute minified React frames
  * to the HTML document URL (inline script / document path) instead of
  * `filename: "undefined"` (KCD-108 / KCD-107 / KCD-106). Those are still not
  * first-party bundle frames — treat them like unusable attribution here.
+ *
+ * Inspect both `filename` and `absPath`: a placeholder in one field must not
+ * hide a real bundle URL in the other.
  */
 export function hasOnlyUnusableOrHtmlDocumentStackFrames(
 	event: SentryEventLike,
@@ -857,10 +868,13 @@ export function hasOnlyUnusableOrHtmlDocumentStackFrames(
 	const frames = exceptionFrames(event)
 	if (frames.length === 0) return true
 	return frames.every((frame) => {
-		const filename = frame.filename ?? frame.absPath
-		if (isUnattributedStackFilename(filename)) return true
-		if (typeof filename !== 'string') return false
-		return isHtmlDocumentScriptFilename(filename)
+		const candidates = [frame.filename, frame.absPath].filter(
+			(value, index, values) => values.indexOf(value) === index,
+		)
+		if (candidates.length === 0) return true
+		return candidates.every((value) =>
+			isUnusableOrHtmlDocumentAttribution(value),
+		)
 	})
 }
 

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -39,8 +39,7 @@ const SAFARI_JSON_PATTERN_ERROR =
  * Firefox reports C1/control codepoints this way when an HTML document is
  * parsed as a script (KCD-105). Chrome's sibling is HTML_AS_JSON_ERROR.
  */
-const FIREFOX_ILLEGAL_CHARACTER_SYNTAX =
-	/^illegal character U\+[0-9A-Fa-f]+$/i
+const FIREFOX_ILLEGAL_CHARACTER_SYNTAX = /^illegal character U\+[0-9A-Fa-f]+$/i
 const HTML_DOCTYPE_SOURCE_LINE = /^\s*<!DOCTYPE\b/i
 /** Real script/module/asset filenames — never treat these as HTML documents. */
 const SCRIPT_OR_ASSET_FILENAME =
@@ -125,7 +124,9 @@ type SentryExceptionValue = {
 			function?: string | null
 			inApp?: boolean | null
 			/** Sentry source context: [lineNo, lineText] pairs when available. */
-			context?: Array<[number, string] | { line?: number; value?: string }> | null
+			context?: Array<
+				[number, string] | { line?: number; value?: string }
+			> | null
 		}> | null
 	} | null
 }
@@ -588,7 +589,11 @@ export function isHtmlDocumentAsScriptNoise(
 	if (frames.length === 0) return false
 
 	return frames.some((frame) => {
-		if (frameContextLines(frame).some((line) => HTML_DOCTYPE_SOURCE_LINE.test(line))) {
+		if (
+			frameContextLines(frame).some((line) =>
+				HTML_DOCTYPE_SOURCE_LINE.test(line),
+			)
+		) {
 			return true
 		}
 		const filename = frame.filename ?? frame.absPath ?? ''
@@ -818,6 +823,17 @@ function exceptionFrames(event: SentryEventLike) {
 	)
 }
 
+function isUnattributedStackFilename(
+	filename: string | null | undefined,
+): boolean {
+	return (
+		filename == null ||
+		filename === '' ||
+		filename === 'undefined' ||
+		filename === 'null'
+	)
+}
+
 /**
  * Real app recursion still attributes frames to bundle URLs. Translator and
  * other injected scripts often report a single unusable "undefined" filename
@@ -826,14 +842,25 @@ function exceptionFrames(event: SentryEventLike) {
 export function hasOnlyUnusableStackFrames(event: SentryEventLike): boolean {
 	const frames = exceptionFrames(event)
 	if (frames.length === 0) return true
+	return frames.every((frame) => isUnattributedStackFilename(frame.filename))
+}
+
+/**
+ * Translator overflows on iOS Chrome sometimes attribute minified React frames
+ * to the HTML document URL (inline script / document path) instead of
+ * `filename: "undefined"` (KCD-108 / KCD-107 / KCD-106). Those are still not
+ * first-party bundle frames — treat them like unusable attribution here.
+ */
+export function hasOnlyUnusableOrHtmlDocumentStackFrames(
+	event: SentryEventLike,
+): boolean {
+	const frames = exceptionFrames(event)
+	if (frames.length === 0) return true
 	return frames.every((frame) => {
-		const filename = frame.filename
-		return (
-			filename == null ||
-			filename === '' ||
-			filename === 'undefined' ||
-			filename === 'null'
-		)
+		const filename = frame.filename ?? frame.absPath
+		if (isUnattributedStackFilename(filename)) return true
+		if (typeof filename !== 'string') return false
+		return isHtmlDocumentScriptFilename(filename)
 	})
 }
 
@@ -902,14 +929,15 @@ export function isHtmlPageTranslated(
 /**
  * Page translators (Google Translate / Chrome Translate) mutate React's DOM
  * with nested <font> tags and can recurse until RangeError. Only drop when the
- * stack is unattributed and translator evidence is present (KCD-QW).
+ * stack is unattributed (or HTML-document-attributed) and translator evidence
+ * is present (KCD-QW / KCD-108).
  */
 export function isPageTranslatorCallStackOverflow(
 	event: SentryEventLike,
 	options: { pageTranslated?: boolean } = {},
 ): boolean {
 	if (!isCallStackOverflow(event)) return false
-	if (!hasOnlyUnusableStackFrames(event)) return false
+	if (!hasOnlyUnusableOrHtmlDocumentStackFrames(event)) return false
 	if (hasTranslatorFontBreadcrumb(event)) return true
 	if (options.pageTranslated === true) return true
 	if (options.pageTranslated === false) return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chrome/Google Translate on iOS injects nested `<font>` tags that make React's reconciler overflow the call stack during client-side navigation. KCD-QW already filtered this when stack frames were unattributed (`filename: "undefined"`), but iOS Chrome attributes the same minified React frames to the HTML document URL (`https://kentcdodds.com/`, `/clubs`), so those events still alerted.

This extends `isPageTranslatorCallStackOverflow` to treat HTML-document-path frames like unusable attribution **only when** translator evidence is present (`font > font` breadcrumbs or `translated-ltr/rtl`). Both Sentry `filename` and `absPath` are inspected so a placeholder in one field cannot hide a real bundle URL in the other. Real bundle frames still alert.

## Sentry

- **KCD-108** (primary): https://kent-c-dodds-tech-llc.sentry.io/issues/7657429854/
- **KCD-107** / **KCD-106**: same root cause (Chrome Mobile iOS, `/clubs`, `font > font` breadcrumbs)

## Test plan

- [x] Unit tests for HTML-document frames + translator breadcrumbs (KCD-108 / KCD-106 signatures)
- [x] Confirms unusable-only heuristic still works (KCD-QW)
- [x] Confirms real bundle frames + translator evidence still report
- [x] Confirms HTML-document frames without translator evidence still report
- [x] Confirms `filename: "undefined"` + bundle `absPath` still report

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64df2814-8a5d-4af7-86c2-caa282495cfe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64df2814-8a5d-4af7-86c2-caa282495cfe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of page-translator call-stack overflow reports involving HTML document URLs.
  - Preserved reporting for genuine application errors and events without sufficient translator evidence.
  - Added support for both absolute and relative document paths to reduce irrelevant error noise without broadly suppressing stack-overflow reports.

- **Documentation**
  - Updated troubleshooting guidance with additional stack-trace examples and the relevant issue references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->