### PR TITLE
fix(ci): unblock Site Gate Playwright install on Node 26

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -47,8 +47,11 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
 
+      # Playwright <1.60 hangs on Node 26 after the zip hits 100% (extract-zip).
+      # Keep @playwright/test >=1.60 and fail this step fast if install ever stalls.
       - name: 🌐 Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: npm run test:e2e:install --workspace kentcdodds.com
 
       - name: 🔬 Verify site
@@ -93,6 +96,7 @@ jobs:
 
       - name: 🌐 Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: npm run test:e2e:install --workspace kentcdodds.com
 
       - name: 🧰 Cache MDX dev artifacts

--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -192,16 +192,12 @@ Kody/workflows/GitHub create the initial PR as a substitute.
   via the sidecar watcher and can take ~30 s; subsequent loads are fast.
 - Playwright browsers (needed for `npm run test:browser` and `test:e2e:*`) are
   pre-installed in the VM snapshot under `~/.cache/ms-playwright`, so you should
-  not normally need to reinstall them. On Node 26, `npm run test:e2e:install`
-  (i.e. `npx playwright install`) hangs during archive extraction (the download
-  reaches 100% but never finishes unpacking). If a browser is missing or its
-  revision changed, install it manually instead: `curl` the build zips from
-  `https://cdn.playwright.dev/builds/...` and unzip them into the matching
-  `~/.cache/ms-playwright/<name>-<revision>/` directory, then `touch` an
-  `INSTALLATION_COMPLETE` marker in each so Playwright treats them as installed.
-  Both `chrome-linux64` (chromium) and `chrome-headless-shell-linux64`
-  (chromium-headless-shell) come from the `builds/cft/<version>/linux64/` path;
-  ffmpeg comes from `builds/ffmpeg/<rev>/ffmpeg-linux.zip`.
+  not normally need to reinstall them. If a browser is missing or its revision
+  changed, run `npm run test:e2e:install`. Keep `@playwright/test` at `^1.60`
+  or newer: Playwright `<1.60` hangs on Node 26 after the zip download reaches
+  100% (`extract-zip` / `yauzl` — microsoft/playwright#40998). Site Gate and
+  the Playwright job install browsers with a 10-minute step timeout so a
+  stalled extract fails the check instead of sitting `in_progress`.
 - Run the Playwright e2e suite with `npm run test:e2e:run` (CI mode, its own
   server on port 8811). It fails to start if a dev server is already bound to
   port 3000/3099 (the MDX sidecar), so stop `npm run dev` first, or set

--- a/package-lock.json
+++ b/package-lock.json
@@ -4818,19 +4818,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -15898,35 +15898,35 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -20779,7 +20779,7 @@
         "@cloudflare/workers-types": "^4.20260306.1",
         "@epic-web/config": "^2.0.0",
         "@faker-js/faker": "^10.3.0",
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.62.1",
         "@react-router/dev": "^7.0.0",
         "@types/bcrypt": "^6.0.0",
         "@types/dom-mediacapture-record": "^1.0.22",

--- a/services/site/package.json
+++ b/services/site/package.json
@@ -148,7 +148,7 @@
     "@cloudflare/workers-types": "^4.20260306.1",
     "@epic-web/config": "^2.0.0",
     "@faker-js/faker": "^10.3.0",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.62.1",
     "@react-router/dev": "^7.0.0",
     "@types/bcrypt": "^6.0.0",
     "@types/dom-mediacapture-record": "^1.0.22",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Site Gate hangs on `🌐 Install Playwright browsers` because `@playwright/test` 1.58.2 uses `extract-zip` / `yauzl`, which never finishes unzipping on Node 26 after the download hits 100%. That is the same hang documented in #829. This PR bumps Playwright to 1.62.1 (first good line is 1.60) so the official `npx playwright install` path completes, and adds a 10-minute timeout on the CI install steps so a future stall fails the required check instead of sitting `in_progress`.

Does not change production media/Cloudinary behavior. Does not merge #906.

## System recap

```mermaid
sequenceDiagram
  participant Gate as Site Gate
  participant Cache as ms-playwright cache
  participant PW as playwright install
  participant Zip as zip extract

  Gate->>Cache: restore ~/.cache/ms-playwright
  alt cache miss
    Gate->>PW: npm run test:e2e:install (Node 26)
    PW->>Zip: unzip chromium after 100% download
    Note over Zip: Playwright 1.58.2 hangs here
    Zip-->>PW: extracted (1.62.1)
    PW-->>Gate: browsers ready
  end
  Gate->>Gate: ci:verify
```

**Primitives touched:** Site Gate / Playwright CI install, `@playwright/test` lockfile, agent docs.

**Risk:** low. CI/tooling only. This repo does not use APIs removed in Playwright 1.60 (`ariaRef`, `videosPath`).

**Out of scope:** #906 Cloudinary/media rename; changing the Node 26 engines pin; auto-merging #906.

## Verify

- Local A/B on Node 26.8.1: `playwright@1.58.2 install chromium` reached 100% of 167.3 MiB then hung (`timeout` exit 124 at 90s, incomplete `chromium-1208`). `playwright@1.62.1` extracted chromium, ffmpeg, and headless-shell (exit 0).
- Workspace script `npm run test:e2e:install` completed on Node 26 with 1.62.1.
- `npm run validate` passed locally (398 backend tests, 23 browser tests, lint, typecheck, build).
- CI evidence on [Site Gate](https://github.com/kentcdodds/kentcdodds.com/actions/runs/33698211587/job/100471676207): `🌐 Install Playwright browsers` **completed successfully** in 22s (`00:09:39Z` → `00:10:01Z`). That is the step that used to sit `in_progress` for tens of minutes.

## Docs

`docs/agents/project-context.md` no longer prescribes the #829 curl/unzip workaround. It points at keeping `@playwright/test` `^1.60+` so `npm run test:e2e:install` is the supported path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9f85a64-c25d-4075-9d2c-6bbaf0435045?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9f85a64-c25d-4075-9d2c-6bbaf0435045&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated browser checks by preventing stalled browser installations from running indefinitely.
  * Checks now fail faster when browser setup encounters installation issues.

* **Documentation**
  * Updated headless testing guidance with the standard browser installation command.
  * Clarified supported Playwright versions and installation timeout behavior for Node 26 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->