### PR TITLE
Add a performing arts easter egg on /resume

### DIFF
--- a/services/site/app/routes/resume.tsx
+++ b/services/site/app/routes/resume.tsx
@@ -52,11 +52,21 @@ export const links: LinksFunction = () => [
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const view = getResumeView(new URL(request.url).searchParams.get('view'))
-	const [resumeData, theaterResumeData] = await Promise.all([
-		getResumeData({ request }),
-		getTheaterResumeData({ request }),
-	])
-	return json({ resumeData, theaterResumeData, view })
+	switch (view) {
+		case 'theater': {
+			const theaterResumeData = await getTheaterResumeData({ request })
+			return json({ resumeData: null, theaterResumeData, view })
+		}
+		case 'short':
+		case 'full': {
+			const resumeData = await getResumeData({ request })
+			return json({ resumeData, theaterResumeData: null, view })
+		}
+		default: {
+			const exhaustive: never = view
+			throw new Error(`Unknown resume view: ${String(exhaustive)}`)
+		}
+	}
 }
 
 function getViewKey(isShort: boolean) {
@@ -188,28 +198,19 @@ function ResumeUnavailable() {
 }
 
 function ResumePhoto({ onSecretClick }: { onSecretClick?: () => void }) {
-	const image = (
+	return (
 		<img
-			className="resume-photo"
+			className={
+				onSecretClick ? 'resume-photo resume-photo--secret' : 'resume-photo'
+			}
 			src={buildMediaUrl('kent/profile', {
 				height: 200,
 				aspectRatio: '1:1',
 				fit: 'cover',
 			})}
 			alt="Photo of Kent C. Dodds"
-		/>
-	)
-
-	if (!onSecretClick) return image
-
-	return (
-		<button
-			type="button"
-			className="resume-photo-button"
 			onClick={onSecretClick}
-		>
-			{image}
-		</button>
+		/>
 	)
 }
 

--- a/services/site/app/routes/resume.tsx
+++ b/services/site/app/routes/resume.tsx
@@ -1,9 +1,10 @@
+import * as React from 'react'
 import {
 	data as json,
 	type LinksFunction,
 	type MetaFunction,
 	Link,
-	useSearchParams,
+	useNavigate,
 } from 'react-router'
 import { ButtonLink } from '#app/components/button.tsx'
 import { Grid } from '#app/components/grid.tsx'
@@ -11,24 +12,51 @@ import { H4, Paragraph } from '#app/components/typography.tsx'
 import resumeStyles from '#app/styles/resume.css?url'
 import { externalLinks } from '#app/external-links.tsx'
 import { buildMediaUrl } from '#app/utils/media.ts'
-import { getResumeData, type ResumeData } from '#app/utils/resume.server.ts'
+import {
+	getResumePath,
+	getResumeView,
+	THEATER_RESUME_UNLOCK_CLICKS,
+} from '#app/utils/resume.ts'
+import {
+	getResumeData,
+	getTheaterResumeData,
+	type ResumeData,
+	type TheaterResumeCredit,
+	type TheaterResumeData,
+} from '#app/utils/resume.server.ts'
 import { type Route } from './+types/resume'
 
-export const meta: MetaFunction = () => [
-	{ title: `Kent C. Dodds' Resume` },
-	{
-		name: 'description',
-		content: `A quick look at Kent C. Dodds' work history.`,
-	},
-]
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+	if (data?.view === 'theater') {
+		return [
+			{ title: `Kent C. Dodds' Performing Arts Resume` },
+			{
+				name: 'description',
+				content: `Kent C. Dodds' theater, choir, and performing arts credits.`,
+			},
+		]
+	}
+
+	return [
+		{ title: `Kent C. Dodds' Resume` },
+		{
+			name: 'description',
+			content: `A quick look at Kent C. Dodds' work history.`,
+		},
+	]
+}
 
 export const links: LinksFunction = () => [
 	{ rel: 'stylesheet', href: resumeStyles },
 ]
 
 export async function loader({ request }: Route.LoaderArgs) {
-	const resumeData = await getResumeData({ request })
-	return json({ resumeData })
+	const view = getResumeView(new URL(request.url).searchParams.get('view'))
+	const [resumeData, theaterResumeData] = await Promise.all([
+		getResumeData({ request }),
+		getTheaterResumeData({ request }),
+	])
+	return json({ resumeData, theaterResumeData, view })
 }
 
 function getViewKey(isShort: boolean) {
@@ -101,55 +129,159 @@ function formatMarkdown(resumeData: ResumeData, isShort: boolean) {
 	return lines.join('\n').trim()
 }
 
-export default function ResumePage({
-	loaderData: { resumeData },
-}: Route.ComponentProps) {
-	const [searchParams] = useSearchParams()
-	const view = searchParams.get('view')
-	const isShort = view === 'short'
-	const viewKey = getViewKey(isShort)
+function formatTheaterCreditMarkdown(credit: TheaterResumeCredit) {
+	const show = credit.href ? `[${credit.show}](${credit.href})` : credit.show
+	const details = [credit.role, credit.company, credit.dates].filter(Boolean)
+	return `- ${show} — ${details.join(' · ')}`
+}
 
-	if (!resumeData) {
-		return (
-			<div className="resume-page">
-				<Grid className="mx-10vw my-24">
-					<div className="col-span-full rounded-lg border border-gray-200 p-8 dark:border-gray-600">
-						<H4 as="h2" className="mb-3">
-							Resume is not available right now.
-						</H4>
-						<Paragraph className="mb-4">
-							We are likely having trouble with our GitHub integration. Please
-							try again soon, or browse the content directly on{' '}
-							<a
-								href={externalLinks.githubRepo}
-								target="_blank"
-								rel="noreferrer noopener"
-								className="text-primary underline"
-							>
-								GitHub
-							</a>
-							.
-						</Paragraph>
-						<ButtonLink variant="primary" to={externalLinks.githubRepo}>
-							Open GitHub repo
-						</ButtonLink>
-					</div>
-				</Grid>
+function formatTheaterMarkdown(theaterResumeData: TheaterResumeData) {
+	const { header, sections, skills } = theaterResumeData
+	const stats = header.stats
+	const lines = [
+		`# ${header.name}`,
+		`Voice: ${stats.voice} · Height: ${stats.height} · Hair: ${stats.hair} · Eyes: ${stats.eyes}`,
+		header.location,
+		'',
+		header.links.map((link) => `[${link.label}](${link.href})`).join(' | '),
+		'',
+		...sections.flatMap((section) => [
+			`## ${section.heading}`,
+			...section.credits.map(formatTheaterCreditMarkdown),
+			'',
+		]),
+		'## Other Relevant Skills',
+		...skills.map((skill) => `- ${skill}`),
+	]
+
+	return lines.join('\n').trim()
+}
+
+function ResumeUnavailable() {
+	return (
+		<div className="resume-page">
+			<Grid className="mx-10vw my-24">
+				<div className="col-span-full rounded-lg border border-gray-200 p-8 dark:border-gray-600">
+					<H4 as="h2" className="mb-3">
+						Resume is not available right now.
+					</H4>
+					<Paragraph className="mb-4">
+						We are likely having trouble with our GitHub integration. Please try
+						again soon, or browse the content directly on{' '}
+						<a
+							href={externalLinks.githubRepo}
+							target="_blank"
+							rel="noreferrer noopener"
+							className="text-primary underline"
+						>
+							GitHub
+						</a>
+						.
+					</Paragraph>
+					<ButtonLink variant="primary" to={externalLinks.githubRepo}>
+						Open GitHub repo
+					</ButtonLink>
+				</div>
+			</Grid>
+		</div>
+	)
+}
+
+function ResumePhoto({ onSecretClick }: { onSecretClick?: () => void }) {
+	const image = (
+		<img
+			className="resume-photo"
+			src={buildMediaUrl('kent/profile', {
+				height: 200,
+				aspectRatio: '1:1',
+				fit: 'cover',
+			})}
+			alt="Photo of Kent C. Dodds"
+		/>
+	)
+
+	if (!onSecretClick) return image
+
+	return (
+		<button
+			type="button"
+			className="resume-photo-button"
+			onClick={onSecretClick}
+		>
+			{image}
+		</button>
+	)
+}
+
+function ResumeLinks({ links }: { links: ResumeData['header']['links'] }) {
+	const printLinks = links.filter((link) => link.includeInPrint)
+
+	return (
+		<>
+			<div className="resume-links resume-links--screen">
+				{links.map((link, index) => (
+					<span key={link.href}>
+						<a href={link.href} target="_blank" rel="noreferrer noopener">
+							{link.label}
+						</a>
+						{index < links.length - 1 ? ' | ' : null}
+					</span>
+				))}
 			</div>
-		)
-	}
+			<div className="resume-links resume-links--print">
+				{printLinks.map((link, index) => (
+					<span key={link.href}>
+						<a href={link.href}>{link.label}</a>
+						{index < printLinks.length - 1 ? ' | ' : null}
+					</span>
+				))}
+			</div>
+		</>
+	)
+}
 
-	const data = resumeData
-	const printLinks = data.header.links.filter((link) => link.includeInPrint)
-	const recognitionView = getRecognitionView(data)
+function ResumeActions({ onCopyMarkdown }: { onCopyMarkdown: () => void }) {
+	return (
+		<div className="resume-toggle__actions">
+			<button
+				type="button"
+				className="resume-toggle__button"
+				onClick={onCopyMarkdown}
+			>
+				Copy as Markdown
+			</button>
+			<button
+				type="button"
+				className="resume-toggle__button"
+				onClick={() => window.print()}
+			>
+				Print
+			</button>
+		</div>
+	)
+}
+
+function SoftwareResumePage({
+	resumeData,
+	isShort,
+}: {
+	resumeData: ResumeData
+	isShort: boolean
+}) {
+	const navigate = useNavigate()
+	const photoClicksRef = React.useRef(0)
+	const viewKey = getViewKey(isShort)
+	const recognitionView = getRecognitionView(resumeData)
 
 	function handleCopyMarkdown() {
-		const markdown = formatMarkdown(data, isShort)
-		void navigator.clipboard.writeText(markdown)
+		void navigator.clipboard.writeText(formatMarkdown(resumeData, isShort))
 	}
 
-	function handlePrint() {
-		window.print()
+	function handlePhotoClick() {
+		photoClicksRef.current += 1
+		if (photoClicksRef.current < THEATER_RESUME_UNLOCK_CLICKS) return
+		photoClicksRef.current = 0
+		void navigate(getResumePath('theater'))
 	}
 
 	return (
@@ -157,7 +289,7 @@ export default function ResumePage({
 			<div className="resume-toggle">
 				<div className="resume-toggle__links">
 					<Link
-						to="/resume"
+						to={getResumePath('full')}
 						prefetch="intent"
 						className={
 							isShort ? 'resume-toggle__link' : 'resume-toggle__link is-active'
@@ -166,7 +298,7 @@ export default function ResumePage({
 						Full
 					</Link>
 					<Link
-						to="/resume?view=short"
+						to={getResumePath('short')}
 						prefetch="intent"
 						className={
 							isShort ? 'resume-toggle__link is-active' : 'resume-toggle__link'
@@ -175,66 +307,26 @@ export default function ResumePage({
 						Short (1 page)
 					</Link>
 				</div>
-				<div className="resume-toggle__actions">
-					<button
-						type="button"
-						className="resume-toggle__button"
-						onClick={handleCopyMarkdown}
-					>
-						Copy as Markdown
-					</button>
-					<button
-						type="button"
-						className="resume-toggle__button"
-						onClick={handlePrint}
-					>
-						Print
-					</button>
-				</div>
+				<ResumeActions onCopyMarkdown={handleCopyMarkdown} />
 			</div>
 
 			<main className="resume-main">
 				<header className="resume-header">
 					<div className="resume-header__identity">
-						<img
-							className="resume-photo"
-							src={buildMediaUrl('kent/profile', {
-								height: 200,
-								aspectRatio: '1:1',
-								fit: 'cover',
-							})}
-							alt="Photo of Kent C. Dodds"
-						/>
+						<ResumePhoto onSecretClick={handlePhotoClick} />
 						<div>
-							<h1 className="resume-name">{data.header.name}</h1>
-							<p className="resume-title">{data.header.title}</p>
-							<p className="resume-location">{data.header.location}</p>
+							<h1 className="resume-name">{resumeData.header.name}</h1>
+							<p className="resume-title">{resumeData.header.title}</p>
+							<p className="resume-location">{resumeData.header.location}</p>
 						</div>
 					</div>
-					<div className="resume-links resume-links--screen">
-						{data.header.links.map((link, index) => (
-							<span key={link.href}>
-								<a href={link.href} target="_blank" rel="noreferrer noopener">
-									{link.label}
-								</a>
-								{index < data.header.links.length - 1 ? ' | ' : null}
-							</span>
-						))}
-					</div>
-					<div className="resume-links resume-links--print">
-						{printLinks.map((link, index) => (
-							<span key={link.href}>
-								<a href={link.href}>{link.label}</a>
-								{index < printLinks.length - 1 ? ' | ' : null}
-							</span>
-						))}
-					</div>
+					<ResumeLinks links={resumeData.header.links} />
 				</header>
 
 				<section className="resume-section">
 					<h2 className="resume-heading">Summary</h2>
 					<ul className="resume-bullets">
-						{data.summary[viewKey].map((item) => (
+						{resumeData.summary[viewKey].map((item) => (
 							<li key={item}>{item}</li>
 						))}
 					</ul>
@@ -243,7 +335,7 @@ export default function ResumePage({
 				<section className="resume-section">
 					<h2 className="resume-heading">Public Work</h2>
 					<ul className="resume-bullets">
-						{data.publicWork[viewKey].map((item) => (
+						{resumeData.publicWork[viewKey].map((item) => (
 							<li key={item}>{item}</li>
 						))}
 					</ul>
@@ -252,35 +344,36 @@ export default function ResumePage({
 				<section className="resume-section">
 					<h2 className="resume-heading">Experience</h2>
 					<div className="resume-experience">
-						{(isShort ? data.experienceShort : data.experienceLong).map(
-							(job) => (
-								<article
-									key={`${job.company}-${job.role}`}
-									className="resume-job"
-								>
-									<div className="resume-job__row">
-										<div className="resume-job__title">
-											<strong>{job.company}</strong> — {job.role}
-										</div>
-										<div className="resume-job__dates">{job.dates}</div>
+						{(isShort
+							? resumeData.experienceShort
+							: resumeData.experienceLong
+						).map((job) => (
+							<article
+								key={`${job.company}-${job.role}`}
+								className="resume-job"
+							>
+								<div className="resume-job__row">
+									<div className="resume-job__title">
+										<strong>{job.company}</strong> — {job.role}
 									</div>
-									<div className="resume-job__context">{job.context}</div>
-									<ul className="resume-bullets">
-										{job.bullets[viewKey].map((bullet) => (
-											<li key={bullet}>{bullet}</li>
-										))}
-									</ul>
-								</article>
-							),
-						)}
+									<div className="resume-job__dates">{job.dates}</div>
+								</div>
+								<div className="resume-job__context">{job.context}</div>
+								<ul className="resume-bullets">
+									{job.bullets[viewKey].map((bullet) => (
+										<li key={bullet}>{bullet}</li>
+									))}
+								</ul>
+							</article>
+						))}
 					</div>
 				</section>
 
-				{data.projects.length ? (
+				{resumeData.projects.length ? (
 					<section className="resume-section">
 						<h2 className="resume-heading">Selected Projects</h2>
 						<ul className="resume-bullets">
-							{data.projects.map((project) => (
+							{resumeData.projects.map((project) => (
 								<li key={project.name}>
 									<strong>{project.name}</strong> — {project.description}
 								</li>
@@ -292,10 +385,10 @@ export default function ResumePage({
 				<section className="resume-section">
 					<h2 className="resume-heading">Skills</h2>
 					{isShort ? (
-						<p className="resume-inline">{data.skills.join(' · ')}</p>
+						<p className="resume-inline">{resumeData.skills.join(' · ')}</p>
 					) : (
 						<ul className="resume-bullets">
-							{data.skills.map((skill) => (
+							{resumeData.skills.map((skill) => (
 								<li key={skill}>{skill}</li>
 							))}
 						</ul>
@@ -318,7 +411,7 @@ export default function ResumePage({
 				<section className="resume-section">
 					<h2 className="resume-heading">Education</h2>
 					<p className="resume-inline">
-						{data.education
+						{resumeData.education
 							.map((item) => `${item.degree}, ${item.school} (${item.year})`)
 							.join(' · ')}
 					</p>
@@ -326,4 +419,121 @@ export default function ResumePage({
 			</main>
 		</div>
 	)
+}
+
+function TheaterCredit({ credit }: { credit: TheaterResumeCredit }) {
+	const show = credit.href ? (
+		<a href={credit.href} target="_blank" rel="noreferrer noopener">
+			{credit.show}
+		</a>
+	) : (
+		credit.show
+	)
+
+	return (
+		<article className="resume-credit">
+			<div className="resume-credit__show">
+				<strong>{show}</strong>
+			</div>
+			<div className="resume-credit__role">{credit.role ?? ''}</div>
+			<div className="resume-credit__company">{credit.company ?? ''}</div>
+			<div className="resume-credit__dates">{credit.dates}</div>
+		</article>
+	)
+}
+
+function TheaterResumePage({
+	theaterResumeData,
+}: {
+	theaterResumeData: TheaterResumeData
+}) {
+	const { header, sections, skills } = theaterResumeData
+	const stats = header.stats
+
+	function handleCopyMarkdown() {
+		void navigator.clipboard.writeText(formatTheaterMarkdown(theaterResumeData))
+	}
+
+	return (
+		<div className="resume-page">
+			<div className="resume-toggle">
+				<div className="resume-toggle__links">
+					<Link
+						to={getResumePath('full')}
+						prefetch="intent"
+						className="resume-toggle__link"
+					>
+						Software
+					</Link>
+					<Link
+						to={getResumePath('theater')}
+						prefetch="intent"
+						className="resume-toggle__link is-active"
+					>
+						Theater
+					</Link>
+				</div>
+				<ResumeActions onCopyMarkdown={handleCopyMarkdown} />
+			</div>
+
+			<main className="resume-main">
+				<header className="resume-header">
+					<div className="resume-header__identity">
+						<ResumePhoto />
+						<div>
+							<h1 className="resume-name">{header.name}</h1>
+							<p className="resume-title">
+								Voice: {stats.voice} · Height: {stats.height} · Hair:{' '}
+								{stats.hair} · Eyes: {stats.eyes}
+							</p>
+							<p className="resume-location">{header.location}</p>
+						</div>
+					</div>
+					<ResumeLinks links={header.links} />
+				</header>
+
+				{sections.map((section) => (
+					<section key={section.heading} className="resume-section">
+						<h2 className="resume-heading">{section.heading}</h2>
+						<div className="resume-credits">
+							{section.credits.map((credit) => (
+								<TheaterCredit
+									key={`${credit.show}-${credit.role ?? ''}-${credit.dates}`}
+									credit={credit}
+								/>
+							))}
+						</div>
+					</section>
+				))}
+
+				<section className="resume-section">
+					<h2 className="resume-heading">Other Relevant Skills</h2>
+					<p className="resume-inline">{skills.join(' · ')}</p>
+				</section>
+			</main>
+		</div>
+	)
+}
+
+export default function ResumePage({
+	loaderData: { resumeData, theaterResumeData, view },
+}: Route.ComponentProps) {
+	switch (view) {
+		case 'theater':
+			if (!theaterResumeData) return <ResumeUnavailable />
+			return <TheaterResumePage theaterResumeData={theaterResumeData} />
+		case 'short':
+		case 'full':
+			if (!resumeData) return <ResumeUnavailable />
+			return (
+				<SoftwareResumePage
+					resumeData={resumeData}
+					isShort={view === 'short'}
+				/>
+			)
+		default: {
+			const exhaustive: never = view
+			throw new Error(`Unknown resume view: ${String(exhaustive)}`)
+		}
+	}
 }

--- a/services/site/app/styles/resume.css
+++ b/services/site/app/styles/resume.css
@@ -73,13 +73,8 @@
 	flex-shrink: 0;
 }
 
-.resume-photo-button {
-	border: 0;
-	padding: 0;
-	background: transparent;
+.resume-photo--secret {
 	cursor: pointer;
-	flex-shrink: 0;
-	border-radius: 999px;
 }
 
 .resume-credits {
@@ -97,6 +92,7 @@
 
 .resume-credit__show a {
 	color: inherit;
+	text-decoration: underline;
 }
 
 .resume-credit__role,
@@ -396,8 +392,7 @@ html.light .resume-bullets li::marker {
 		font-family: Arial, Helvetica, 'Liberation Sans', sans-serif;
 	}
 
-	.resume-photo,
-	.resume-photo-button {
+	.resume-photo {
 		display: none;
 	}
 

--- a/services/site/app/styles/resume.css
+++ b/services/site/app/styles/resume.css
@@ -73,6 +73,44 @@
 	flex-shrink: 0;
 }
 
+.resume-photo-button {
+	border: 0;
+	padding: 0;
+	background: transparent;
+	cursor: pointer;
+	flex-shrink: 0;
+	border-radius: 999px;
+}
+
+.resume-credits {
+	display: grid;
+	gap: 8px;
+}
+
+.resume-credit {
+	display: grid;
+	grid-template-columns: minmax(0, 1.6fr) minmax(0, 1.1fr) minmax(0, 1.3fr) auto;
+	gap: 8px 12px;
+	align-items: baseline;
+	font-size: 0.95rem;
+}
+
+.resume-credit__show a {
+	color: inherit;
+}
+
+.resume-credit__role,
+.resume-credit__company,
+.resume-credit__dates {
+	font-size: 0.85rem;
+	color: #555555;
+}
+
+.resume-credit__dates {
+	white-space: nowrap;
+	text-align: right;
+}
+
 .resume-name {
 	font-size: 1.6rem;
 	margin: 0;
@@ -209,6 +247,16 @@
 		white-space: normal;
 	}
 
+	.resume-credit {
+		grid-template-columns: 1fr;
+		gap: 2px;
+	}
+
+	.resume-credit__dates {
+		text-align: left;
+		white-space: normal;
+	}
+
 	.resume-bullets {
 		padding-left: 16px;
 	}
@@ -252,7 +300,10 @@
 	.resume-location,
 	.resume-links,
 	.resume-job__dates,
-	.resume-job__context {
+	.resume-job__context,
+	.resume-credit__role,
+	.resume-credit__company,
+	.resume-credit__dates {
 		color: #cbd5f5;
 	}
 
@@ -277,7 +328,10 @@ html.dark .resume-toggle__link.is-active {
 html.dark .resume-location,
 html.dark .resume-links,
 html.dark .resume-job__dates,
-html.dark .resume-job__context {
+html.dark .resume-job__context,
+html.dark .resume-credit__role,
+html.dark .resume-credit__company,
+html.dark .resume-credit__dates {
 	color: #cbd5f5;
 }
 
@@ -300,7 +354,10 @@ html.light .resume-toggle__link.is-active {
 
 html.light .resume-location,
 html.light .resume-job__dates,
-html.light .resume-job__context {
+html.light .resume-job__context,
+html.light .resume-credit__role,
+html.light .resume-credit__company,
+html.light .resume-credit__dates {
 	color: #555555;
 }
 
@@ -339,7 +396,8 @@ html.light .resume-bullets li::marker {
 		font-family: Arial, Helvetica, 'Liberation Sans', sans-serif;
 	}
 
-	.resume-photo {
+	.resume-photo,
+	.resume-photo-button {
 		display: none;
 	}
 

--- a/services/site/app/utils/__tests__/resume.test.ts
+++ b/services/site/app/utils/__tests__/resume.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import {
+	getResumePath,
+	getResumeView,
+	THEATER_RESUME_VIEW,
+} from '#app/utils/resume.ts'
+import { parseTheaterResumeData } from '#app/utils/resume.server.ts'
+
+test('getResumeView treats theater as a hidden resume view', () => {
+	expect(getResumeView(null)).toBe('full')
+	expect(getResumeView('short')).toBe('short')
+	expect(getResumeView(THEATER_RESUME_VIEW)).toBe('theater')
+	expect(getResumeView('performing')).toBe('full')
+})
+
+test('getResumePath keeps theater off the default resume URLs', () => {
+	expect(getResumePath('full')).toBe('/resume')
+	expect(getResumePath('short')).toBe('/resume?view=short')
+	expect(getResumePath('theater')).toBe(`/resume?view=${THEATER_RESUME_VIEW}`)
+})
+
+test('theater resume YAML includes the performing arts credits', () => {
+	const raw = fs.readFileSync(
+		path.join(process.cwd(), 'content/data/theater-resume.yml'),
+		'utf8',
+	)
+	const data = parseTheaterResumeData(raw)
+	const theater = data.sections.find((section) => section.heading === 'Theater')
+	const findingNeverland = theater?.credits.find(
+		(credit) => credit.show === 'Finding Neverland',
+	)
+
+	expect(data.header.stats.voice).toBe('Tenor')
+	expect(data.header.stats.height).toBe(`5'9"`)
+	expect(findingNeverland).toMatchObject({
+		role: 'Elliot',
+		company: 'Alpine Community Theater',
+		dates: '2026',
+		href: 'https://alpinecommunitytheater.org/2026/07/09/finding-neverland-playing-now/',
+	})
+	expect(JSON.stringify(data)).not.toMatch(/801-|phone/i)
+})

--- a/services/site/app/utils/resume.server.ts
+++ b/services/site/app/utils/resume.server.ts
@@ -55,18 +55,69 @@ const resumeDataSchema = z.object({
 	recognitionByLength: resumeSectionSchema.optional(),
 })
 
-export type ResumeData = z.infer<typeof resumeDataSchema>
+const theaterCreditSchema = z.object({
+	show: z.string(),
+	role: z.string().optional(),
+	company: z.string().optional(),
+	dates: z.string(),
+	href: z.string().optional(),
+})
 
-async function getResumeData({
+const theaterResumeDataSchema = z.object({
+	header: z.object({
+		name: z.string(),
+		location: z.string(),
+		stats: z.object({
+			voice: z.string(),
+			height: z.string(),
+			hair: z.string(),
+			eyes: z.string(),
+		}),
+		links: z.array(resumeLinkSchema),
+	}),
+	sections: z.array(
+		z.object({
+			heading: z.string(),
+			credits: z.array(theaterCreditSchema),
+		}),
+	),
+	skills: z.array(z.string()),
+})
+
+export type ResumeData = z.infer<typeof resumeDataSchema>
+export type TheaterResumeData = z.infer<typeof theaterResumeDataSchema>
+export type TheaterResumeCredit = z.infer<typeof theaterCreditSchema>
+
+function parseYamlData<T>(raw: string, schema: z.ZodType<T>, label: string) {
+	const parsed = YAML.parse(raw)
+	const result = schema.safeParse(parsed)
+	if (!result.success) {
+		console.error(`${label} data is invalid`, result.error.flatten())
+		throw new Error(`${label} data is invalid.`)
+	}
+	return result.data
+}
+
+export function parseTheaterResumeData(raw: string) {
+	return parseYamlData(raw, theaterResumeDataSchema, 'Theater resume')
+}
+
+async function getCachedYamlData<T>({
+	filename,
+	schema,
+	label,
 	request,
 	forceFresh,
 	timings,
 }: {
+	filename: string
+	schema: z.ZodType<T>
+	label: string
 	request?: Request
 	forceFresh?: boolean
 	timings?: Timings
 }) {
-	const key = getContentDataCacheKey('resume.yml')
+	const key = getContentDataCacheKey(filename)
 	try {
 		return await cachified({
 			cache,
@@ -77,24 +128,56 @@ async function getResumeData({
 			staleWhileRevalidate: 1000 * 60 * 60 * 24 * 30,
 			forceFresh,
 			getFreshValue: async () => {
-				const resumeString = await getContentDataFile('data/resume.yml')
-				if (!resumeString) {
-					throw new Error('resume.yml is unavailable')
+				const raw = await getContentDataFile(`data/${filename}`)
+				if (!raw) {
+					throw new Error(`${filename} is unavailable`)
 				}
-				const parsed = YAML.parse(resumeString)
-				const result = resumeDataSchema.safeParse(parsed)
-				if (!result.success) {
-					console.error('Resume data is invalid', result.error.flatten())
-					throw new Error('Resume data is invalid.')
-				}
-				return result.data
+				return parseYamlData(raw, schema, label)
 			},
-			checkValue: (value: unknown) => resumeDataSchema.safeParse(value).success,
+			checkValue: (value: unknown) => schema.safeParse(value).success,
 		})
 	} catch (error: unknown) {
-		console.error(`resume: failed to load resume data, returning null`, error)
+		console.error(`${label}: failed to load data, returning null`, error)
 		return null
 	}
 }
 
-export { getResumeData }
+async function getResumeData({
+	request,
+	forceFresh,
+	timings,
+}: {
+	request?: Request
+	forceFresh?: boolean
+	timings?: Timings
+}) {
+	return getCachedYamlData({
+		filename: 'resume.yml',
+		schema: resumeDataSchema,
+		label: 'Resume',
+		request,
+		forceFresh,
+		timings,
+	})
+}
+
+async function getTheaterResumeData({
+	request,
+	forceFresh,
+	timings,
+}: {
+	request?: Request
+	forceFresh?: boolean
+	timings?: Timings
+}) {
+	return getCachedYamlData({
+		filename: 'theater-resume.yml',
+		schema: theaterResumeDataSchema,
+		label: 'Theater resume',
+		request,
+		forceFresh,
+		timings,
+	})
+}
+
+export { getResumeData, getTheaterResumeData }

--- a/services/site/app/utils/resume.ts
+++ b/services/site/app/utils/resume.ts
@@ -1,0 +1,30 @@
+export const THEATER_RESUME_VIEW = 'theater'
+export const THEATER_RESUME_UNLOCK_CLICKS = 5
+
+export type ResumeView = 'full' | 'short' | 'theater'
+
+export function getResumeView(viewParam: string | null): ResumeView {
+	switch (viewParam) {
+		case 'short':
+			return 'short'
+		case THEATER_RESUME_VIEW:
+			return 'theater'
+		default:
+			return 'full'
+	}
+}
+
+export function getResumePath(view: ResumeView) {
+	switch (view) {
+		case 'short':
+			return '/resume?view=short'
+		case 'theater':
+			return `/resume?view=${THEATER_RESUME_VIEW}`
+		case 'full':
+			return '/resume'
+		default: {
+			const exhaustive: never = view
+			return exhaustive
+		}
+	}
+}

--- a/services/site/content/data/theater-resume.yml
+++ b/services/site/content/data/theater-resume.yml
@@ -1,0 +1,53 @@
+header:
+  name: 'Kent C. Dodds'
+  location: 'Utah, USA'
+  stats:
+    voice: 'Tenor'
+    height: '5''9"'
+    hair: 'Brown'
+    eyes: 'Blue'
+  links:
+    - label: 'kentcdodds.com'
+      href: 'https://kentcdodds.com'
+      includeInPrint: true
+    - label: 'me@kentcdodds.com'
+      href: 'mailto:me@kentcdodds.com'
+      includeInPrint: true
+sections:
+  - heading: 'Theater'
+    credits:
+      - show: 'Finding Neverland'
+        role: 'Elliot'
+        company: 'Alpine Community Theater'
+        dates: '2026'
+        href: 'https://alpinecommunitytheater.org/2026/07/09/finding-neverland-playing-now/'
+      - show: 'Les Misérables'
+        role: 'Chorus'
+        dates: '2006'
+      - show: 'The Sound of Music'
+        role: 'Rolf / Herr Zeller'
+        dates: '2005'
+  - heading: 'Show Choir'
+    credits:
+      - show: 'Twin Falls High School Jive!'
+        role: 'Tenor I and Tenor II'
+        dates: '2004–2007'
+  - heading: 'Choir'
+    credits:
+      - show: 'The BYU Men’s Chorus'
+        role: 'Tenor I'
+        dates: '2007, 2010'
+      - show: 'Twin Falls High School Chamber Singers'
+        role: 'Tenor I and Tenor II'
+        dates: '2005–2007'
+      - show: 'Twin Falls High School Concert Choir'
+        role: 'Tenor I, Tenor II, and Baritone'
+        dates: '2004–2005'
+  - heading: 'Training'
+    credits:
+      - show: 'Voice lessons'
+        dates: '2006'
+      - show: 'Piano lessons'
+        dates: '1994–2004'
+skills:
+  - 'Gymnastics'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hidden theater resume for Kent’s performing arts credits, reachable as an easter egg on `/resume`.

## What’s new

- `/resume?view=theater` renders a performing arts resume instead of the software one
- Clicking the profile photo five times on the software resume unlocks that view
- Theater view has Software / Theater toggles, plus the existing print and copy-as-markdown actions
- The default `/resume` payload only includes the software resume, so theater credits stay out of the page source until that view is requested

## Credits

Source material is Kent’s theater resume Google Doc, with Finding Neverland added as the most recent credit:

- **Finding Neverland** — Elliot — Alpine Community Theater — 2026
- Les Misérables, The Sound of Music, Jive!, BYU Men’s Chorus, high school choir, voice/piano, gymnastics

Public contact details match the software resume (`kentcdodds.com` and `me@kentcdodds.com`). The old document’s phone number is not included.

## Test plan

- [x] Unit tests for `?view=theater` routing and YAML parsing (includes Finding Neverland / Elliot)
- [x] Site lint, typecheck, backend tests, and browser tests via pre-commit / pre-push
- [ ] Open `/resume` and confirm Full / Short still behave as before
- [ ] Confirm `/resume` page source does not include Finding Neverland
- [ ] Click the profile photo five times and land on the theater resume
- [ ] Open `/resume?view=theater` directly and confirm credits, print, and copy-as-markdown

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37278105-8bf8-4e33-9645-cc23e655d9a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37278105-8bf8-4e33-9645-cc23e655d9a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theater resume view featuring performance credits, training, skills, statistics, and contact links.
  * Added full and short software resume views with streamlined navigation between formats.
  * Added support for copying either resume as Markdown.
  * Repeatedly clicking the resume photo unlocks the theater view.
* **Enhancements**
  * Improved responsive layouts for theater credits and mobile screens.
  * Updated print layouts to omit the photo and photo controls.
  * Added clearer handling for unavailable resume content and invalid view selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->