### PR TITLE
Add Laracon US 2026 recording for The Last Software Engineer

### DIFF
--- a/services/site/content/data/talks.yml
+++ b/services/site/content/data/talks.yml
@@ -87,6 +87,7 @@
       date: 2026-07-09
     - event: '[Laracon 2026](https://laracon.us/)'
       date: 2026-07-28
+      recording: https://www.youtube.com/watch?v=zZPV_ggx5F8&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf
     - event: '[All Things Open](https://allthingsopen.org/)'
       date: 2026-10-19
     - event: '[React Summit US](https://reactsummit.us/)'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Attaches the published Laravel YouTube recording of Kent’s Laracon US 2026 talk to the existing *The Last Software Engineer* entry.

## Change
- Adds one `recording` URL on the existing Laracon 2026 delivery in `services/site/content/data/talks.yml`.
- Uses the same Kent talks playlist query param as other YouTube recordings (`PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf`).
- Does not add a second talk entry or change title, description, tags, or other deliveries.

## Video
- https://www.youtube.com/watch?v=zZPV_ggx5F8
- Title: The Last Software Engineer | Kent C. Dodds at Laracon US 2026
- Channel: Laravel
- Published: 2026-08-12

The video is on Kent’s talks playlist (`Talks and workshops from Kent C. Dodds`).

## Verify
- YAML parses; Prettier check on `talks.yml` is clean.
- `http://localhost:3000/talks` HTML includes a YouTube icon on The Last Software Engineer → Laracon 2026 with `https://www.youtube.com/watch?v=zZPV_ggx5F8&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf`.
- Other deliveries on that talk still have no recording.
- Browser check: clicking the icon opens the Laravel video page (YouTube bot-check overlay can block playback in this environment).

![Talks page showing Laracon 2026 YouTube icon](https://cursor.com/artifacts/c/art-f90b2a74-cb7d-49cf-9293-655ba7aa2640)
![Hover shows the YouTube recording URL](https://cursor.com/artifacts/c/art-c268cf70-76e9-46a8-bed5-5a2fa053f952)
![YouTube page for The Last Software Engineer at Laracon US 2026](https://cursor.com/artifacts/c/art-471c2de3-82d7-4103-a183-7b95d4a885d8)
<a href="https://cursor.com/agents/bc-b94df0c9-e354-43f6-9456-f6a3a312fd05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftalks_laracon_2026_recording.mp4"><img src="https://cursor.com/artifacts/c/art-29ba3910-33bb-4d13-9cd8-21f895ee9e67" alt="talks_laracon_2026_recording.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94df0c9-e354-43f6-9456-f6a3a312fd05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94df0c9-e354-43f6-9456-f6a3a312fd05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a YouTube recording link for the Laracon 2026 talk “The Last Software Engineer.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->