### PR TITLE
Filter injected HTMLInputElement.onchange location Sentry noise (KCD-109)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -151,9 +151,10 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   visitor's browser — not site code. Filter via `denyUrls` for that host plus
   the distinctive `zp_token` ignoreErrors (KCD-102); do not chase app fixes.
 - Client `TypeError: … reading 'location'` with function
-  `HTMLInputElement.onchange` and exclusively HTML-document stack frames
-  (`https://kentcdodds.com/…`, source context that is page HTML / route
+  `HTMLInputElement.onchange` and exclusively unusable or HTML-document stack
+  frames (`https://kentcdodds.com/…`, source context that is page HTML / route
   manifest JSON) is password-manager / autofill extension noise — not app
   `navigation.location` (KCD-109). Filter via
-  `isInjectedInputOnchangeLocationError`; never drop the location TypeError
-  from first-party `/assets/` bundles.
+  `isInjectedInputOnchangeLocationError` (uses
+  `hasOnlyUnusableOrHtmlDocumentStackFrames`); never drop the location
+  TypeError from first-party `/assets/` bundles.

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -150,3 +150,10 @@ action request. Aborting the action.`, invalid/`missing host` Origin variants)
   Point Zero Phishing (`zerophishing.iaas.checkpoint.com`) injected into the
   visitor's browser — not site code. Filter via `denyUrls` for that host plus
   the distinctive `zp_token` ignoreErrors (KCD-102); do not chase app fixes.
+- Client `TypeError: … reading 'location'` with function
+  `HTMLInputElement.onchange` and exclusively HTML-document stack frames
+  (`https://kentcdodds.com/…`, source context that is page HTML / route
+  manifest JSON) is password-manager / autofill extension noise — not app
+  `navigation.location` (KCD-109). Filter via
+  `isInjectedInputOnchangeLocationError`; never drop the location TypeError
+  from first-party `/assets/` bundles.

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -15,6 +15,7 @@ import {
 	isHtmlDocumentScriptFilename,
 	isHtmlPageTranslated,
 	isInjectedBlobAddListenerError,
+	isInjectedInputOnchangeLocationError,
 	isPageTranslatorCallStackOverflow,
 	isReactRouterCsrfAbortError,
 	isReactRouterDataProtocolNoise,
@@ -693,6 +694,107 @@ test('drops extension blob-script addListener noise (KCD-Z7)', () => {
 			{ originalException: blobStackError },
 		),
 	).toBe(true)
+})
+
+test('drops injected HTMLInputElement.onchange location noise (KCD-109)', () => {
+	const injectedEvent = {
+		exception: {
+			values: [
+				{
+					type: 'TypeError',
+					value: "Cannot read properties of undefined (reading 'location')",
+					stacktrace: {
+						frames: [
+							{
+								filename: 'https://kentcdodds.com/',
+								absPath: 'https://kentcdodds.com/',
+								function: 'HTMLInputElement.onchange',
+								inApp: true,
+								context: [
+									[107, '      "hasDefaultExport": true,'],
+								],
+							},
+							{
+								filename: 'https://kentcdodds.com/',
+								absPath: 'https://kentcdodds.com/',
+								function: null,
+								inApp: true,
+								context: [
+									[
+										68,
+										"            I'm also a big extreme sports enthusiast. When I'm not hanging out",
+									],
+								],
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+
+	expect(isInjectedInputOnchangeLocationError(injectedEvent)).toBe(true)
+	expect(shouldDropSentryEvent(injectedEvent)).toBe(true)
+
+	// App bundle stacks that read `.location` must still alert.
+	expect(
+		isInjectedInputOnchangeLocationError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'location')",
+						stacktrace: {
+							frames: [
+								{
+									filename: '/assets/root-j32IyX5o.js',
+									function: 'HTMLInputElement.onchange',
+									inApp: true,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// HTML-document stacks without the native onchange frame are not enough.
+	expect(
+		isInjectedInputOnchangeLocationError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'location')",
+						stacktrace: {
+							frames: [
+								{
+									filename: 'https://kentcdodds.com/',
+									function: 'anonymous',
+									inApp: true,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// Message alone (no frames) must not drop.
+	expect(
+		isInjectedInputOnchangeLocationError({
+			exception: {
+				values: [
+					{
+						type: 'TypeError',
+						value: "Cannot read properties of undefined (reading 'location')",
+					},
+				],
+			},
+		}),
+	).toBe(false)
 })
 
 test('keeps Module load timeout filter (KCD-ZS / KCD-ZT)', () => {

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -710,21 +710,12 @@ test('drops injected HTMLInputElement.onchange location noise (KCD-109)', () => 
 								absPath: 'https://kentcdodds.com/',
 								function: 'HTMLInputElement.onchange',
 								inApp: true,
-								context: [
-									[107, '      "hasDefaultExport": true,'],
-								],
 							},
 							{
 								filename: 'https://kentcdodds.com/',
 								absPath: 'https://kentcdodds.com/',
 								function: null,
 								inApp: true,
-								context: [
-									[
-										68,
-										"            I'm also a big extreme sports enthusiast. When I'm not hanging out",
-									],
-								],
 							},
 						],
 					},

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -879,6 +879,39 @@ export function hasOnlyUnusableOrHtmlDocumentStackFrames(
 }
 
 /**
+ * Password managers / autofill extensions attach native `onchange` handlers
+ * that sometimes read `.location` off an undefined object. Chrome attributes
+ * those throws to the HTML document URL with function
+ * `HTMLInputElement.onchange` and source context that is page HTML / route
+ * manifest JSON — never a first-party `/assets/` bundle (KCD-109).
+ *
+ * Require the native input onchange frame plus exclusively
+ * unusable/HTML-document attribution. Do not drop a generic "reading
+ * 'location'" TypeError from app bundles (e.g. `navigation.location`).
+ */
+const UNDEFINED_LOCATION_PROP =
+	/Cannot read properties of undefined \(reading 'location'\)|undefined is not an object \(evaluating ['"][^'"]*\.location['"]\)|can't access property "location"/i
+
+const HTML_INPUT_ONCHANGE = /^HTMLInputElement\.onchange$/
+
+export function isInjectedInputOnchangeLocationError(
+	event: SentryEventLike,
+): boolean {
+	if (
+		!eventMessages(event).some((message) => UNDEFINED_LOCATION_PROP.test(message))
+	) {
+		return false
+	}
+
+	const frames = exceptionFrames(event)
+	if (frames.length === 0) return false
+	if (!frames.some((frame) => HTML_INPUT_ONCHANGE.test(frame.function ?? ''))) {
+		return false
+	}
+	return hasOnlyUnusableOrHtmlDocumentStackFrames(event)
+}
+
+/**
  * React Router production `sanitizeError` replaces thrown Errors with
  * `new Error("Unexpected Server Error")` and clears `stack` before they reach
  * the client (see react-router `sanitizeError` / turbo-stream `SanitizedError`).
@@ -969,6 +1002,7 @@ export function shouldDropSentryEvent(
 	if (isCustomEventUnhandledRejectionNoise(event, hint)) return true
 	if (isBrokenClientFetchContractError(event, hint)) return true
 	if (isInjectedBlobAddListenerError(event, hint)) return true
+	if (isInjectedInputOnchangeLocationError(event)) return true
 	if (isDegradedUiPerformanceEvent(event)) return true
 	if (isCloudflareEdgeRouteErrorEvent(event)) return true
 	if (isReactRouterEdgeHttpStatusError(event, hint)) return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sentry [KCD-109](https://kent-c-dodds-tech-llc.sentry.io/issues/7662540717/) is a single production `TypeError: Cannot read properties of undefined (reading 'location')` on `/`.
- Stack is exclusively HTML-document attributed (`https://kentcdodds.com/`, function `HTMLInputElement.onchange`) with source context that is page prose / React Router route-manifest JSON — not a first-party `/assets/` bundle.
- That signature matches password-manager / autofill extension noise attaching native `onchange` handlers; it is not app `navigation.location`.

## Fix

- Add narrow `isInjectedInputOnchangeLocationError` in `sentry-noise.ts` requiring:
  1. location TypeError message
  2. `HTMLInputElement.onchange` frame
  3. exclusively unusable / HTML-document stack frames
- Unit tests cover drop + keep (bundle stack, missing onchange, message-only).
- Document the signature in `docs/agents/bugfix-workflow.md`.

## Risk

Low — client noise filter only; real app `.location` TypeErrors from bundles still alert.

## Sibling issues

Listed unresolved network fetch siblings (KCD-QG / KCD-104 / etc.) do **not** share this root cause; left alone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b7c1c6a-3193-4637-ae67-7d4bb089c894?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b7c1c6a-3193-4637-ae67-7d4bb089c894&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced Sentry noise from password-manager and autofill errors caused by injected form behavior.
  - Preserved reporting for similar errors originating from application code.
  - Added safeguards to avoid filtering unrelated, incomplete, or message-only error reports.
  - Improved error triage for injected autofill issues involving undefined location access.

- **Documentation**
  - Added guidance for identifying and triaging these injected autofill errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->