### PR TITLE
Hard-reload on React Router SPA-nav network TypeErrors (KCD-10B)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -41,7 +41,8 @@ fetch resource` / Safari `Load failed` with React Router stacks
   and skips Sentry capture for that signature. If `sessionStorage` is
   unavailable, skip the hard-reload (avoid loops) and show the normal error
   UI; `shouldShowSpaNavNetworkReconnecting` only renders “Reconnecting…” when
-  a reload will still be attempted.
+  storage reads show the one-shot is unused **and** a `setItem` write probe
+  succeeds (so a write failure cannot leave a stuck reconnecting state).
 - Blog `markAsRead()` (`routes/action/mark-as-read.tsx`) is best-effort read
   tracking. Uncaught `fetch` rejections from that path are app noise: keep the
   catch inside `markAsRead` (KCD-FY / KCD-1R / KCD-ZW / KCD-WV), do not filter

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -35,8 +35,10 @@ fetch resource` / Safari `Load failed` with React Router stacks
   failing `.data` / `__manifest` breadcrumb **without** `status_code` are
   browser network-layer failures during SPA nav (idle tab, offline, flaky
   mobile) — not an app throw. Live endpoints often still return 200. Do not
-  broadly `ignoreErrors` these (KCD-XZ / KCD-QG family); optional product UX is
-  a hard-reload fallback on nav TypeError.
+  broadly `ignoreErrors` these (KCD-XZ / KCD-QG / KCD-10B family). Product UX:
+  `useCapturedRouteError` hard-reloads the document once per location
+  (`isReactRouterSpaNavNetworkError` + `shouldHardReloadSpaNavNetworkError`)
+  and skips Sentry capture for that signature.
 - Blog `markAsRead()` (`routes/action/mark-as-read.tsx`) is best-effort read
   tracking. Uncaught `fetch` rejections from that path are app noise: keep the
   catch inside `markAsRead` (KCD-FY / KCD-1R / KCD-ZW / KCD-WV), do not filter

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -39,8 +39,10 @@ fetch resource` / Safari `Load failed` with React Router stacks
   `useCapturedRouteError` hard-reloads the document once per location
   (`isReactRouterSpaNavNetworkError` + `shouldHardReloadSpaNavNetworkError`)
   and skips Sentry capture for that signature. If `sessionStorage` is
-  unavailable, skip the hard-reload (avoid loops) and show the normal error
-  UI; `shouldShowSpaNavNetworkReconnecting` only renders “Reconnecting…” when
+  unavailable (including when accessing `window.sessionStorage` itself throws),
+  skip the hard-reload (avoid loops) and show the normal error UI;
+  `getSessionStorageSafely` returns null in that case.
+  `shouldShowSpaNavNetworkReconnecting` only renders “Reconnecting…” when
   storage reads show the one-shot is unused **and** a `setItem` write probe
   succeeds (so a write failure cannot leave a stuck reconnecting state).
 - Blog `markAsRead()` (`routes/action/mark-as-read.tsx`) is best-effort read

--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -38,7 +38,10 @@ fetch resource` / Safari `Load failed` with React Router stacks
   broadly `ignoreErrors` these (KCD-XZ / KCD-QG / KCD-10B family). Product UX:
   `useCapturedRouteError` hard-reloads the document once per location
   (`isReactRouterSpaNavNetworkError` + `shouldHardReloadSpaNavNetworkError`)
-  and skips Sentry capture for that signature.
+  and skips Sentry capture for that signature. If `sessionStorage` is
+  unavailable, skip the hard-reload (avoid loops) and show the normal error
+  UI; `shouldShowSpaNavNetworkReconnecting` only renders “Reconnecting…” when
+  a reload will still be attempted.
 - Blog `markAsRead()` (`routes/action/mark-as-read.tsx`) is best-effort read
   tracking. Uncaught `fetch` rejections from that path are app noise: keep the
   catch inside `markAsRead` (KCD-FY / KCD-1R / KCD-ZW / KCD-WV), do not filter

--- a/services/site/app/components/error-boundary.tsx
+++ b/services/site/app/components/error-boundary.tsx
@@ -5,6 +5,8 @@ import {
 } from 'react-router'
 import {
 	getErrorMessage,
+	getSessionStorageSafely,
+	getSpaNavNetworkLocationKey,
 	shouldShowSpaNavNetworkReconnecting,
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
@@ -34,8 +36,8 @@ export function GeneralErrorBoundary({
 		typeof window !== 'undefined' &&
 		shouldShowSpaNavNetworkReconnecting(
 			error,
-			window.sessionStorage,
-			`${window.location.pathname}${window.location.search}`,
+			getSessionStorageSafely(window),
+			getSpaNavNetworkLocationKey(window),
 		)
 	) {
 		return (

--- a/services/site/app/components/error-boundary.tsx
+++ b/services/site/app/components/error-boundary.tsx
@@ -5,9 +5,9 @@ import {
 } from 'react-router'
 import {
 	getErrorMessage,
+	shouldShowSpaNavNetworkReconnecting,
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
-import { isReactRouterSpaNavNetworkError } from '#app/utils/sentry-noise.ts'
 
 type StatusHandler = (info: {
 	error: ErrorResponse
@@ -30,7 +30,14 @@ export function GeneralErrorBoundary({
 	const error = useCapturedRouteError()
 	const params = useParams()
 
-	if (isReactRouterSpaNavNetworkError(error)) {
+	if (
+		typeof window !== 'undefined' &&
+		shouldShowSpaNavNetworkReconnecting(
+			error,
+			window.sessionStorage,
+			`${window.location.pathname}${window.location.search}`,
+		)
+	) {
 		return (
 			<div className="container mx-auto flex items-center justify-center p-4 lg:p-20">
 				<p>Reconnecting…</p>

--- a/services/site/app/components/error-boundary.tsx
+++ b/services/site/app/components/error-boundary.tsx
@@ -7,6 +7,7 @@ import {
 	getErrorMessage,
 	useCapturedRouteError,
 } from '#app/utils/misc-react.tsx'
+import { isReactRouterSpaNavNetworkError } from '#app/utils/sentry-noise.ts'
 
 type StatusHandler = (info: {
 	error: ErrorResponse
@@ -28,6 +29,14 @@ export function GeneralErrorBoundary({
 }) {
 	const error = useCapturedRouteError()
 	const params = useParams()
+
+	if (isReactRouterSpaNavNetworkError(error)) {
+		return (
+			<div className="container mx-auto flex items-center justify-center p-4 lg:p-20">
+				<p>Reconnecting…</p>
+			</div>
+		)
+	}
 
 	if (typeof document !== 'undefined') {
 		console.error(error)

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -26,6 +26,7 @@ import {
 	getUrl,
 	removeTrailingSlash,
 } from '#app/utils/misc-react.tsx'
+import { isReactRouterSpaNavNetworkError } from '#app/utils/sentry-noise.ts'
 import { type Route } from './+types/root'
 import { AppHotkeys } from './components/app-hotkeys.tsx'
 import { ArrowLink } from './components/arrow-button.tsx'
@@ -109,10 +110,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const requestPath = new URL(request.url).pathname
 	const session = await getSession(request)
 	const [user, clientSession, loginInfoSession] = await Promise.all([
-			session.getUser({ timings }),
-			getClientSession(request, session.getUser({ timings })),
-			getLoginInfoSession(request),
-		])
+		session.getUser({ timings }),
+		getClientSession(request, session.getUser({ timings })),
+		getLoginInfoSession(request),
+	])
 
 	const randomFooterImageKeys = Object.keys(illustrationImages)
 	const randomFooterImageKey = randomFooterImageKeys[
@@ -464,6 +465,15 @@ export function ErrorBoundary() {
 			)
 		}
 		throw new Error(`Unhandled error: ${error.status}`)
+	}
+
+	// SPA-nav network TypeError: useCapturedRouteError hard-reloads once.
+	if (isReactRouterSpaNavNetworkError(error)) {
+		return (
+			<ErrorDoc title="Reconnecting">
+				<p className="text-primary p-8 text-center">Reconnecting…</p>
+			</ErrorDoc>
+		)
 	}
 
 	console.error(error)

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -25,8 +25,8 @@ import {
 	getDomainUrl,
 	getUrl,
 	removeTrailingSlash,
+	shouldShowSpaNavNetworkReconnecting,
 } from '#app/utils/misc-react.tsx'
-import { isReactRouterSpaNavNetworkError } from '#app/utils/sentry-noise.ts'
 import { type Route } from './+types/root'
 import { AppHotkeys } from './components/app-hotkeys.tsx'
 import { ArrowLink } from './components/arrow-button.tsx'
@@ -468,7 +468,14 @@ export function ErrorBoundary() {
 	}
 
 	// SPA-nav network TypeError: useCapturedRouteError hard-reloads once.
-	if (isReactRouterSpaNavNetworkError(error)) {
+	if (
+		typeof window !== 'undefined' &&
+		shouldShowSpaNavNetworkReconnecting(
+			error,
+			window.sessionStorage,
+			`${window.location.pathname}${window.location.search}`,
+		)
+	) {
 		return (
 			<ErrorDoc title="Reconnecting">
 				<p className="text-primary p-8 text-center">Reconnecting…</p>

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -25,6 +25,8 @@ import {
 	getDomainUrl,
 	getUrl,
 	removeTrailingSlash,
+	getSessionStorageSafely,
+	getSpaNavNetworkLocationKey,
 	shouldShowSpaNavNetworkReconnecting,
 } from '#app/utils/misc-react.tsx'
 import { type Route } from './+types/root'
@@ -472,8 +474,8 @@ export function ErrorBoundary() {
 		typeof window !== 'undefined' &&
 		shouldShowSpaNavNetworkReconnecting(
 			error,
-			window.sessionStorage,
-			`${window.location.pathname}${window.location.search}`,
+			getSessionStorageSafely(window),
+			getSpaNavNetworkLocationKey(window),
 		)
 	) {
 		return (

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -23,6 +23,7 @@ import {
 	isReactRouterEdgeHttpStatusError,
 	isReactRouterSanitizedServerError,
 	isReactRouterSanitizedServerErrorInstance,
+	isReactRouterSpaNavNetworkError,
 	isReactSchedulerAlreadyWorkingNoise,
 	isTranslatorDomMutationNoise,
 	isWalletUserRejection,
@@ -789,7 +790,6 @@ test('drops injected HTMLInputElement.onchange location noise (KCD-109)', () => 
 	).toBe(false)
 })
 
-
 test('drops injected Object.postUserData Failed to fetch noise (KCD-10A)', () => {
 	const injectedEvent = {
 		exception: {
@@ -930,6 +930,38 @@ test('does not broadly ignore generic Failed to fetch', () => {
 	expect(
 		matchesIgnoreError('NetworkError when attempting to fetch resource.'),
 	).toBe(false)
+})
+
+test('detects React Router SPA-nav browser network TypeErrors (KCD-10B)', () => {
+	const spaNavError = new TypeError('Failed to fetch (kentcdodds.com)')
+	spaNavError.stack = `TypeError: Failed to fetch (kentcdodds.com)
+    at fetchAndApplyManifestPatches (react-router/dist/chunk.js:1:1)
+    at discoverRoutes (react-router/dist/chunk.js:1:1)`
+	expect(isReactRouterSpaNavNetworkError(spaNavError)).toBe(true)
+
+	const safariLoadFailed = new TypeError('Load failed (kentcdodds.com)')
+	safariLoadFailed.stack = `TypeError: Load failed (kentcdodds.com)
+    at fetchAndDecodeViaTurboStream (react-router/dist/chunk.js:1:1)`
+	expect(isReactRouterSpaNavNetworkError(safariLoadFailed)).toBe(true)
+
+	const firefoxNetworkError = new TypeError(
+		'NetworkError when attempting to fetch resource.',
+	)
+	firefoxNetworkError.stack = `TypeError: NetworkError when attempting to fetch resource.
+    at fetchAndDecodeViaTurboStream (react-router/dist/chunk.js:1:1)`
+	expect(isReactRouterSpaNavNetworkError(firefoxNetworkError)).toBe(true)
+
+	// Same message without a React Router SPA-nav stack must not match.
+	const bareFetch = new TypeError('Failed to fetch')
+	bareFetch.stack = `TypeError: Failed to fetch\n    at doStuff (app.js:1:1)`
+	expect(isReactRouterSpaNavNetworkError(bareFetch)).toBe(false)
+
+	// Non-TypeError must not match.
+	const plainError = new Error('Failed to fetch')
+	plainError.stack = `Error: Failed to fetch\n    at fetchAndDecodeViaTurboStream (x:1:1)`
+	expect(isReactRouterSpaNavNetworkError(plainError)).toBe(false)
+
+	expect(isReactRouterSpaNavNetworkError('Failed to fetch')).toBe(false)
 })
 
 test('filters Cloudflare edge RouteErrorResponse HTML (KCD-VH family)', () => {

--- a/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
+++ b/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
@@ -26,6 +26,7 @@ vi.mock('react-router', async () => {
 })
 
 import {
+	getSessionStorageSafely,
 	shouldHardReloadSpaNavNetworkError,
 	shouldShowSpaNavNetworkReconnecting,
 	useCapturedRouteError,
@@ -229,5 +230,29 @@ test('shouldShowSpaNavNetworkReconnecting is false when setItem throws', () => {
 	).toBe(false)
 	expect(
 		shouldHardReloadSpaNavNetworkError(error, readOkWriteFails, '/blog'),
+	).toBe(false)
+})
+
+test('getSessionStorageSafely returns null when the getter throws', () => {
+	const throwingWindow = {
+		get sessionStorage(): Storage {
+			throw new Error('SecurityError')
+		},
+	}
+	expect(getSessionStorageSafely(throwingWindow)).toBe(null)
+	const error = spaNavNetworkTypeError('Failed to fetch')
+	expect(
+		shouldHardReloadSpaNavNetworkError(
+			error,
+			getSessionStorageSafely(throwingWindow),
+			'/blog',
+		),
+	).toBe(false)
+	expect(
+		shouldShowSpaNavNetworkReconnecting(
+			error,
+			getSessionStorageSafely(throwingWindow),
+			'/blog',
+		),
 	).toBe(false)
 })

--- a/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
+++ b/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
@@ -215,3 +215,19 @@ test('shouldHardReloadSpaNavNetworkError skips reload when storage throws', () =
 		shouldShowSpaNavNetworkReconnecting(error, brokenStorage, '/blog'),
 	).toBe(false)
 })
+
+test('shouldShowSpaNavNetworkReconnecting is false when setItem throws', () => {
+	const error = spaNavNetworkTypeError('Failed to fetch')
+	const readOkWriteFails = {
+		getItem: () => null,
+		setItem: () => {
+			throw new Error('quota')
+		},
+	}
+	expect(
+		shouldShowSpaNavNetworkReconnecting(error, readOkWriteFails, '/blog'),
+	).toBe(false)
+	expect(
+		shouldHardReloadSpaNavNetworkError(error, readOkWriteFails, '/blog'),
+	).toBe(false)
+})

--- a/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
+++ b/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
@@ -27,6 +27,7 @@ vi.mock('react-router', async () => {
 
 import {
 	shouldHardReloadSpaNavNetworkError,
+	shouldShowSpaNavNetworkReconnecting,
 	useCapturedRouteError,
 } from '../misc-react.tsx'
 
@@ -167,8 +168,22 @@ test('shouldHardReloadSpaNavNetworkError is one-shot per location', () => {
 	const error = spaNavNetworkTypeError('Load failed')
 
 	expect(
+		shouldShowSpaNavNetworkReconnecting(
+			error,
+			sessionStorageLike,
+			'/blog/post',
+		),
+	).toBe(true)
+	expect(
 		shouldHardReloadSpaNavNetworkError(error, sessionStorageLike, '/blog/post'),
 	).toBe(true)
+	expect(
+		shouldShowSpaNavNetworkReconnecting(
+			error,
+			sessionStorageLike,
+			'/blog/post',
+		),
+	).toBe(false)
 	expect(
 		shouldHardReloadSpaNavNetworkError(error, sessionStorageLike, '/blog/post'),
 	).toBe(false)
@@ -180,5 +195,23 @@ test('shouldHardReloadSpaNavNetworkError is one-shot per location', () => {
 	unrelated.stack = 'TypeError: Failed to fetch\n    at app.js:1:1'
 	expect(
 		shouldHardReloadSpaNavNetworkError(unrelated, sessionStorageLike, '/other'),
+	).toBe(false)
+})
+
+test('shouldHardReloadSpaNavNetworkError skips reload when storage throws', () => {
+	const error = spaNavNetworkTypeError('Failed to fetch')
+	const brokenStorage = {
+		getItem: () => {
+			throw new Error('blocked')
+		},
+		setItem: () => {
+			throw new Error('blocked')
+		},
+	}
+	expect(
+		shouldHardReloadSpaNavNetworkError(error, brokenStorage, '/blog'),
+	).toBe(false)
+	expect(
+		shouldShowSpaNavNetworkReconnecting(error, brokenStorage, '/blog'),
 	).toBe(false)
 })

--- a/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
+++ b/services/site/app/utils/__tests__/use-captured-route-error.test.browser.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 const { mockCaptureException, mockIsRouteErrorResponse, mockUseRouteError } =
@@ -25,11 +25,24 @@ vi.mock('react-router', async () => {
 	}
 })
 
-import { useCapturedRouteError } from '../misc-react.tsx'
+import {
+	shouldHardReloadSpaNavNetworkError,
+	useCapturedRouteError,
+} from '../misc-react.tsx'
 
 function TestComponent() {
 	useCapturedRouteError()
 	return <div>hook called</div>
+}
+
+function spaNavNetworkTypeError(
+	message = 'Failed to fetch (kentcdodds.com)',
+): TypeError {
+	const error = new TypeError(message)
+	error.stack = `${error.name}: ${message}
+    at fetchAndApplyManifestPatches (react-router/dist/chunk.js:1:1)
+    at discoverRoutes (react-router/dist/chunk.js:1:1)`
+	return error
 }
 
 describe('useCapturedRouteError', () => {
@@ -123,4 +136,49 @@ describe('useCapturedRouteError', () => {
 
 		expect(mockCaptureException).not.toHaveBeenCalled()
 	})
+
+	it('does not capture React Router SPA-nav network TypeErrors (KCD-10B)', async () => {
+		const spaNavError = spaNavNetworkTypeError()
+		mockUseRouteError.mockReturnValue(spaNavError)
+		mockIsRouteErrorResponse.mockReturnValue(false)
+
+		// Pre-mark this location so the hard-reload effect does not call
+		// location.reload() (non-configurable in Playwright).
+		const locationKey = `${window.location.pathname}${window.location.search}`
+		window.sessionStorage.setItem(
+			`kcd:spa-nav-network-reload:${locationKey}`,
+			'1',
+		)
+
+		await render(<TestComponent />)
+
+		expect(mockCaptureException).not.toHaveBeenCalled()
+	})
+})
+
+test('shouldHardReloadSpaNavNetworkError is one-shot per location', () => {
+	const storage = new Map<string, string>()
+	const sessionStorageLike = {
+		getItem: (key: string) => storage.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			storage.set(key, value)
+		},
+	}
+	const error = spaNavNetworkTypeError('Load failed')
+
+	expect(
+		shouldHardReloadSpaNavNetworkError(error, sessionStorageLike, '/blog/post'),
+	).toBe(true)
+	expect(
+		shouldHardReloadSpaNavNetworkError(error, sessionStorageLike, '/blog/post'),
+	).toBe(false)
+	expect(
+		shouldHardReloadSpaNavNetworkError(error, sessionStorageLike, '/about'),
+	).toBe(true)
+
+	const unrelated = new TypeError('Failed to fetch')
+	unrelated.stack = 'TypeError: Failed to fetch\n    at app.js:1:1'
+	expect(
+		shouldHardReloadSpaNavNetworkError(unrelated, sessionStorageLike, '/other'),
+	).toBe(false)
 })

--- a/services/site/app/utils/misc-react.tsx
+++ b/services/site/app/utils/misc-react.tsx
@@ -20,7 +20,31 @@ import { getOptionalTeam } from './misc.ts'
 import {
 	isCloudflareEdgeRouteError,
 	isReactRouterSanitizedServerErrorInstance,
+	isReactRouterSpaNavNetworkError,
 } from './sentry-noise.ts'
+
+const SPA_NAV_NETWORK_RELOAD_STORAGE_PREFIX = 'kcd:spa-nav-network-reload:'
+
+/**
+ * One-shot document reload for React Router SPA-nav network TypeErrors
+ * (KCD-XZ / KCD-QG / KCD-10B). Returns whether a reload should run; marks the
+ * current location so a failed second pass does not loop.
+ */
+export function shouldHardReloadSpaNavNetworkError(
+	error: unknown,
+	storage: Pick<Storage, 'getItem' | 'setItem'>,
+	locationKey: string,
+): boolean {
+	if (!isReactRouterSpaNavNetworkError(error)) return false
+	const key = `${SPA_NAV_NETWORK_RELOAD_STORAGE_PREFIX}${locationKey}`
+	try {
+		if (storage.getItem(key) === '1') return false
+		storage.setItem(key, '1')
+	} catch {
+		// sessionStorage may be blocked (private mode / iframe); still reload once.
+	}
+	return true
+}
 
 export * from './misc.ts'
 
@@ -227,6 +251,24 @@ export function useDoubleCheck() {
 
 export function useCapturedRouteError() {
 	const error = useRouteError()
+
+	// SPA-nav browser network TypeError (idle tab / flaky mobile): document
+	// reload usually succeeds where the client `.data` / `__manifest` fetch
+	// did not (KCD-XZ / KCD-QG / KCD-10B). Guard against reload loops.
+	React.useEffect(() => {
+		if (typeof window === 'undefined') return
+		if (
+			!shouldHardReloadSpaNavNetworkError(
+				error,
+				window.sessionStorage,
+				`${window.location.pathname}${window.location.search}`,
+			)
+		) {
+			return
+		}
+		window.location.reload()
+	}, [error])
+
 	if (isRouteErrorResponse(error)) {
 		if (error.status < 500) return error
 
@@ -248,7 +290,12 @@ export function useCapturedRouteError() {
 
 	// React Router production sanitizeError — empty-stack client echo of a
 	// server Error already reported via entry.server handleError (KCD-SE).
-	if (!isReactRouterSanitizedServerErrorInstance(error)) {
+	// SPA-nav network TypeErrors are recovered via hard-reload above — not
+	// app throws (KCD-XZ / KCD-QG / KCD-10B).
+	if (
+		!isReactRouterSanitizedServerErrorInstance(error) &&
+		!isReactRouterSpaNavNetworkError(error)
+	) {
 		Sentry.captureException(error)
 	}
 	return error

--- a/services/site/app/utils/misc-react.tsx
+++ b/services/site/app/utils/misc-react.tsx
@@ -30,6 +30,34 @@ function spaNavNetworkReloadStorageKey(locationKey: string): string {
 }
 
 /**
+ * `window.sessionStorage` access itself can throw (SecurityError) before
+ * getItem/setItem — catch that and treat storage as unavailable.
+ */
+export function getSessionStorageSafely(
+	win: Pick<Window, 'sessionStorage'> | null | undefined = typeof window ===
+	'undefined'
+		? undefined
+		: window,
+): Storage | null {
+	if (win == null) return null
+	try {
+		return win.sessionStorage
+	} catch {
+		return null
+	}
+}
+
+export function getSpaNavNetworkLocationKey(
+	win: Pick<Window, 'location'> | null | undefined = typeof window ===
+	'undefined'
+		? undefined
+		: window,
+): string {
+	if (win == null) return ''
+	return `${win.location.pathname}${win.location.search}`
+}
+
+/**
  * One-shot document reload for React Router SPA-nav network TypeErrors
  * (KCD-XZ / KCD-QG / KCD-10B). Returns whether a reload should run; marks the
  * current location so a failed second pass does not loop.
@@ -40,9 +68,10 @@ function spaNavNetworkReloadStorageKey(locationKey: string): string {
  */
 export function shouldHardReloadSpaNavNetworkError(
 	error: unknown,
-	storage: Pick<Storage, 'getItem' | 'setItem'>,
+	storage: Pick<Storage, 'getItem' | 'setItem'> | null,
 	locationKey: string,
 ): boolean {
+	if (storage == null) return false
 	if (!isReactRouterSpaNavNetworkError(error)) return false
 	const key = spaNavNetworkReloadStorageKey(locationKey)
 	try {
@@ -63,9 +92,10 @@ export function shouldHardReloadSpaNavNetworkError(
  */
 export function shouldShowSpaNavNetworkReconnecting(
 	error: unknown,
-	storage: Pick<Storage, 'getItem' | 'setItem'>,
+	storage: Pick<Storage, 'getItem' | 'setItem'> | null,
 	locationKey: string,
 ): boolean {
+	if (storage == null) return false
 	if (!isReactRouterSpaNavNetworkError(error)) return false
 	const key = spaNavNetworkReloadStorageKey(locationKey)
 	try {
@@ -293,8 +323,8 @@ export function useCapturedRouteError() {
 		if (
 			!shouldHardReloadSpaNavNetworkError(
 				error,
-				window.sessionStorage,
-				`${window.location.pathname}${window.location.search}`,
+				getSessionStorageSafely(window),
+				getSpaNavNetworkLocationKey(window),
 			)
 		) {
 			return

--- a/services/site/app/utils/misc-react.tsx
+++ b/services/site/app/utils/misc-react.tsx
@@ -25,10 +25,18 @@ import {
 
 const SPA_NAV_NETWORK_RELOAD_STORAGE_PREFIX = 'kcd:spa-nav-network-reload:'
 
+function spaNavNetworkReloadStorageKey(locationKey: string): string {
+	return `${SPA_NAV_NETWORK_RELOAD_STORAGE_PREFIX}${locationKey}`
+}
+
 /**
  * One-shot document reload for React Router SPA-nav network TypeErrors
  * (KCD-XZ / KCD-QG / KCD-10B). Returns whether a reload should run; marks the
  * current location so a failed second pass does not loop.
+ *
+ * If sessionStorage is unavailable, returns false (no reload) so a missing
+ * persistence guard cannot loop document reloads — fall through to the normal
+ * error UI instead.
  */
 export function shouldHardReloadSpaNavNetworkError(
 	error: unknown,
@@ -36,14 +44,33 @@ export function shouldHardReloadSpaNavNetworkError(
 	locationKey: string,
 ): boolean {
 	if (!isReactRouterSpaNavNetworkError(error)) return false
-	const key = `${SPA_NAV_NETWORK_RELOAD_STORAGE_PREFIX}${locationKey}`
+	const key = spaNavNetworkReloadStorageKey(locationKey)
 	try {
 		if (storage.getItem(key) === '1') return false
 		storage.setItem(key, '1')
+		return true
 	} catch {
-		// sessionStorage may be blocked (private mode / iframe); still reload once.
+		return false
 	}
-	return true
+}
+
+/**
+ * Show the brief "Reconnecting…" boundary only when a hard-reload will still
+ * be attempted. After the one-shot marker is set (or when storage is blocked),
+ * fall through to the normal error UI instead of a stuck reconnecting state.
+ */
+export function shouldShowSpaNavNetworkReconnecting(
+	error: unknown,
+	storage: Pick<Storage, 'getItem'>,
+	locationKey: string,
+): boolean {
+	if (!isReactRouterSpaNavNetworkError(error)) return false
+	const key = spaNavNetworkReloadStorageKey(locationKey)
+	try {
+		return storage.getItem(key) !== '1'
+	} catch {
+		return false
+	}
 }
 
 export * from './misc.ts'

--- a/services/site/app/utils/misc-react.tsx
+++ b/services/site/app/utils/misc-react.tsx
@@ -56,18 +56,24 @@ export function shouldHardReloadSpaNavNetworkError(
 
 /**
  * Show the brief "Reconnecting…" boundary only when a hard-reload will still
- * be attempted. After the one-shot marker is set (or when storage is blocked),
- * fall through to the normal error UI instead of a stuck reconnecting state.
+ * be attempted. After the one-shot marker is set (or when storage reads/writes
+ * fail), fall through to the normal error UI instead of a stuck reconnecting
+ * state. Probes `setItem` so a read-only / write-failing store does not leave
+ * the UI on “Reconnecting…” with no reload.
  */
 export function shouldShowSpaNavNetworkReconnecting(
 	error: unknown,
-	storage: Pick<Storage, 'getItem'>,
+	storage: Pick<Storage, 'getItem' | 'setItem'>,
 	locationKey: string,
 ): boolean {
 	if (!isReactRouterSpaNavNetworkError(error)) return false
 	const key = spaNavNetworkReloadStorageKey(locationKey)
 	try {
-		return storage.getItem(key) !== '1'
+		if (storage.getItem(key) === '1') return false
+		// Prove writes work before promising a reconnecting UI. A successful
+		// getItem alone is not enough — setItem can still throw (Bugbot).
+		storage.setItem('kcd:spa-nav-network-write-probe', '1')
+		return true
 	} catch {
 		return false
 	}

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -898,7 +898,9 @@ export function isInjectedInputOnchangeLocationError(
 	event: SentryEventLike,
 ): boolean {
 	if (
-		!eventMessages(event).some((message) => UNDEFINED_LOCATION_PROP.test(message))
+		!eventMessages(event).some((message) =>
+			UNDEFINED_LOCATION_PROP.test(message),
+		)
 	) {
 		return false
 	}
@@ -925,7 +927,30 @@ export function isInjectedInputOnchangeLocationError(
 const BROWSER_NETWORK_FETCH_TYPEERROR =
 	/^(?:Failed to fetch|Load failed|NetworkError when attempting to fetch resource\.?)(?:\s*\([^)]*\))?$/i
 
+/**
+ * React Router client data/manifest fetches that fail at the browser network
+ * layer (no HTTP status) during SPA navigation / revalidation (KCD-XZ /
+ * KCD-QG / KCD-10B). Require a RR stack signature so a first-party
+ * `TypeError: Failed to fetch` still alerts.
+ */
+const REACT_ROUTER_SPA_NAV_NETWORK_STACK =
+	/fetchAndApplyManifestPatches|fetchAndDecodeViaTurboStream|Failed to fetch manifest patches/i
+
 const POST_USER_DATA_FUNCTION = /(?:^|\.)postUserData$/
+
+/**
+ * Browser network-layer TypeError during React Router SPA navigation.
+ * Live endpoints often still return 200; do not broadly `ignoreErrors` —
+ * prefer a one-shot document hard-reload in the route error boundary.
+ */
+export function isReactRouterSpaNavNetworkError(error: unknown): boolean {
+	if (!(error instanceof TypeError)) return false
+	if (!BROWSER_NETWORK_FETCH_TYPEERROR.test(error.message.trim())) {
+		return false
+	}
+	const stack = error.stack ?? ''
+	return REACT_ROUTER_SPA_NAV_NETWORK_STACK.test(stack)
+}
 
 function isAnonymousStackFilename(value: string | null | undefined): boolean {
 	if (typeof value !== 'string') return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KCD-10B](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7688292890/) (`TypeError: Failed to fetch`) and siblings KCD-104 / KCD-XB / KCD-XZ are browser network-layer failures during React Router SPA navigation (`fetchAndApplyManifestPatches` / `fetchAndDecodeViaTurboStream`) when `__manifest` or `.data` fetch fails **without** an HTTP `status_code`. Live endpoints still return 200 — this is flaky mobile / idle-tab noise, not an app throw.

Per `docs/agents/bugfix-workflow.md`, do **not** broadly `ignoreErrors` these. This PR implements the documented product UX:

- Detect RR SPA-nav network TypeErrors (`isReactRouterSpaNavNetworkError`)
- Skip Sentry capture in `useCapturedRouteError` (same pattern as sanitized / edge route errors)
- One-shot `location.reload()` per path via `sessionStorage` to recover with a document navigation
- Show a brief “Reconnecting…” boundary while reloading

## Test plan

- [x] Unit: `isReactRouterSpaNavNetworkError` positive/negative cases
- [x] Browser: `useCapturedRouteError` skips capture for SPA-nav network TypeErrors
- [x] Unit: `shouldHardReloadSpaNavNetworkError` one-shot per location
- [x] `npm run test` (pre-push) green

## Siblings

- KCD-10B `7688292890` Failed to fetch (this issue)
- KCD-104 `7654785929` Load failed
- KCD-XB `7343998333` Load failed
- KCD-XZ `7381116292` Failed to fetch

Unrelated sibling KCD-2K (ethereum) left alone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb16d91e-ffb3-4e40-bb9b-e7e91aa43846?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb16d91e-ffb3-4e40-bb9b-e7e91aa43846&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from SPA navigation network errors with a “Reconnecting…” state and a single hard reload per location.
  * Prevented expected navigation errors from being reported as Sentry noise.
  * When browser storage is unavailable, displays the normal error UI without attempting to reload.
  * Preserved standard error handling for unrelated failures.

* **Documentation**
  * Added guidance on navigation errors, reload behavior, and error reporting.

* **Tests**
  * Added coverage for detection, reload limits, location changes, storage failures, and Sentry filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->