### PR TITLE
Require send-shipped-pr for ship-pr Discord summaries

### DIFF
--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -32,14 +32,29 @@ without `gh`, and `request` / `graphql` (`kody:@kentcdodds/github/request`,
 
 ## Done → Discord
 
-When finished (whether merged or not), send a discord summary with relevant links.
+Always summarize (merged or not) by calling
+`kody:@kentcdodds/discord/send-shipped-pr` with structured fields. Do **not**
+use raw `post-message` and do **not** compute or guess token cost — the export
+fetches the billed Cursor Cloud Agent usage and formats the cost line.
+
+**agentId (required):**
+- In a Cursor Cloud Agent VM, read it from the metadata socket:
+  curl -fsS --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}" http://cursor-agent/v1/meta-data/agent/id
+- Otherwise pass the `bc-` id from the agent URL you were launched as
+  (https://cursor.com/agents/{id}).
 
 ```javascript
-import postMessage from 'kody:@kentcdodds/discord/post-message'
+import sendShippedPr from 'kody:@kentcdodds/discord/send-shipped-pr'
 
 export default async function main() {
-	const content = ` ... `
-	const shipPrChannelId = '1491568683737157683'
-	return postMessage({ channelId: shipPrChannelId, content })
+	return sendShippedPr({
+		agentId, // bc- id from the metadata socket or launch URL
+		title: 'PR title',
+		summary: 'What shipped / parked / blocked and why.',
+		prUrl: 'https://github.com/owner/repo/pull/1',
+		repo: 'owner/repo',
+		extras: ['CI green', 'preview verified'],
+		status: 'Shipped', // or 'Parked' | 'Blocked'
+	})
 }
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates only the **Done → Discord** section of `.agents/skills/ship-pr/SKILL.md`.

Agents must now call `kody:@kentcdodds/discord/send-shipped-pr` with structured fields (`agentId`, `title`, `summary`, `prUrl`, `repo`, `extras`, `status`) instead of raw `post-message` / freeform content.

They must not compute or guess token cost — the export fetches billed Cursor Cloud Agent usage.

`agentId` comes from:
- the Cursor Cloud Agent metadata socket in a VM
- otherwise the `bc-` id from the agent launch URL

The rest of the skill is unchanged. Official Kody Discord / kody-discord were not touched.

## Test plan

- [x] Diff is limited to `.agents/skills/ship-pr/SKILL.md`
- [x] Loop / Merge sections are byte-identical to `main`
- [x] Discord section matches the requested copy, including tabs in the JS sample
- [x] Sample requires `agentId` plus `title`, `summary`, `prUrl`, `repo`, `extras`, `status`
- [x] Copy forbids raw `post-message` and guessing token cost

Verification log:

[discord_section_verification.log](https://cursor.com/artifacts/c/art-33b2ba50-1f2e-47a4-86f8-42a1262c9085)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c32ef8b4-23cb-48a2-9595-25bb12cf32ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c32ef8b4-23cb-48a2-9595-25bb12cf32ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized shipped pull request notifications with consistent status, summary, and agent details.
  * Improved usage-cost reporting by automatically retrieving and formatting cost information.
  * Increased reliability of completion updates by requiring accurate agent identification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->