### PR TITLE
Fix resume print staying dark during theme transition

### DIFF
--- a/services/site/app/styles/resume.css
+++ b/services/site/app/styles/resume.css
@@ -382,13 +382,26 @@
 
 	/* Print must stay light even when the site or OS is in dark mode.
 	   `html.dark` / prefers-color-scheme otherwise keep slate text and a dark
-	   canvas (`color-scheme: dark` on `.dark`). */
+	   canvas (`color-scheme: dark` on `.dark`). Body also has
+	   `dark:bg-gray-900` plus `transition duration-500`, so disable
+	   transitions or computed print colors stay on the dark interpolated
+	   value. */
+	*,
+	*::before,
+	*::after {
+		transition: none !important;
+		animation: none !important;
+	}
+
 	html,
 	html.dark,
 	html.light,
+	html.dark body,
+	html.light body,
 	body {
 		color-scheme: only light !important;
-		background: #ffffff !important;
+		background-color: #ffffff !important;
+		background-image: none !important;
 		color: #000000 !important;
 		print-color-adjust: exact;
 		-webkit-print-color-adjust: exact;

--- a/services/site/e2e/resume-print.spec.ts
+++ b/services/site/e2e/resume-print.spec.ts
@@ -41,11 +41,6 @@ test('resume print uses light colors when the page is in dark mode', async ({
 	await expect(page.locator('main.resume-main')).toBeVisible()
 	await page.evaluate(() => document.documentElement.classList.add('dark'))
 	await page.emulateMedia({ media: 'print', colorScheme: 'dark' })
-	await page.evaluate(() => {
-		for (const animation of document.getAnimations()) {
-			animation.finish()
-		}
-	})
 
 	const colors = await page.evaluate(() => {
 		const pageEl = document.querySelector('.resume-page')

--- a/services/site/e2e/resume-print.spec.ts
+++ b/services/site/e2e/resume-print.spec.ts
@@ -41,6 +41,11 @@ test('resume print uses light colors when the page is in dark mode', async ({
 	await expect(page.locator('main.resume-main')).toBeVisible()
 	await page.evaluate(() => document.documentElement.classList.add('dark'))
 	await page.emulateMedia({ media: 'print', colorScheme: 'dark' })
+	await page.evaluate(() => {
+		for (const animation of document.getAnimations()) {
+			animation.finish()
+		}
+	})
 
 	const colors = await page.evaluate(() => {
 		const pageEl = document.querySelector('.resume-page')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #894. Playwright failed on the light-print e2e because `body` uses `dark:bg-gray-900` with `transition duration-500`. Print CSS set a white background, but `getComputedStyle` still saw the dark interpolated canvas (`rgb(31, 32, 40)` / `rgb(32, 33, 41)`).

- Disable transitions and animations in the resume print stylesheet
- Force `html.dark body` to a white background

Dropped an e2e `animation.finish()` settle loop after Bugbot: it throws `InvalidStateError` on the navbar's infinite framer-motion rotate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37278105-8bf8-4e33-9645-cc23e655d9a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37278105-8bf8-4e33-9645-cc23e655d9a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume print output by ensuring animations and transitions do not affect printed styles.
  * Preserved appropriate light and dark color schemes when printing resumes.
  * Improved background rendering consistency in print previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->