### PR TITLE
fix(d1): cut rows-read billing from PostRead aggregates (~$195/mo)

### DIFF
--- a/docs/agents/data-table-conventions.md
+++ b/docs/agents/data-table-conventions.md
@@ -4,6 +4,28 @@ Runtime DB access uses `@remix-run/data-table`. SQL migrations live in
 `services/site/migrations/`. User/session helpers live in
 `app/utils/user-data.server.ts`.
 
+## D1 billing sharp edge: rows read
+
+D1 bills **rows scanned**, not rows returned. A `GROUP BY` or
+`COUNT(DISTINCT ...)` over `PostRead` (~1M rows) scans the whole table on every
+execution, so where a query's result is cached matters as much as the query:
+
+- `lruCache` (`app/utils/cache.server.ts`) is **per-isolate memory**. Isolates
+  churn constantly (deploys, eviction, the warmup cron), so an `lruCache`-only
+  cachified value re-runs its `getFreshValue` on every new isolate regardless
+  of TTL. In Aug 2026 this made two full-table `PostRead` aggregates
+  (`blog:post-read-counts`, `total-reader-count` in `app/utils/blog.server.ts`)
+  run ~53k times/week ≈ 51B rows read/week ≈ a $195/month D1 line item.
+- `cache` (KV-backed via `CACHE_RPC`) is shared across isolates. Any cachified
+  value whose `getFreshValue` scans a large table MUST use `cache`, not
+  `lruCache`. Reserve `lruCache` for values that are cheap to recompute.
+- Also avoid `forceFresh: true` on request paths (e.g. actions) unless the
+  underlying data actually changed; it bypasses the shared cache and re-runs
+  the aggregate queries.
+- To verify what is burning reads, query GraphQL
+  `d1QueriesAdaptiveGroups` ordered by `sum_rowsRead_DESC` (or
+  `wrangler d1 insights`).
+
 Do **not** import the `remix` umbrella package; use `@remix-run/data-table` and
 `@remix-run/data-table-sqlite` directly.
 

--- a/services/site/app/routes/action/__tests__/mark-as-read.test.ts
+++ b/services/site/app/routes/action/__tests__/mark-as-read.test.ts
@@ -1,9 +1,82 @@
 import { afterEach, expect, test, vi } from 'vitest'
-import { markAsRead } from '../mark-as-read.tsx'
+
+const blogServerMocks = vi.hoisted(() => ({
+	addPostRead: vi.fn(),
+	getBlogReadRankings: vi.fn(),
+	notifyOfOverallTeamLeaderChange: vi.fn(),
+	notifyOfTeamLeaderChangeOnPost: vi.fn(),
+}))
+
+vi.mock('#app/utils/blog.server.ts', () => blogServerMocks)
+
+const sessionServerMocks = vi.hoisted(() => ({
+	getSession: vi.fn(),
+}))
+
+vi.mock('#app/utils/session.server.ts', () => sessionServerMocks)
+
+const clientServerMocks = vi.hoisted(() => ({
+	getClientSession: vi.fn(),
+}))
+
+vi.mock('#app/utils/client.server.ts', () => clientServerMocks)
+
+// Import after mocks so the action sees the mocked deps.
+import { action, markAsRead } from '../mark-as-read.tsx'
+
+function setup({ user }: { user: { id: string } | null }) {
+	vi.clearAllMocks()
+	sessionServerMocks.getSession.mockResolvedValue({
+		getUser: async () => user,
+	})
+	clientServerMocks.getClientSession.mockResolvedValue({
+		getClientId: () => 'client-1',
+	})
+	blogServerMocks.getBlogReadRankings.mockResolvedValue([])
+	return {
+		request: new Request('http://localhost/action/mark-as-read', {
+			method: 'POST',
+			body: new URLSearchParams({ slug: 'some-post' }),
+		}),
+	}
+}
 
 afterEach(() => {
 	vi.unstubAllGlobals()
 	vi.restoreAllMocks()
+})
+
+test('action skips the forceFresh ranking recompute when the read was a repeat', async () => {
+	const { request } = setup({ user: { id: 'user-1' } })
+	// addPostRead returns null when this user already read the post this week.
+	blogServerMocks.addPostRead.mockResolvedValue(null)
+
+	const response = await action({ request, params: {}, context: {} } as any)
+
+	expect(response.data).toEqual({ success: true })
+	expect(blogServerMocks.addPostRead).toHaveBeenCalledOnce()
+	const forceFreshCalls = blogServerMocks.getBlogReadRankings.mock.calls.filter(
+		([args]) => args.forceFresh,
+	)
+	expect(forceFreshCalls).toHaveLength(0)
+})
+
+test('action force-refreshes rankings when a new PostRead row was created', async () => {
+	const { request } = setup({ user: null })
+	blogServerMocks.addPostRead.mockResolvedValue({ id: 'post-read-1' })
+
+	const response = await action({ request, params: {}, context: {} } as any)
+
+	expect(response.data).toEqual({ success: true })
+	expect(blogServerMocks.addPostRead).toHaveBeenCalledWith({
+		slug: 'some-post',
+		clientId: 'client-1',
+	})
+	const forceFreshCalls = blogServerMocks.getBlogReadRankings.mock.calls.filter(
+		([args]) => args.forceFresh,
+	)
+	// one per-slug refresh and one overall refresh
+	expect(forceFreshCalls).toHaveLength(2)
 })
 
 test('markAsRead posts the slug to the mark-as-read action', async () => {

--- a/services/site/app/routes/action/mark-as-read.tsx
+++ b/services/site/app/routes/action/mark-as-read.tsx
@@ -22,8 +22,9 @@ export async function action({ request }: Route.ActionArgs) {
 		getBlogReadRankings({ request, slug }).then(getRankingLeader),
 		getBlogReadRankings({ request }).then(getRankingLeader),
 	])
+	let createdPostRead = null
 	if (user) {
-		await addPostRead({
+		createdPostRead = await addPostRead({
 			slug,
 			userId: user.id,
 		})
@@ -31,8 +32,17 @@ export async function action({ request }: Route.ActionArgs) {
 		const client = await getClientSession(request, user)
 		const clientId = client.getClientId()
 		if (clientId) {
-			await addPostRead({ slug, clientId })
+			createdPostRead = await addPostRead({ slug, clientId })
 		}
+	}
+
+	// Rankings only change when a new PostRead row was actually created
+	// (addPostRead dedupes repeat reads within a week). Skip the forceFresh
+	// recompute otherwise: it bypasses the shared cache and re-runs 9 heavy
+	// PostRead aggregate queries per ranking, which is the expensive part of
+	// D1's rows-read billing.
+	if (!createdPostRead) {
+		return json({ success: true })
 	}
 
 	// trigger an update to the ranking cache and notify when the leader changed

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -226,7 +226,10 @@ async function getBlogPostReadCounts({
 		key: `blog:post-read-counts`,
 		ttl: 1000 * 60 * 30,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
-		cache: lruCache,
+		// Must be the shared KV cache: getFreshValue scans the whole PostRead
+		// table (D1 bills rows read) and lruCache is per-isolate, so isolate
+		// churn would re-run the full scan far more often than the TTL implies.
+		cache,
 		request,
 		timings,
 		checkValue: (value: unknown) =>
@@ -307,8 +310,12 @@ async function getReaderCount({
 	const key = 'total-reader-count'
 	return cachified({
 		key,
-		cache: lruCache,
-		ttl: 1000 * 60 * 5,
+		// Must be the shared KV cache: the COUNT(DISTINCT ...) below scans the
+		// whole PostRead table (D1 bills rows read), so per-isolate lruCache
+		// would re-run it on every isolate churn. The count moves slowly, so an
+		// hour of staleness is fine.
+		cache,
+		ttl: 1000 * 60 * 60,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
 		request,
 		timings,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

The Aug 8, 2026 Cloudflare invoice (IN-74519948, $213.79) included a **$195.05 D1 line item for 195 billion rows read** (Jul 8–Aug 7). Cloudflare's `d1QueriesAdaptiveGroups` analytics for the last 7 days attribute ~96% of it to two full-table `PostRead` aggregates (the table has ~961K rows, and D1 bills rows *scanned*):

| Query | Executions / 7d | Rows read / 7d |
| --- | --- | --- |
| `SELECT "postSlug", count(*) FROM "PostRead" GROUP BY "postSlug"` (`getBlogPostReadCounts`) | 42,720 | 41.06B |
| `COUNT(DISTINCT userId) + COUNT(DISTINCT clientId)` (`getReaderCount`) | 10,770 | 10.35B |

Both were cachified with `lruCache` only (per-isolate memory), so every isolate churn (deploys, eviction, the 2-minute warmup cron) re-ran a full-table scan despite 5–30 min TTLs — ~127× more often than the TTLs imply.

## Changes

1. **`services/site/app/utils/blog.server.ts`** — `blog:post-read-counts` and `total-reader-count` now use the shared KV-backed `cache` (which already layers the LRU in front for in-isolate hits) instead of `lruCache`. `total-reader-count` TTL raised from 5 min to 1 h (slow-moving vanity stat). `getTotalPostReads` stays on `lruCache` intentionally: its `getFreshValue` just reads the (now shared) counts cache, so recompute is cheap.
2. **`services/site/app/routes/action/mark-as-read.tsx`** — the action no longer force-refreshes the per-slug + overall team rankings (9 aggregate JOIN queries each) when `addPostRead` deduped a repeat read within the week. Leader-change notifications are unaffected: rankings can only change when a row was actually inserted.
3. **Tests** — action-level tests asserting the forceFresh refresh is skipped on repeat reads and still runs (once per-slug, once overall) on new reads.
4. **`docs/agents/data-table-conventions.md`** — records the sharp edge (D1 bills rows scanned; `lruCache` vs shared `cache`; how to audit with `d1QueriesAdaptiveGroups`).

Note on the warmup cron: no change needed there. With the shared KV cache, cold isolates hit KV instead of re-scanning D1, and its cookie-less requests only do an indexed 0-row lookup. Rerouting warmup through the page cache would defeat its purpose (warming dynamic isolates).

## Expected impact

Steady-state D1 reads from these paths drop from ~220B/month to ~2B/month (one full scan per TTL expiry instead of per isolate), well inside the 25B free tier → the $195 line item goes to ~$0. KV traffic added is negligible (well under the 10M free reads).

## Verification

- `npm run test:backend` — 89 files, 392 tests passed
- `npm run typecheck`, `npm run lint` — clean
- Read hotspots confirmed via Cloudflare GraphQL `d1QueriesAdaptiveGroups` sorted by `sum_rowsRead_DESC`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4628d8ba-21e5-4d53-af25-13536da6af48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4628d8ba-21e5-4d53-af25-13536da6af48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved read tracking so repeated reads no longer trigger unnecessary ranking updates or notifications.
  - Reduced database work for popular posts and reader-count lookups through shared caching.
  - Extended reader-count cache freshness to improve responsiveness and reduce repeated queries.

- **Documentation**
  - Added guidance for identifying costly read-heavy queries and using caching effectively for large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->