### PR TITLE
Mention Kody in the four public speaker bios on /info

### DIFF
--- a/services/site/content/pages/info.mdx
+++ b/services/site/content/pages/info.mdx
@@ -117,7 +117,9 @@ engineer. I'm actively involved in the
 [EpicAI.pro](https://epicai.pro),
 [EpicWeb.dev](https://epicweb.dev),
 [EpicReact.dev](https://epicreact.dev), and
-[TestingJavaScript.com](https://testingjavascript.com). I'm a
+[TestingJavaScript.com](https://testingjavascript.com). I also built
+[Kody](https://kody.codes), an open-source personal software ecosystem for
+multi-agent work. I'm a
 [Microsoft MVP](https://kcd.im/mvp),
 [GitHub Star](https://stars.github.com/profiles/kentcdodds/), instructor on
 [egghead.io](https://kcd.im/egghead) and [Frontend Masters](https://kcd.im/fem),
@@ -133,7 +135,9 @@ He is the creator of [EpicProduct.engineer](https://www.epicproduct.engineer),
 [EpicWeb.dev](https://epicweb.dev),
 [EpicAI.pro](https://epicai.pro),
 [EpicReact.dev](https://epicreact.dev), and
-[TestingJavaScript.com](https://testingjavascript.com). He's a
+[TestingJavaScript.com](https://testingjavascript.com). He also built
+[Kody](https://kody.codes), an open-source personal software ecosystem for
+multi-agent work. He's a
 [Microsoft MVP](https://kcd.im/mvp),
 [GitHub Star](https://stars.github.com/profiles/kentcdodds/), instructor on
 [egghead.io](https://kcd.im/egghead) and [Frontend Masters](https://kcd.im/fem),
@@ -144,11 +148,11 @@ of six kids and he lives in Utah.
 ### Short First Person
 
 My name is Kent C. Dodds and I'm a web development educator currently focused on
-[EpicProduct.engineer](https://www.epicproduct.engineer), and I'm the father of
-six kids in Utah.
+[EpicProduct.engineer](https://www.epicproduct.engineer) and
+[Kody](https://kody.codes), and I'm the father of six kids in Utah.
 
 ### Short Third Person
 
 Kent C. Dodds is a web development educator currently focused on
-[EpicProduct.engineer](https://www.epicproduct.engineer), and he's the father
-of six kids in Utah.
+[EpicProduct.engineer](https://www.epicproduct.engineer) and
+[Kody](https://kody.codes), and he's the father of six kids in Utah.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Kody to Kent's public speaker bios on `/info` (also kcd.im/info). Conference rider / travel / honorarium language is unchanged.

## Changes
- **Long first/third person:** after the Epic/TestingJavaScript creator list, mention that Kent also built [Kody](https://kody.codes), an open-source personal software ecosystem for multi-agent work. All existing facts stay (MVP, GitHub Star, egghead, Frontend Masters, live streamer, podcaster, family, Utah).
- **Short first/third person:** currently focused on EpicProduct.engineer **and** [Kody](https://kody.codes), then the six kids in Utah line.

## Out of scope
- Projects blurb already mentions Kody — left as-is.
- Photos, Employment, Social Links, name pronunciation, and `confs.mdx` were not touched.

## Verification
- Local `/info` (200) renders all four Bio headings with `https://kody.codes` links.
- CodeRabbit: no actionable comments.
- Bugbot: no new issues.
- Site Pipeline skipped on the PR (content-only). Merge should refresh production content via 🥬 Refresh Content.

![Long first-person bio mentioning Kody](https://cursor.com/artifacts/c/art-563ee151-4401-4052-8391-9d744157f7ce)
![Long third-person bio mentioning Kody](https://cursor.com/artifacts/c/art-d5863d2f-596a-4bbd-8fe2-da26bc3236c4)
![Short bios mentioning Kody](https://cursor.com/artifacts/c/art-f916dff2-bbf9-477a-8b9b-e9dcc215f0c6)
<a href="https://cursor.com/agents/bc-e78a7bd9-91d5-483a-bc59-5e90e7cb2fe5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finfo_bios_mention_kody.mp4"><img src="https://cursor.com/artifacts/c/art-01c3602b-8c09-4a68-ba82-18531a57c502" alt="info_bios_mention_kody.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e78a7bd9-91d5-483a-bc59-5e90e7cb2fe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e78a7bd9-91d5-483a-bc59-5e90e7cb2fe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the long biography sections to mention Kody, an open-source personal software ecosystem for multi-agent work.
  - Updated the short biography sections to reference both EpicProduct.engineer and Kody.
  - Revised the short biography formatting to keep the “father of six kids in Utah” detail on the same line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->