### PR TITLE
Link info-page photos to raw media files

### DIFF
--- a/services/site/content/pages/info.mdx
+++ b/services/site/content/pages/info.mdx
@@ -44,11 +44,7 @@ And if you want to add a possessive apostrophe to "Dodds" then it should be:
 	}}
 >
 	<div>
-		<a
-			target="_blank"
-			rel="noreferrer noopener"
-			href="/media/w_1600/kent/profile.jpg"
-		>
+		<a target="_blank" rel="noreferrer noopener" href="/media/kent/profile.jpg">
 			<img
 				alt="Cropped photo of Kent"
 				style={{ height: 200, width: 200, display: 'block', marginBottom: 4 }}
@@ -61,7 +57,7 @@ And if you want to add a possessive apostrophe to "Dodds" then it should be:
 		<a
 			target="_blank"
 			rel="noreferrer noopener"
-			href="/media/w_1600/kent/profile-transparent.png"
+			href="/media/kent/profile-transparent.png"
 		>
 			<img
 				alt="Unropped photo of Kent"


### PR DESCRIPTION
## Summary
- Point `/info` photo click-throughs at the raw R2 originals (`/media/kent/profile.jpg` and `/media/kent/profile-transparent.png`) instead of the `w_1600` transforms.
- The transformed URLs were not full-res and flattened the transparent PNG to JPEG.

## Test plan
- [ ] Open https://kentcdodds.com/info#photos after content refresh
- [ ] Click the uncropped photo and confirm it opens the raw JPEG
- [ ] Click the cropped/transparent photo and confirm it opens the raw PNG with alpha


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated photo links to open the correct full-resolution images.
  * Preserved optimized image previews for faster page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->