### PR TITLE
docs(agents): always enable Cursor Cloud PR tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,4 @@ project-specific guidance over generic advice.
 ## Cursor Cloud specific instructions
 
 - See `docs/agents/project-context.md` for setup, commands, seed data, VM
-  snapshot details, and caveats.
+  snapshot details, caveats, and Cursor Cloud PR ownership.

--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -166,6 +166,13 @@ user against the local Miniflare D1 database: `me@kentcdodds.com` / `iliketwix`
 After `npm run db:reset --workspace kentcdodds.com`, verify the seed ran.
 Unit tests apply committed SQL migrations via `app/utils/db/test-helpers.server.ts`.
 
+## Cursor Cloud PR ownership
+
+Code-changing agents push their branch and create or update the pull request
+with Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before finishing.
+`@kentcdodds/cursor` `createAgent` always enables those tools. Never have
+Kody/workflows/GitHub create the initial PR as a substitute.
+
 ## Cloud / headless manual testing
 
 - The Cursor Cloud VM snapshot's default nvm Node is older than the required


### PR DESCRIPTION
Add the same Cursor Cloud PR-ownership note as kody: agents open their own PRs via ManagePullRequest, and `createAgent` always enables those tools.

Low-risk docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only agent workflow guidance; no application, auth, or runtime code changes.
> 
> **Overview**
> Documents that **code-changing agents must open or update their own PRs** via Cursor Cloud **`ManagePullRequest`** (Kent C. Dodds account) before finishing, and that **`@kentcdodds/cursor` `createAgent` always enables those tools**.
> 
> Adds a **Cursor Cloud PR ownership** section under **`docs/agents/project-context.md`** and updates **`AGENTS.md`** so the Cursor Cloud bullet points readers at that section (including PR ownership alongside setup and VM caveats). The guidance explicitly says **not** to use Kody, workflows, or GitHub as a substitute for the initial PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d923052012942c161efc1f70e2d5c504c875ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->