### PR TITLE
Theater resume: personal email and light-mode print

### DIFF
--- a/services/site/app/routes/resume.tsx
+++ b/services/site/app/routes/resume.tsx
@@ -197,10 +197,12 @@ function ResumeUnavailable() {
 	)
 }
 
-function ResumePhoto({ onSecretClick }: { onSecretClick: () => void }) {
+function ResumePhoto({ onSecretClick }: { onSecretClick?: () => void }) {
 	return (
 		<img
-			className="resume-photo resume-photo--secret"
+			className={
+				onSecretClick ? 'resume-photo resume-photo--secret' : 'resume-photo'
+			}
 			src={buildMediaUrl('kent/profile', {
 				height: 200,
 				aspectRatio: '1:1',
@@ -478,12 +480,15 @@ function TheaterResumePage({
 			<main className="resume-main">
 				<header className="resume-header">
 					<div className="resume-header__identity">
-						<h1 className="resume-name">{header.name}</h1>
-						<p className="resume-title">
-							Voice: {stats.voice} · Height: {stats.height} · Hair: {stats.hair}{' '}
-							· Eyes: {stats.eyes}
-						</p>
-						<p className="resume-location">{header.location}</p>
+						<ResumePhoto />
+						<div>
+							<h1 className="resume-name">{header.name}</h1>
+							<p className="resume-title">
+								Voice: {stats.voice} · Height: {stats.height} · Hair:{' '}
+								{stats.hair} · Eyes: {stats.eyes}
+							</p>
+							<p className="resume-location">{header.location}</p>
+						</div>
 					</div>
 					<ResumeLinks links={header.links} />
 				</header>

--- a/services/site/app/routes/resume.tsx
+++ b/services/site/app/routes/resume.tsx
@@ -197,12 +197,10 @@ function ResumeUnavailable() {
 	)
 }
 
-function ResumePhoto({ onSecretClick }: { onSecretClick?: () => void }) {
+function ResumePhoto({ onSecretClick }: { onSecretClick: () => void }) {
 	return (
 		<img
-			className={
-				onSecretClick ? 'resume-photo resume-photo--secret' : 'resume-photo'
-			}
+			className="resume-photo resume-photo--secret"
 			src={buildMediaUrl('kent/profile', {
 				height: 200,
 				aspectRatio: '1:1',
@@ -480,15 +478,12 @@ function TheaterResumePage({
 			<main className="resume-main">
 				<header className="resume-header">
 					<div className="resume-header__identity">
-						<ResumePhoto />
-						<div>
-							<h1 className="resume-name">{header.name}</h1>
-							<p className="resume-title">
-								Voice: {stats.voice} · Height: {stats.height} · Hair:{' '}
-								{stats.hair} · Eyes: {stats.eyes}
-							</p>
-							<p className="resume-location">{header.location}</p>
-						</div>
+						<h1 className="resume-name">{header.name}</h1>
+						<p className="resume-title">
+							Voice: {stats.voice} · Height: {stats.height} · Hair: {stats.hair}{' '}
+							· Eyes: {stats.eyes}
+						</p>
+						<p className="resume-location">{header.location}</p>
 					</div>
 					<ResumeLinks links={header.links} />
 				</header>

--- a/services/site/app/styles/resume.css
+++ b/services/site/app/styles/resume.css
@@ -279,7 +279,7 @@
 	}
 }
 
-@media (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
 	.resume-page {
 		color: #e2e8f0;
 	}
@@ -308,61 +308,63 @@
 	}
 }
 
-html.dark .resume-page {
-	color: #e2e8f0;
-}
+@media screen {
+	html.dark .resume-page {
+		color: #e2e8f0;
+	}
 
-html.dark .resume-toggle__link,
-html.dark .resume-toggle__button {
-	border-color: #475569;
-}
+	html.dark .resume-toggle__link,
+	html.dark .resume-toggle__button {
+		border-color: #475569;
+	}
 
-html.dark .resume-toggle__link.is-active {
-	border-color: #e2e8f0;
-}
+	html.dark .resume-toggle__link.is-active {
+		border-color: #e2e8f0;
+	}
 
-html.dark .resume-location,
-html.dark .resume-links,
-html.dark .resume-job__dates,
-html.dark .resume-job__context,
-html.dark .resume-credit__role,
-html.dark .resume-credit__company,
-html.dark .resume-credit__dates {
-	color: #cbd5f5;
-}
+	html.dark .resume-location,
+	html.dark .resume-links,
+	html.dark .resume-job__dates,
+	html.dark .resume-job__context,
+	html.dark .resume-credit__role,
+	html.dark .resume-credit__company,
+	html.dark .resume-credit__dates {
+		color: #cbd5f5;
+	}
 
-html.dark .resume-bullets li::marker {
-	color: #94a3b8;
-}
+	html.dark .resume-bullets li::marker {
+		color: #94a3b8;
+	}
 
-html.light .resume-page {
-	color: #222222;
-}
+	html.light .resume-page {
+		color: #222222;
+	}
 
-html.light .resume-toggle__link,
-html.light .resume-toggle__button {
-	border-color: #bdbdbd;
-}
+	html.light .resume-toggle__link,
+	html.light .resume-toggle__button {
+		border-color: #bdbdbd;
+	}
 
-html.light .resume-toggle__link.is-active {
-	border-color: #333333;
-}
+	html.light .resume-toggle__link.is-active {
+		border-color: #333333;
+	}
 
-html.light .resume-location,
-html.light .resume-job__dates,
-html.light .resume-job__context,
-html.light .resume-credit__role,
-html.light .resume-credit__company,
-html.light .resume-credit__dates {
-	color: #555555;
-}
+	html.light .resume-location,
+	html.light .resume-job__dates,
+	html.light .resume-job__context,
+	html.light .resume-credit__role,
+	html.light .resume-credit__company,
+	html.light .resume-credit__dates {
+		color: #555555;
+	}
 
-html.light .resume-links {
-	color: #444444;
-}
+	html.light .resume-links {
+		color: #444444;
+	}
 
-html.light .resume-bullets li::marker {
-	color: #888888;
+	html.light .resume-bullets li::marker {
+		color: #888888;
+	}
 }
 
 @media print {
@@ -378,18 +380,52 @@ html.light .resume-bullets li::marker {
 		display: none;
 	}
 
+	/* Print must stay light even when the site or OS is in dark mode.
+	   `html.dark` / prefers-color-scheme otherwise keep slate text and a dark
+	   canvas (`color-scheme: dark` on `.dark`). */
+	html,
+	html.dark,
+	html.light,
+	body {
+		color-scheme: only light !important;
+		background: #ffffff !important;
+		color: #000000 !important;
+		print-color-adjust: exact;
+		-webkit-print-color-adjust: exact;
+	}
+
 	.resume-page {
 		max-width: none;
 		padding: 0;
+		background: #ffffff !important;
+		color: #222222 !important;
 	}
 
 	main.resume-main {
-		color: #000000;
+		color: #000000 !important;
+		background: #ffffff !important;
 		/* Pin metric-compatible fonts (Arial on Windows, Helvetica on macOS,
 		   Liberation Sans on Linux) so pagination is stable across machines.
 		   Wider system-font fallbacks (e.g. DejaVu Sans) push the one-page
 		   view onto a second page. */
 		font-family: Arial, Helvetica, 'Liberation Sans', sans-serif;
+	}
+
+	.resume-location,
+	.resume-job__dates,
+	.resume-job__context,
+	.resume-credit__role,
+	.resume-credit__company,
+	.resume-credit__dates {
+		color: #555555 !important;
+	}
+
+	.resume-links {
+		color: #444444 !important;
+	}
+
+	.resume-bullets li::marker {
+		color: #888888 !important;
 	}
 
 	.resume-photo {

--- a/services/site/app/utils/__tests__/resume.test.ts
+++ b/services/site/app/utils/__tests__/resume.test.ts
@@ -47,8 +47,5 @@ test('theater resume YAML includes the performing arts credits', () => {
 			includeInPrint: true,
 		},
 	])
-	expect(data.header.links.map((link) => link.href).join(' ')).not.toMatch(
-		/https?:\/\/kentcdodds\.com/i,
-	)
 	expect(JSON.stringify(data)).not.toMatch(/801-|phone/i)
 })

--- a/services/site/app/utils/__tests__/resume.test.ts
+++ b/services/site/app/utils/__tests__/resume.test.ts
@@ -40,5 +40,15 @@ test('theater resume YAML includes the performing arts credits', () => {
 		dates: '2026',
 		href: 'https://alpinecommunitytheater.org/2026/07/09/finding-neverland-playing-now/',
 	})
+	expect(data.header.links).toEqual([
+		{
+			label: 'kentcdodds@gmail.com',
+			href: 'mailto:kentcdodds@gmail.com',
+			includeInPrint: true,
+		},
+	])
+	expect(data.header.links.map((link) => link.href).join(' ')).not.toMatch(
+		/https?:\/\/kentcdodds\.com/i,
+	)
 	expect(JSON.stringify(data)).not.toMatch(/801-|phone/i)
 })

--- a/services/site/content/data/theater-resume.yml
+++ b/services/site/content/data/theater-resume.yml
@@ -7,11 +7,8 @@ header:
     hair: 'Brown'
     eyes: 'Blue'
   links:
-    - label: 'kentcdodds.com'
-      href: 'https://kentcdodds.com'
-      includeInPrint: true
-    - label: 'me@kentcdodds.com'
-      href: 'mailto:me@kentcdodds.com'
+    - label: 'kentcdodds@gmail.com'
+      href: 'mailto:kentcdodds@gmail.com'
       includeInPrint: true
 sections:
   - heading: 'Theater'

--- a/services/site/e2e/resume-print.spec.ts
+++ b/services/site/e2e/resume-print.spec.ts
@@ -32,3 +32,41 @@ test('full resume prints without trailing blank pages', async ({ page }) => {
 	// the expected count.
 	expect(getPdfPageCount(pdf)).toBe(2)
 })
+
+test('resume print uses light colors when the page is in dark mode', async ({
+	page,
+}) => {
+	await page.emulateMedia({ colorScheme: 'dark' })
+	await page.goto('/resume')
+	await expect(page.locator('main.resume-main')).toBeVisible()
+	await page.evaluate(() => document.documentElement.classList.add('dark'))
+	await page.emulateMedia({ media: 'print', colorScheme: 'dark' })
+
+	const colors = await page.evaluate(() => {
+		const pageEl = document.querySelector('.resume-page')
+		const mainEl = document.querySelector('main.resume-main')
+		const locationEl = document.querySelector('.resume-location')
+		if (!pageEl || !mainEl || !locationEl) {
+			throw new Error('Resume print elements were not found')
+		}
+		const htmlStyle = getComputedStyle(document.documentElement)
+		const bodyStyle = getComputedStyle(document.body)
+		const pageStyle = getComputedStyle(pageEl)
+		const mainStyle = getComputedStyle(mainEl)
+		const locationStyle = getComputedStyle(locationEl)
+		return {
+			htmlBackground: htmlStyle.backgroundColor,
+			bodyBackground: bodyStyle.backgroundColor,
+			pageColor: pageStyle.color,
+			pageBackground: pageStyle.backgroundColor,
+			mainColor: mainStyle.color,
+			locationColor: locationStyle.color,
+		}
+	})
+
+	expect(colors.htmlBackground).toBe('rgb(255, 255, 255)')
+	expect(colors.bodyBackground).toBe('rgb(255, 255, 255)')
+	expect(colors.pageBackground).toBe('rgb(255, 255, 255)')
+	expect(colors.mainColor).toBe('rgb(0, 0, 0)')
+	expect(colors.locationColor).toBe('rgb(85, 85, 85)')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the theater resume easter egg.

- Keep the photo on the **site** theater view
- Print still hides it (existing `.resume-photo { display: none }` in the print stylesheet)
- Remove `kentcdodds.com` from theater contact links
- Use `kentcdodds@gmail.com` instead of `me@kentcdodds.com`
- Resume print always uses light colors, even when the site or OS is in dark mode

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37278105-8bf8-4e33-9645-cc23e655d9a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37278105-8bf8-4e33-9645-cc23e655d9a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Content Updates**
  * Updated the theater resume contact information to feature the current email address with a direct mail link.
  * Removed the previous website and email entries.

* **Bug Fixes**
  * Improved resume printing in dark mode with light backgrounds, dark text, and clearer secondary content.

* **Tests**
  * Added coverage for the displayed email link and print appearance in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->