### PR TITLE
Point Kody product links at kody.codes

### DIFF
--- a/services/site/app/routes/kody.tsx
+++ b/services/site/app/routes/kody.tsx
@@ -157,8 +157,8 @@ export default function KodyPage() {
 				<section className="prose dark:prose-dark">
 					<p className="bg-secondary mb-8 rounded-lg p-6 text-lg">
 						Looking for Kody, Kent's personal AI assistant platform? Head to{' '}
-						<a className="underlined" href="https://heykody.dev">
-							heykody.dev
+						<a className="underlined" href="https://kody.codes">
+							kody.codes
 						</a>
 						.
 					</p>

--- a/services/site/content/pages/info.mdx
+++ b/services/site/content/pages/info.mdx
@@ -102,7 +102,7 @@ Software Engineer and Educator
 
 ## Projects and Products
 
-- [Kody](https://heykody.dev) — my open-source personal assistant platform for
+- [Kody](https://kody.codes) — my open-source personal assistant platform for
   builders: your agent's memory, secrets, and automations — owned by you,
   available from any MCP host.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`heykody.dev` / `heykody.app` are sunset domains. The live Kody assistant-platform origin is `https://kody.codes`.

This PR updates leftover **current-product** links on kentcdodds.com so they point at that origin.

### Changes

- `/kody` koala-mascot callout: `https://heykody.dev` → `https://kody.codes`, visible text `heykody.dev` → `kody.codes`
- `/info` Projects and Products list: `[Kody](https://heykody.dev)` → `[Kody](https://kody.codes)`

The mascot page purpose is unchanged; only the assistant-platform pointer was updated.

### Search notes

Repo-wide search for `heykody.dev`, `heykody.app`, `kody.tools`, and `kody.software` found only those two current-product leftovers. No historical blog/content presented those URLs as the place to go now, so nothing else was rewritten. Talks copy that describes Kody without a URL was left as-is.

## Test plan

- [x] Repo-wide search confirms no remaining current-product `heykody.*` / `kody.tools` / `kody.software` links
- [x] Site lint (`oxlint`) — 0 errors (pre-existing unused-var warnings only; none in the changed files)
- [x] Local `/kody` and `/info` render 200 and link to `https://kody.codes`
- [x] Browser walkthrough: both links show `kody.codes` and navigate there
- [x] CI: Validate Site Worker, Site Gate, and Playwright are green

![Kody mascot callout now points at kody.codes](https://cursor.com/artifacts/c/art-361cad4b-c3b0-4993-82d8-9552ae708f32)
![Info page Projects list Kody link to https://kody.codes](https://cursor.com/artifacts/c/art-b9bcd7ab-2e8a-4556-a5c1-3ff653106746)
<a href="https://cursor.com/agents/bc-475ea78e-621b-48fc-a7ce-f9c5c2451ed7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkody_codes_product_links_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-399dea4d-0ab2-45e4-b250-51984f31231a" alt="kody_codes_product_links_walkthrough.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-475ea78e-621b-48fc-a7ce-f9c5c2451ed7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-475ea78e-621b-48fc-a7ce-f9c5c2451ed7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links to Kody’s AI assistant platform from `heykody.dev` to `kody.codes`.
  * Updated the visible link text to match the new website address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->