### PR TITLE
fix(d1): stop PostRead full-table scans burning row reads

### DIFF
--- a/docs/agents/data-table-conventions.md
+++ b/docs/agents/data-table-conventions.md
@@ -8,8 +8,23 @@ Runtime DB access uses `@remix-run/data-table`. SQL migrations live in
 
 D1 bills **rows scanned**, not rows returned. A `GROUP BY` or
 `COUNT(DISTINCT ...)` over `PostRead` (~1M rows) scans the whole table on every
-execution, so where a query's result is cached matters as much as the query:
+execution. Request-path popularity / reader-count reads must **not** scan
+`PostRead`:
 
+- `PostReadSlugCount` (`postSlug` PK) is the source for `blog:post-read-counts`
+  / `getTotalPostReads`. Increment it in `addPostRead`; never
+  `GROUP BY "PostRead"."postSlug"` on a request path (including MCP
+  `get_most_popular_posts`).
+- `PostReadReader` (`u:{userId}` / `c:{clientId}`) is the source for
+  `total-reader-count`. Increment with `INSERT OR IGNORE` on new reads;
+  reassign client → user in `migrateClientPostReadsToUser` (login / signup /
+  password reset). Do not `COUNT(DISTINCT userId/clientId)` over `PostRead`.
+- Team rankings still join `PostRead` ↔ `User` on cache miss / SWR, but only
+  as **two** grouped queries (`teamReadStatsSql` + `activeMembersByTeamSql`),
+  not 9 per-team scans. `/action/mark-as-read` increments the cached ranking
+  objects (`recentReads`, `activeMembers`, `totalReads`) instead of
+  `forceFresh`. Fallback `forceFresh` is only for pre-increment cache entries
+  that lack those fields.
 - `lruCache` (`app/utils/cache.server.ts`) is **per-isolate memory**. Isolates
   churn constantly (deploys, eviction, the warmup cron), so an `lruCache`-only
   cachified value re-runs its `getFreshValue` on every new isolate regardless
@@ -17,8 +32,8 @@ execution, so where a query's result is cached matters as much as the query:
   (`blog:post-read-counts`, `total-reader-count` in `app/utils/blog.server.ts`)
   run ~53k times/week ≈ 51B rows read/week ≈ a $195/month D1 line item.
 - `cache` (KV-backed via `CACHE_RPC`) is shared across isolates. Any cachified
-  value whose `getFreshValue` scans a large table MUST use `cache`, not
-  `lruCache`. Reserve `lruCache` for values that are cheap to recompute.
+  value whose `getFreshValue` used to scan a large table MUST use `cache`,
+  not `lruCache`. Reserve `lruCache` for values that are cheap to recompute.
 - Also avoid `forceFresh: true` on request paths (e.g. actions) unless the
   underlying data actually changed; it bypasses the shared cache and re-runs
   the aggregate queries.
@@ -66,11 +81,11 @@ type D1RpcBinding = D1SqlExecutor & {
 Structured clone does **not** reliably round-trip `Date` values. RPC boundaries
 use explicit serialization in `row-serialization.server.ts`:
 
-| Type | On the wire | After read |
-| --- | --- | --- |
-| `Date` | ISO string | `Date` (when field matches ISO prefix) |
-| `bigint` | `number` | `number` |
-| `Uint8Array` / `Buffer` | `ArrayBuffer` | `Uint8Array` (`Passkey.publicKey`) |
+| Type                    | On the wire   | After read                             |
+| ----------------------- | ------------- | -------------------------------------- |
+| `Date`                  | ISO string    | `Date` (when field matches ISO prefix) |
+| `bigint`                | `number`      | `number`                               |
+| `Uint8Array` / `Buffer` | `ArrayBuffer` | `Uint8Array` (`Passkey.publicKey`)     |
 
 WebAuthn `counter` is stored as SQLite `BIGINT` but coerced to `number` at read
 boundaries (counters are small).
@@ -88,27 +103,27 @@ Row types are exported as `User`, `Session`, `Call`, etc. (`TableRow<typeof …>
 
 ## Error mapping
 
-| Prisma | data-table / SQLite |
-| --- | --- |
-| `P2002` unique violation | `isUniqueConstraintError(error)` |
-| `P2025` not found | `isNotFoundError(error)`; `db.delete` returns `false` when missing |
+| Prisma                   | data-table / SQLite                                                |
+| ------------------------ | ------------------------------------------------------------------ |
+| `P2002` unique violation | `isUniqueConstraintError(error)`                                   |
+| `P2025` not found        | `isNotFoundError(error)`; `db.delete` returns `false` when missing |
 
 Import from `#app/utils/db.server.ts`.
 
 ## Operation mapping (our patterns)
 
-| Prisma | data-table |
-| --- | --- |
-| `findUnique({ where: { id } })` | `db.find(table, id)` or `db.findOne(table, { where: { id } })` |
-| `findUnique({ where: { email } })` | `db.findOne(table, { where: { email } })` |
-| `findFirst({ where, select })` | `db.findOne(table, { where })` or `db.query(table).where(...).select({...}).first()` |
-| `findMany({ where, include })` | `db.findMany(table, { where, with: { relation } })` |
-| `create({ data })` | `db.create(table, data)` or `{ returnRow: true }` |
-| `update({ where: { id }, data })` | `db.update(table, id, data)` |
-| `updateMany({ where, data })` | `db.updateMany(table, data, { where })` |
-| `delete` / `deleteMany` | `db.delete(table, id)` / `db.deleteMany(table, { where })` |
-| `upsert` (single field unique) | `db.query(table).upsert(values, { conflictTarget: ['email'], update })` |
-| `upsert` (composite unique) | `db.query(table).upsert(values, { conflictTarget: [...], update, touch: true })` |
+| Prisma                             | data-table                                                                           |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| `findUnique({ where: { id } })`    | `db.find(table, id)` or `db.findOne(table, { where: { id } })`                       |
+| `findUnique({ where: { email } })` | `db.findOne(table, { where: { email } })`                                            |
+| `findFirst({ where, select })`     | `db.findOne(table, { where })` or `db.query(table).where(...).select({...}).first()` |
+| `findMany({ where, include })`     | `db.findMany(table, { where, with: { relation } })`                                  |
+| `create({ data })`                 | `db.create(table, data)` or `{ returnRow: true }`                                    |
+| `update({ where: { id }, data })`  | `db.update(table, id, data)`                                                         |
+| `updateMany({ where, data })`      | `db.updateMany(table, data, { where })`                                              |
+| `delete` / `deleteMany`            | `db.delete(table, id)` / `db.deleteMany(table, { where })`                           |
+| `upsert` (single field unique)     | `db.query(table).upsert(values, { conflictTarget: ['email'], update })`              |
+| `upsert` (composite unique)        | `db.query(table).upsert(values, { conflictTarget: [...], update, touch: true })`     |
 
 ### Upsert bind-order caveat
 
@@ -118,6 +133,6 @@ bound values before ON CONFLICT UPDATE values. SQL placeholder order is
 params are pushed first, columns get the wrong bindings (e.g. Password
 `userId` receiving the hash → FK failure / 500 on password set/reset).
 | `count` | `db.count(table, { where })` |
-| `groupBy` | `db.query(table).groupBy('col').select({...})` **or** `db.exec(sql\`...\`)` |
-| `$queryRaw` / `$executeRaw` | `db.exec(sql\`...\`)` or `db.exec({ text, values })` |
-| `lt` / `gt` in `where` | `import { lt, gt } from '@remix-run/data-table'` |
+| `groupBy` | `db.query(table).groupBy('col').select({...})` **or** `db.exec(sql\`...\`)`|
+|`$queryRaw` / `$executeRaw`|`db.exec(sql\`...\`)`or`db.exec({ text, values })`|
+|`lt`/`gt`in`where`|`import { lt, gt } from '@remix-run/data-table'` |

--- a/services/site/app/routes/action/__tests__/mark-as-read.test.ts
+++ b/services/site/app/routes/action/__tests__/mark-as-read.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test, vi } from 'vitest'
 
 const blogServerMocks = vi.hoisted(() => ({
 	addPostRead: vi.fn(),
+	applyPostReadToCachedAnalytics: vi.fn(),
 	getBlogReadRankings: vi.fn(),
 	notifyOfOverallTeamLeaderChange: vi.fn(),
 	notifyOfTeamLeaderChangeOnPost: vi.fn(),
@@ -24,7 +25,11 @@ vi.mock('#app/utils/client.server.ts', () => clientServerMocks)
 // Import after mocks so the action sees the mocked deps.
 import { action, markAsRead } from '../mark-as-read.tsx'
 
-function setup({ user }: { user: { id: string } | null }) {
+function setup({
+	user,
+}: {
+	user: { id: string; team?: 'RED' | 'BLUE' | 'YELLOW' } | null
+}) {
 	vi.clearAllMocks()
 	sessionServerMocks.getSession.mockResolvedValue({
 		getUser: async () => user,
@@ -33,6 +38,10 @@ function setup({ user }: { user: { id: string } | null }) {
 		getClientId: () => 'client-1',
 	})
 	blogServerMocks.getBlogReadRankings.mockResolvedValue([])
+	blogServerMocks.applyPostReadToCachedAnalytics.mockResolvedValue({
+		afterPostRankings: [],
+		afterOverallRankings: [],
+	})
 	return {
 		request: new Request('http://localhost/action/mark-as-read', {
 			method: 'POST',
@@ -46,8 +55,8 @@ afterEach(() => {
 	vi.restoreAllMocks()
 })
 
-test('action skips the forceFresh ranking recompute when the read was a repeat', async () => {
-	const { request } = setup({ user: { id: 'user-1' } })
+test('action skips ranking cache updates when the read was a repeat', async () => {
+	const { request } = setup({ user: { id: 'user-1', team: 'BLUE' } })
 	// addPostRead returns null when this user already read the post this week.
 	blogServerMocks.addPostRead.mockResolvedValue(null)
 
@@ -55,15 +64,20 @@ test('action skips the forceFresh ranking recompute when the read was a repeat',
 
 	expect(response.data).toEqual({ success: true })
 	expect(blogServerMocks.addPostRead).toHaveBeenCalledOnce()
+	expect(blogServerMocks.applyPostReadToCachedAnalytics).not.toHaveBeenCalled()
 	const forceFreshCalls = blogServerMocks.getBlogReadRankings.mock.calls.filter(
 		([args]) => args.forceFresh,
 	)
 	expect(forceFreshCalls).toHaveLength(0)
 })
 
-test('action force-refreshes rankings when a new PostRead row was created', async () => {
+test('action increments cached rankings when a new PostRead row was created', async () => {
 	const { request } = setup({ user: null })
-	blogServerMocks.addPostRead.mockResolvedValue({ id: 'post-read-1' })
+	blogServerMocks.addPostRead.mockResolvedValue({
+		id: 'post-read-1',
+		newlyActive: false,
+		newReader: true,
+	})
 
 	const response = await action({ request, params: {}, context: {} } as any)
 
@@ -72,11 +86,39 @@ test('action force-refreshes rankings when a new PostRead row was created', asyn
 		slug: 'some-post',
 		clientId: 'client-1',
 	})
+	expect(blogServerMocks.applyPostReadToCachedAnalytics).toHaveBeenCalledWith({
+		request,
+		slug: 'some-post',
+		team: null,
+		newlyActive: false,
+		newReader: true,
+		beforePostRankings: [],
+		beforeOverallRankings: [],
+	})
 	const forceFreshCalls = blogServerMocks.getBlogReadRankings.mock.calls.filter(
 		([args]) => args.forceFresh,
 	)
-	// one per-slug refresh and one overall refresh
-	expect(forceFreshCalls).toHaveLength(2)
+	expect(forceFreshCalls).toHaveLength(0)
+})
+
+test('action passes the reader team when incrementing cached rankings', async () => {
+	const { request } = setup({ user: { id: 'user-1', team: 'BLUE' } })
+	blogServerMocks.addPostRead.mockResolvedValue({
+		id: 'post-read-1',
+		newlyActive: true,
+		newReader: true,
+	})
+
+	await action({ request, params: {}, context: {} } as any)
+
+	expect(blogServerMocks.applyPostReadToCachedAnalytics).toHaveBeenCalledWith(
+		expect.objectContaining({
+			slug: 'some-post',
+			team: 'BLUE',
+			newlyActive: true,
+			newReader: true,
+		}),
+	)
 })
 
 test('markAsRead posts the slug to the mark-as-read action', async () => {

--- a/services/site/app/routes/action/mark-as-read.tsx
+++ b/services/site/app/routes/action/mark-as-read.tsx
@@ -2,12 +2,14 @@ import { invariantResponse } from '@epic-web/invariant'
 import { data as json } from 'react-router'
 import {
 	addPostRead,
+	applyPostReadToCachedAnalytics,
 	getBlogReadRankings,
 	notifyOfOverallTeamLeaderChange,
 	notifyOfTeamLeaderChangeOnPost,
 } from '#app/utils/blog.server.ts'
 import { getRankingLeader } from '#app/utils/blog.ts'
 import { getClientSession } from '#app/utils/client.server.ts'
+import { isTeam } from '#app/utils/misc.ts'
 import { getSession } from '#app/utils/session.server.ts'
 import { type Route } from './+types/mark-as-read'
 
@@ -18,10 +20,12 @@ export async function action({ request }: Route.ActionArgs) {
 	const session = await getSession(request)
 	const user = await session.getUser()
 
-	const [beforePostLeader, beforeOverallLeader] = await Promise.all([
-		getBlogReadRankings({ request, slug }).then(getRankingLeader),
-		getBlogReadRankings({ request }).then(getRankingLeader),
+	const [beforePostRankings, beforeOverallRankings] = await Promise.all([
+		getBlogReadRankings({ request, slug }),
+		getBlogReadRankings({ request }),
 	])
+	const beforePostLeader = getRankingLeader(beforePostRankings)
+	const beforeOverallLeader = getRankingLeader(beforeOverallRankings)
 	let createdPostRead = null
 	if (user) {
 		createdPostRead = await addPostRead({
@@ -37,23 +41,24 @@ export async function action({ request }: Route.ActionArgs) {
 	}
 
 	// Rankings only change when a new PostRead row was actually created
-	// (addPostRead dedupes repeat reads within a week). Skip the forceFresh
-	// recompute otherwise: it bypasses the shared cache and re-runs 9 heavy
-	// PostRead aggregate queries per ranking, which is the expensive part of
-	// D1's rows-read billing.
+	// (addPostRead dedupes repeat reads within a week). Increment the cached
+	// analytics in-place instead of forceFresh-scanning PostRead.
 	if (!createdPostRead) {
 		return json({ success: true })
 	}
 
-	// trigger an update to the ranking cache and notify when the leader changed
-	const [afterPostLeader, afterOverallLeader] = await Promise.all([
-		getBlogReadRankings({
+	const { afterPostRankings, afterOverallRankings } =
+		await applyPostReadToCachedAnalytics({
 			request,
 			slug,
-			forceFresh: true,
-		}).then(getRankingLeader),
-		getBlogReadRankings({ request, forceFresh: true }).then(getRankingLeader),
-	])
+			team: user && isTeam(user.team) ? user.team : null,
+			newlyActive: createdPostRead.newlyActive,
+			newReader: createdPostRead.newReader,
+			beforePostRankings,
+			beforeOverallRankings,
+		})
+	const afterPostLeader = getRankingLeader(afterPostRankings)
+	const afterOverallLeader = getRankingLeader(afterOverallRankings)
 
 	if (
 		afterPostLeader?.team &&

--- a/services/site/app/routes/login.tsx
+++ b/services/site/app/routes/login.tsx
@@ -34,11 +34,8 @@ import {
 	verifyPassword,
 } from '#app/utils/password.server.ts'
 import { db } from '#app/utils/db.server.ts'
-import {
-	passwordTable,
-	postReadTable,
-	userTable,
-} from '#app/utils/db/schema.server.ts'
+import { passwordTable, userTable } from '#app/utils/db/schema.server.ts'
+import { migrateClientPostReadsToUser } from '#app/utils/post-read-aggregates.server.ts'
 import { migrateHomeworkCompletionsToUser } from '#app/utils/user-data.server.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
 import { type Route } from './+types/login'
@@ -165,11 +162,10 @@ export async function action({ request }: Route.ActionArgs) {
 		try {
 			const clientId = clientSession.getClientId()
 			if (clientId) {
-				await db.updateMany(
-					postReadTable,
-					{ userId: user.id, clientId: null },
-					{ where: { clientId } },
-				)
+				await migrateClientPostReadsToUser({
+					userId: user.id,
+					clientId,
+				})
 				await migrateHomeworkCompletionsToUser({
 					userId: user.id,
 					clientId,

--- a/services/site/app/routes/mcp/mcp.runtime.server.ts
+++ b/services/site/app/routes/mcp/mcp.runtime.server.ts
@@ -8,12 +8,14 @@ import {
 import { type SearchResult } from '@kcd-internal/search-shared'
 import { z } from 'zod'
 import { addSubscriberToForm } from '#app/kit/kit.server.js'
-import { getBlogRecommendations } from '#app/utils/blog.server.js'
+import {
+	getBlogPostReadCounts,
+	getBlogRecommendations,
+} from '#app/utils/blog.server.js'
 import { cache, cachified } from '#app/utils/cache.server.js'
 import { groupBy } from '#app/utils/cjs/lodash.ts'
 import { GITHUB_CONTENT_PATH } from '#app/utils/github-content-paths.server.js'
 import { getDomainUrl, getErrorMessage } from '#app/utils/misc.js'
-import { sql } from '@remix-run/data-table'
 import { db } from '#app/utils/db.server.js'
 import { postReadTable, userTable } from '#app/utils/db/schema.server.js'
 import { searchKCD } from '#app/utils/search.server.js'
@@ -175,22 +177,14 @@ function createServer() {
 		async () => {
 			const request = requireRequest()
 			const domainUrl = getDomainUrl(request)
-			const popularPostsResult = await db.exec(sql`
-				SELECT "postSlug", COUNT(*) AS count
-				FROM "PostRead"
-				GROUP BY "postSlug"
-				ORDER BY count DESC
-				LIMIT 10
-			`)
-			const mostPopularPosts = (popularPostsResult.rows ?? []).map((row) => ({
-				postSlug: String(row.postSlug),
-				_count: Number(row.count),
-			}))
-
-			const posts = mostPopularPosts.map(({ postSlug, _count }) => ({
-				url: `${domainUrl}/blog/${postSlug}`,
-				readCount: _count,
-			}))
+			const readCounts = await getBlogPostReadCounts({ request })
+			const posts = Object.entries(readCounts)
+				.sort(([, aCount], [, bCount]) => bCount - aCount)
+				.slice(0, 10)
+				.map(([postSlug, readCount]) => ({
+					url: `${domainUrl}/blog/${postSlug}`,
+					readCount,
+				}))
 
 			return {
 				content: [{ type: 'text', text: JSON.stringify(posts) }],

--- a/services/site/app/routes/reset-password.tsx
+++ b/services/site/app/routes/reset-password.tsx
@@ -14,11 +14,8 @@ import {
 	getPasswordHash,
 } from '#app/utils/password.server.ts'
 import { db } from '#app/utils/db.server.ts'
-import {
-	passwordTable,
-	postReadTable,
-	userTable,
-} from '#app/utils/db/schema.server.ts'
+import { passwordTable, userTable } from '#app/utils/db/schema.server.ts'
+import { migrateClientPostReadsToUser } from '#app/utils/post-read-aggregates.server.ts'
 import { migrateHomeworkCompletionsToUser } from '#app/utils/user-data.server.ts'
 import { upsertPasswordAndDeleteSessions } from '#app/utils/auth-write-flows.server.ts'
 import { getSession, getUser } from '#app/utils/session.server.ts'
@@ -280,11 +277,10 @@ export async function action({ request }: Route.ActionArgs) {
 		try {
 			const clientId = clientSession.getClientId()
 			if (clientId) {
-				await db.updateMany(
-					postReadTable,
-					{ userId: userRecord.id, clientId: null },
-					{ where: { clientId } },
-				)
+				await migrateClientPostReadsToUser({
+					userId: userRecord.id,
+					clientId,
+				})
 				await migrateHomeworkCompletionsToUser({
 					userId: userRecord.id,
 					clientId,

--- a/services/site/app/routes/signup.tsx
+++ b/services/site/app/routes/signup.tsx
@@ -27,10 +27,10 @@ import {
 import { db, isUniqueConstraintError } from '#app/utils/db.server.ts'
 import {
 	passwordTable,
-	postReadTable,
 	userTable,
 	verificationTable,
 } from '#app/utils/db/schema.server.ts'
+import { migrateClientPostReadsToUser } from '#app/utils/post-read-aggregates.server.ts'
 import { migrateHomeworkCompletionsToUser } from '#app/utils/user-data.server.ts'
 import { runBackgroundTask } from '#app/utils/background-task.server.ts'
 import { sendSignupVerificationEmail } from '#app/utils/send-email.server.ts'
@@ -347,11 +347,10 @@ export async function action({ request }: Route.ActionArgs) {
 			const clientId = clientSession.getClientId()
 			// update all PostReads from clientId to userId
 			if (clientId) {
-				await db.updateMany(
-					postReadTable,
-					{ userId: user.id, clientId: null },
-					{ where: { clientId } },
-				)
+				await migrateClientPostReadsToUser({
+					userId: user.id,
+					clientId,
+				})
 				await migrateHomeworkCompletionsToUser({
 					userId: user.id,
 					clientId,

--- a/services/site/app/utils/__tests__/blog-rankings.test.ts
+++ b/services/site/app/utils/__tests__/blog-rankings.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest'
+import {
+	emptyTeamRankings,
+	hasIncrementableRankings,
+	incrementTeamRankings,
+	rankingForTeam,
+	withRankPercentages,
+} from '../blog-rankings.ts'
+
+test('incrementTeamRankings adds a logged-in read without changing other teams', () => {
+	const before = withRankPercentages([
+		rankingForTeam({
+			team: 'RED',
+			totalReads: 10,
+			recentReads: 4,
+			activeMembers: 2,
+		}),
+		rankingForTeam({
+			team: 'BLUE',
+			totalReads: 8,
+			recentReads: 2,
+			activeMembers: 2,
+		}),
+		rankingForTeam({
+			team: 'YELLOW',
+			totalReads: 1,
+			recentReads: 0,
+			activeMembers: 1,
+		}),
+	])
+
+	const after = incrementTeamRankings(before, 'BLUE', { newlyActive: false })
+	const blue = after.find((row) => row.team === 'BLUE')
+	const red = after.find((row) => row.team === 'RED')
+
+	expect(blue).toMatchObject({
+		totalReads: 9,
+		recentReads: 3,
+		activeMembers: 2,
+		ranking: 1.5,
+	})
+	expect(red).toMatchObject({
+		totalReads: 10,
+		recentReads: 4,
+		activeMembers: 2,
+	})
+})
+
+test('incrementTeamRankings treats a first-in-a-year reader as a new active member', () => {
+	const before = emptyTeamRankings()
+	const after = incrementTeamRankings(before, 'YELLOW', { newlyActive: true })
+	const yellow = after.find((row) => row.team === 'YELLOW')
+
+	expect(yellow).toMatchObject({
+		totalReads: 1,
+		recentReads: 1,
+		activeMembers: 1,
+		ranking: 1,
+		percent: 1,
+	})
+})
+
+test('hasIncrementableRankings rejects legacy cache entries without recentReads', () => {
+	expect(
+		hasIncrementableRankings([
+			{ team: 'BLUE', totalReads: 3, ranking: 0.2, percent: 1 },
+		]),
+	).toBe(false)
+	expect(hasIncrementableRankings(emptyTeamRankings())).toBe(true)
+})

--- a/services/site/app/utils/__tests__/migrate-client-post-reads.server.test.ts
+++ b/services/site/app/utils/__tests__/migrate-client-post-reads.server.test.ts
@@ -1,0 +1,97 @@
+import { createDatabase } from '@remix-run/data-table'
+import { expect, test, vi } from 'vitest'
+import { createSqliteExecutorDataTableAdapter } from '../db/d1-data-table-adapter.server.ts'
+import { postReadTable, userTable } from '../db/schema.server.ts'
+import {
+	createMigratedMemoryDatabase,
+	createNodeSqliteExecutor,
+} from '../db/test-helpers.server.ts'
+
+const harness = vi.hoisted(() => ({
+	db: undefined as unknown,
+}))
+
+vi.mock('#app/utils/db.server.ts', () => ({
+	get db() {
+		return harness.db
+	},
+}))
+
+import {
+	migrateClientPostReadsToUser,
+	postReadReaderId,
+} from '../post-read-aggregates.server.ts'
+
+function setupDb() {
+	const sqlite = createMigratedMemoryDatabase()
+	const db = createDatabase(
+		createSqliteExecutorDataTableAdapter(createNodeSqliteExecutor(sqlite)),
+		{ now: () => new Date('2026-09-04T00:00:00.000Z') },
+	)
+	harness.db = db
+	return { sqlite, db }
+}
+
+test('login migrate does not insert a user reader when the client has no PostRead rows', async () => {
+	const { sqlite, db } = setupDb()
+	const user = await db.create(
+		userTable,
+		{
+			email: 'new@example.com',
+			firstName: 'New',
+			team: 'BLUE',
+			role: 'MEMBER',
+		},
+		{ returnRow: true },
+	)
+
+	await migrateClientPostReadsToUser({
+		userId: user.id,
+		clientId: 'anon-client',
+	})
+
+	const readerCount = sqlite
+		.prepare(`SELECT COUNT(*) as count FROM "PostReadReader"`)
+		.get() as { count: number }
+	expect(readerCount.count).toBe(0)
+	sqlite.close()
+})
+
+test('login migrate converts a client reader into a user reader when PostRead rows move', async () => {
+	const { sqlite, db } = setupDb()
+	const user = await db.create(
+		userTable,
+		{
+			email: 'reader@example.com',
+			firstName: 'Reader',
+			team: 'RED',
+			role: 'MEMBER',
+		},
+		{ returnRow: true },
+	)
+	await db.create(postReadTable, {
+		clientId: 'anon-client',
+		postSlug: 'popular-post',
+	})
+	sqlite
+		.prepare(`INSERT INTO "PostReadReader" ("id", "kind") VALUES (?, ?)`)
+		.run(postReadReaderId('client', 'anon-client'), 'client')
+
+	await migrateClientPostReadsToUser({
+		userId: user.id,
+		clientId: 'anon-client',
+	})
+
+	const readers = sqlite
+		.prepare(`SELECT "id", "kind" FROM "PostReadReader" ORDER BY "id"`)
+		.all() as Array<{ id: string; kind: string }>
+	const assigned = sqlite
+		.prepare(`SELECT "userId", "clientId" FROM "PostRead" WHERE "postSlug" = ?`)
+		.get('popular-post') as { userId: string | null; clientId: string | null }
+
+	expect(readers).toEqual([
+		{ id: postReadReaderId('user', user.id), kind: 'user' },
+	])
+	expect(assigned).toEqual({ userId: user.id, clientId: null })
+	sqlite.close()
+})

--- a/services/site/app/utils/__tests__/post-read-aggregates.server.test.ts
+++ b/services/site/app/utils/__tests__/post-read-aggregates.server.test.ts
@@ -1,0 +1,275 @@
+import { createDatabase } from '@remix-run/data-table'
+import { expect, test } from 'vitest'
+import {
+	incrementTeamRankings,
+	rankingForTeam,
+	withRankPercentages,
+} from '../blog-rankings.ts'
+import { createSqliteExecutorDataTableAdapter } from '../db/d1-data-table-adapter.server.ts'
+import { postReadTable, userTable } from '../db/schema.server.ts'
+import {
+	createMigratedMemoryDatabase,
+	createNodeSqliteExecutor,
+} from '../db/test-helpers.server.ts'
+
+function explain(
+	sqlite: ReturnType<typeof createMigratedMemoryDatabase>,
+	sql: string,
+) {
+	return sqlite.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{
+		detail: string
+	}>
+}
+
+function planMentions(
+	plan: Array<{ detail: string }>,
+	needle: string | RegExp,
+) {
+	return plan.some((row) =>
+		typeof needle === 'string'
+			? row.detail.includes(needle)
+			: needle.test(row.detail),
+	)
+}
+
+const scansPostReadTable = /SCAN (?:TABLE )?"?PostRead(?!Slug|Reader)/
+
+test('slug-count and reader-count plans avoid scanning PostRead', () => {
+	const sqlite = createMigratedMemoryDatabase()
+	const slugPlan = explain(
+		sqlite,
+		`SELECT "postSlug", "count" FROM "PostReadSlugCount"`,
+	)
+	const readerPlan = explain(
+		sqlite,
+		`SELECT COUNT(*) as count FROM "PostReadReader"`,
+	)
+	const legacyGroupPlan = explain(
+		sqlite,
+		`SELECT "postSlug", count(*) as count FROM "PostRead" GROUP BY "postSlug"`,
+	)
+
+	expect(planMentions(slugPlan, 'PostReadSlugCount')).toBe(true)
+	expect(planMentions(slugPlan, scansPostReadTable)).toBe(false)
+	expect(planMentions(readerPlan, 'PostReadReader')).toBe(true)
+	expect(planMentions(readerPlan, scansPostReadTable)).toBe(false)
+	expect(planMentions(legacyGroupPlan, scansPostReadTable)).toBe(true)
+	sqlite.close()
+})
+
+test('slug-filtered ranking plan uses the postSlug index instead of scanning PostRead', () => {
+	const sqlite = createMigratedMemoryDatabase()
+	const plan = explain(
+		sqlite,
+		`SELECT u."team" as team, COUNT(*) as totalReads
+		 FROM "PostRead" pr
+		 INNER JOIN "User" u ON pr."userId" = u."id"
+		 WHERE pr."postSlug" = 'some-post'
+		 GROUP BY u."team"`,
+	)
+
+	expect(
+		planMentions(plan, 'PostRead_postSlug_createdAt_idx') ||
+			planMentions(plan, 'SEARCH PostRead'),
+	).toBe(true)
+	expect(planMentions(plan, scansPostReadTable)).toBe(false)
+	sqlite.close()
+})
+
+test('grouped ranking SQL matches per-team PostRead joins used by the old 9-query path', async () => {
+	const sqlite = createMigratedMemoryDatabase()
+	const db = createDatabase(
+		createSqliteExecutorDataTableAdapter(createNodeSqliteExecutor(sqlite)),
+		{ now: () => new Date('2026-09-04T00:00:00.000Z') },
+	)
+	const red = await db.create(
+		userTable,
+		{
+			email: 'red@example.com',
+			firstName: 'Red',
+			team: 'RED',
+			role: 'MEMBER',
+		},
+		{ returnRow: true },
+	)
+	const blue = await db.create(
+		userTable,
+		{
+			email: 'blue@example.com',
+			firstName: 'Blue',
+			team: 'BLUE',
+			role: 'MEMBER',
+		},
+		{ returnRow: true },
+	)
+
+	await db.create(postReadTable, {
+		userId: red.id,
+		postSlug: 'popular-post',
+		createdAt: new Date('2026-08-01T00:00:00.000Z'),
+	})
+	await db.create(postReadTable, {
+		userId: red.id,
+		postSlug: 'popular-post',
+		createdAt: new Date('2026-03-01T00:00:00.000Z'),
+	})
+	await db.create(postReadTable, {
+		userId: blue.id,
+		postSlug: 'other-post',
+		createdAt: new Date('2026-08-15T00:00:00.000Z'),
+	})
+
+	const recentAfter = new Date('2026-03-04T00:00:00.000Z')
+	const activeSince = new Date('2025-09-04T00:00:00.000Z')
+	const readStats = sqlite
+		.prepare(
+			`SELECT u."team" as team,
+				COUNT(*) as totalReads,
+				SUM(CASE WHEN pr."createdAt" > ? THEN 1 ELSE 0 END) as recentReads
+			FROM "PostRead" pr
+			INNER JOIN "User" u ON pr."userId" = u."id"
+			WHERE pr."postSlug" = ?
+			GROUP BY u."team"`,
+		)
+		.all(recentAfter.toISOString(), 'popular-post') as Array<{
+		team: string
+		totalReads: number
+		recentReads: number
+	}>
+	const active = sqlite
+		.prepare(
+			`SELECT u."team" as team, COUNT(DISTINCT u."id") as count
+			FROM "User" u
+			INNER JOIN "PostRead" pr ON pr."userId" = u."id"
+			WHERE pr."createdAt" > ?
+			GROUP BY u."team"`,
+		)
+		.all(activeSince.toISOString()) as Array<{
+		team: string
+		count: number
+	}>
+
+	expect(readStats).toEqual([{ team: 'RED', totalReads: 2, recentReads: 1 }])
+	expect(active).toEqual(
+		expect.arrayContaining([
+			{ team: 'RED', count: 1 },
+			{ team: 'BLUE', count: 1 },
+		]),
+	)
+
+	const before = withRankPercentages([
+		rankingForTeam({
+			team: 'RED',
+			totalReads: 2,
+			recentReads: 1,
+			activeMembers: 1,
+		}),
+		rankingForTeam({
+			team: 'BLUE',
+			totalReads: 0,
+			recentReads: 0,
+			activeMembers: 1,
+		}),
+		rankingForTeam({
+			team: 'YELLOW',
+			totalReads: 0,
+			recentReads: 0,
+			activeMembers: 0,
+		}),
+	])
+	const after = incrementTeamRankings(before, 'RED', { newlyActive: false })
+	expect(after.find((row) => row.team === 'RED')).toMatchObject({
+		totalReads: 3,
+		recentReads: 2,
+		activeMembers: 1,
+		ranking: 2,
+	})
+
+	sqlite.close()
+})
+
+test('PostReadSlugCount and PostReadReader stay in sync with increment SQL', () => {
+	const sqlite = createMigratedMemoryDatabase()
+	sqlite
+		.prepare(
+			`INSERT INTO "PostReadSlugCount" ("postSlug", "count") VALUES (?, 1)
+			 ON CONFLICT("postSlug") DO UPDATE SET "count" = "count" + 1`,
+		)
+		.run('popular-post')
+	sqlite
+		.prepare(
+			`INSERT INTO "PostReadSlugCount" ("postSlug", "count") VALUES (?, 1)
+			 ON CONFLICT("postSlug") DO UPDATE SET "count" = "count" + 1`,
+		)
+		.run('popular-post')
+	sqlite
+		.prepare(
+			`INSERT OR IGNORE INTO "PostReadReader" ("id", "kind") VALUES (?, ?)`,
+		)
+		.run('u:user-1', 'user')
+	const ignored = sqlite
+		.prepare(
+			`INSERT OR IGNORE INTO "PostReadReader" ("id", "kind") VALUES (?, ?)`,
+		)
+		.run('u:user-1', 'user')
+
+	const slugCount = sqlite
+		.prepare(`SELECT "count" FROM "PostReadSlugCount" WHERE "postSlug" = ?`)
+		.get('popular-post') as { count: number }
+	const readerCount = sqlite
+		.prepare(`SELECT COUNT(*) as count FROM "PostReadReader"`)
+		.get() as { count: number }
+
+	expect(slugCount.count).toBe(2)
+	expect(readerCount.count).toBe(1)
+	expect(Number(ignored.changes)).toBe(0)
+	sqlite.close()
+})
+
+test('PostReadSlugCount stays an order of magnitude smaller than PostRead after backfill', () => {
+	const sqlite = createMigratedMemoryDatabase()
+	const insertUser = sqlite.prepare(
+		`INSERT INTO "User" ("id", "createdAt", "updatedAt", "email", "firstName", "role", "team")
+		 VALUES (?, ?, ?, ?, ?, 'MEMBER', 'BLUE')`,
+	)
+	const insertRead = sqlite.prepare(
+		`INSERT INTO "PostRead" ("id", "createdAt", "userId", "postSlug")
+		 VALUES (?, ?, ?, ?)`,
+	)
+	const now = '2026-09-04T00:00:00.000Z'
+	for (let userIndex = 0; userIndex < 20; userIndex += 1) {
+		const userId = `user-${userIndex}`
+		insertUser.run(userId, now, now, `user-${userIndex}@example.com`, 'Reader')
+		for (let readIndex = 0; readIndex < 100; readIndex += 1) {
+			insertRead.run(
+				`read-${userIndex}-${readIndex}`,
+				now,
+				userId,
+				`post-${readIndex % 20}`,
+			)
+		}
+	}
+	sqlite.exec(`
+		INSERT INTO "PostReadSlugCount" ("postSlug", "count")
+		SELECT "postSlug", COUNT(*) FROM "PostRead" GROUP BY "postSlug"
+		ON CONFLICT("postSlug") DO UPDATE SET "count" = excluded."count"
+	`)
+
+	const postReadRows = (
+		sqlite.prepare(`SELECT COUNT(*) as count FROM "PostRead"`).get() as {
+			count: number
+		}
+	).count
+	const slugRows = (
+		sqlite
+			.prepare(`SELECT COUNT(*) as count FROM "PostReadSlugCount"`)
+			.get() as {
+			count: number
+		}
+	).count
+
+	expect(postReadRows).toBe(2000)
+	expect(slugRows).toBe(20)
+	expect(slugRows * 10).toBeLessThanOrEqual(postReadRows)
+	sqlite.close()
+})

--- a/services/site/app/utils/blog-rankings.ts
+++ b/services/site/app/utils/blog-rankings.ts
@@ -1,0 +1,110 @@
+import { type Team } from '#app/types.ts'
+import { teams } from '#app/utils/misc.ts'
+
+export type BlogReadRanking = {
+	team: Team
+	totalReads: number
+	recentReads: number
+	activeMembers: number
+	ranking: number
+	percent: number
+}
+
+export type BlogReadRankingDraft = Omit<BlogReadRanking, 'percent'>
+
+export function rankingForTeam({
+	team,
+	totalReads,
+	recentReads,
+	activeMembers,
+}: {
+	team: Team
+	totalReads: number
+	recentReads: number
+	activeMembers: number
+}): BlogReadRankingDraft {
+	return {
+		team,
+		totalReads,
+		recentReads,
+		activeMembers,
+		ranking: activeMembers
+			? Number((recentReads / activeMembers).toFixed(4))
+			: 0,
+	}
+}
+
+export function withRankPercentages(
+	rawRankingData: ReadonlyArray<BlogReadRankingDraft>,
+): Array<BlogReadRanking> {
+	const rankings = rawRankingData.map((row) => row.ranking)
+	const maxRanking = Math.max(...rankings)
+	const minRanking = Math.min(...rankings)
+	const span = maxRanking - minRanking || 1
+	return rawRankingData.map((row) => ({
+		...row,
+		percent: Number(((row.ranking - minRanking) / span).toFixed(2)),
+	}))
+}
+
+export function emptyTeamRankings(): Array<BlogReadRanking> {
+	return withRankPercentages(
+		teams.map((team) =>
+			rankingForTeam({
+				team,
+				totalReads: 0,
+				recentReads: 0,
+				activeMembers: 0,
+			}),
+		),
+	)
+}
+
+export function hasIncrementableRankings(
+	value: unknown,
+): value is Array<BlogReadRanking> {
+	return (
+		Array.isArray(value) &&
+		value.length > 0 &&
+		value.every(
+			(row) =>
+				typeof row === 'object' &&
+				row !== null &&
+				'team' in row &&
+				typeof row.totalReads === 'number' &&
+				typeof row.recentReads === 'number' &&
+				typeof row.activeMembers === 'number' &&
+				typeof row.ranking === 'number',
+		)
+	)
+}
+
+export function incrementTeamRankings(
+	rankings: ReadonlyArray<BlogReadRanking>,
+	team: Team,
+	{ newlyActive }: { newlyActive: boolean },
+): Array<BlogReadRanking> {
+	const byTeam = new Map(rankings.map((row) => [row.team, row]))
+	return withRankPercentages(
+		teams.map((nextTeam) => {
+			const current = byTeam.get(nextTeam)
+			if (nextTeam !== team) {
+				return (
+					current ??
+					rankingForTeam({
+						team: nextTeam,
+						totalReads: 0,
+						recentReads: 0,
+						activeMembers: 0,
+					})
+				)
+			}
+			return rankingForTeam({
+				team: nextTeam,
+				totalReads: (current?.totalReads ?? 0) + 1,
+				recentReads: (current?.recentReads ?? 0) + 1,
+				activeMembers: (current?.activeMembers ?? 0) + (newlyActive ? 1 : 0),
+			})
+		}),
+	)
+}

--- a/services/site/app/utils/blog.server.ts
+++ b/services/site/app/utils/blog.server.ts
@@ -1,17 +1,30 @@
 import { subMonths, subYears } from 'date-fns'
-import { and, eq, gt, notInList, sql } from '@remix-run/data-table'
+import { and, eq, gt, notInList } from '@remix-run/data-table'
 import pLimit from 'p-limit'
 import { type MdxListItem, type Team, type User } from '#app/types.ts'
+import {
+	hasIncrementableRankings,
+	incrementTeamRankings,
+	type BlogReadRanking,
+} from '#app/utils/blog-rankings.ts'
 import { shuffle } from '#app/utils/cjs/lodash.ts'
 import { db } from '#app/utils/db.server.ts'
 import { postReadTable } from '#app/utils/db/schema.server.ts'
+import {
+	countPostReadReaders,
+	incrementPostReadSlugCount,
+	listPostReadSlugCounts,
+	loadBlogReadRankings,
+	recordPostReadReader,
+	userHasPostReadSince,
+} from '#app/utils/post-read-aggregates.server.ts'
 import { filterPosts } from './blog.ts'
 import { cache, cachified, lruCache } from './cache.server.ts'
 import { getClientSession, hasClientSessionCookie } from './client.server.ts'
 import { sendMessageFromDiscordBot } from './discord.server.ts'
 import { getEnv } from './env.server.ts'
 import { getBlogMdxListItems } from './mdx.server.ts'
-import { getDomainUrl, getOptionalTeam, teams, typedBoolean } from './misc.ts'
+import { getDomainUrl, getOptionalTeam, typedBoolean } from './misc.ts'
 import { getUser } from './session.server.ts'
 import { teamEmoji } from './team-provider.tsx'
 import { time, type Timings } from './timing.server.ts'
@@ -38,12 +51,21 @@ async function addPostRead({
 		return null
 	}
 
+	const yearAgo = subYears(new Date(), 1)
+	const newlyActive = userId
+		? !(await userHasPostReadSince({ userId, since: yearAgo }))
+		: false
+
 	const postRead = await db.create(
 		postReadTable,
 		{ postSlug: slug, ...ownerWhere },
 		{ returnRow: true },
 	)
-	return { id: postRead.id }
+	await incrementPostReadSlugCount(slug)
+	const newReader = userId
+		? await recordPostReadReader('user', userId)
+		: await recordPostReadReader('client', clientId as string)
+	return { id: postRead.id, newlyActive, newReader }
 }
 
 async function getBlogRecommendations({
@@ -226,9 +248,9 @@ async function getBlogPostReadCounts({
 		key: `blog:post-read-counts`,
 		ttl: 1000 * 60 * 30,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
-		// Must be the shared KV cache: getFreshValue scans the whole PostRead
-		// table (D1 bills rows read) and lruCache is per-isolate, so isolate
-		// churn would re-run the full scan far more often than the TTL implies.
+		// Shared KV cache: isolate-local lruCache would recompute on every
+		// isolate churn. The fresh value now reads PostReadSlugCount (~one row
+		// per slug) instead of GROUP BY PostRead.
 		cache,
 		request,
 		timings,
@@ -242,19 +264,7 @@ async function getBlogPostReadCounts({
 		getFreshValue: async (context) => {
 			try {
 				const timeoutMs = context.background ? 1000 * 10 : 1000 * 5
-				const result = await promiseWithTimeout(
-					(async () => {
-						const queryResult = await db.exec(
-							sql`SELECT "postSlug", count(*) as count FROM "PostRead" GROUP BY "postSlug"`,
-						)
-						return queryResult.rows ?? []
-					})(),
-					timeoutMs,
-				)
-
-				return Object.fromEntries(
-					result.map((row) => [row.postSlug as string, Number(row.count)]),
-				) as Record<string, number>
+				return await promiseWithTimeout(listPostReadSlugCounts(), timeoutMs)
 			} catch (error: unknown) {
 				// Popularity counts should not take down the whole /blog page.
 				console.error(`Failed to get blog post read counts`, error)
@@ -294,12 +304,6 @@ async function getTotalPostReads({
 	})
 }
 
-function isRawQueryResult(
-	result: any,
-): result is Array<Record<string, unknown>> {
-	return Array.isArray(result) && result.every((r) => typeof r === 'object')
-}
-
 async function getReaderCount({
 	request,
 	timings,
@@ -310,36 +314,29 @@ async function getReaderCount({
 	const key = 'total-reader-count'
 	return cachified({
 		key,
-		// Must be the shared KV cache: the COUNT(DISTINCT ...) below scans the
-		// whole PostRead table (D1 bills rows read), so per-isolate lruCache
-		// would re-run it on every isolate churn. The count moves slowly, so an
-		// hour of staleness is fine.
+		// Shared KV cache: isolate-local lruCache would recompute on every
+		// isolate churn. Fresh value is COUNT(*) on PostReadReader (unique
+		// readers), not COUNT(DISTINCT) over PostRead.
 		cache,
 		ttl: 1000 * 60 * 60,
 		staleWhileRevalidate: 1000 * 60 * 60 * 24,
 		request,
 		timings,
 		checkValue: (value: unknown) => typeof value === 'number',
-		getFreshValue: async () => {
-			// couldn't figure out how to do this in one query without raw SQL 🤷‍♂️
-			const queryResult = await db.exec(
-				sql`SELECT
-        (SELECT COUNT(DISTINCT "userId") FROM "PostRead" WHERE "userId" IS NOT NULL) +
-        (SELECT COUNT(DISTINCT "clientId") FROM "PostRead" WHERE "clientId" IS NOT NULL) as count`,
-			)
-			const result = queryResult.rows ?? []
-			if (!isRawQueryResult(result)) {
-				console.error(`Unexpected result from getReaderCount: ${result}`)
-				return 0
-			}
-			const count = Object.values(result[0] ?? [])[0] ?? 0
-			// the count is a BigInt, so we need to convert it to a number
-			return Number(count)
-		},
+		getFreshValue: async () => countPostReadReaders(),
 	})
 }
 
-export type ReadRankings = Awaited<ReturnType<typeof getBlogReadRankings>>
+export type ReadRankings = Array<BlogReadRanking>
+
+const OVERALL_RANKINGS_CACHE_KEY = 'blog:rankings'
+const ALL_POST_RANKINGS_CACHE_KEY = 'all-blog-post-read-rankings'
+const POST_READ_COUNTS_CACHE_KEY = 'blog:post-read-counts'
+const READER_COUNT_CACHE_KEY = 'total-reader-count'
+
+function blogSlugRankingsCacheKey(slug: string) {
+	return `blog:${slug}:rankings`
+}
 
 async function getBlogReadRankings({
 	slug,
@@ -352,7 +349,7 @@ async function getBlogReadRankings({
 	forceFresh?: boolean
 	timings?: Timings
 }) {
-	const key = slug ? `blog:${slug}:rankings` : `blog:rankings`
+	const key = slug ? blogSlugRankingsCacheKey(slug) : OVERALL_RANKINGS_CACHE_KEY
 	const rankingObjs = await cachified({
 		key,
 		cache,
@@ -365,45 +362,20 @@ async function getBlogReadRankings({
 			Array.isArray(value) &&
 			value.every((v) => typeof v === 'object' && 'team' in v),
 		getFreshValue: async () => {
-			const rawRankingData = await Promise.all(
-				teams.map(async function getRankingsForTeam(team): Promise<{
-					team: Team
-					totalReads: number
-					ranking: number
-				}> {
-					const totalReads = await countPostReadsForTeam({
-						slug,
-						team,
-						timings,
-					})
-					const activeMembers = await getActiveMembers({ team, timings })
-					const recentReads = await getRecentReads({ slug, team, timings })
-					let ranking = 0
-					if (activeMembers) {
-						ranking = Number((recentReads / activeMembers).toFixed(4))
-					}
-					return { team, totalReads, ranking }
+			return time(
+				loadBlogReadRankings({
+					slug,
+					recentAfter: subMonths(new Date(), 6),
+					activeSince: subYears(new Date(), 1),
 				}),
-			)
-			const rankings = rawRankingData.map((r) => r.ranking)
-			const maxRanking = Math.max(...rankings)
-			const minRanking = Math.min(...rankings)
-			const rankPercentages = rawRankingData.map(
-				({ team, totalReads, ranking }) => {
-					return {
-						team,
-						totalReads,
-						ranking,
-						percent: Number(
-							((ranking - minRanking) / (maxRanking - minRanking || 1)).toFixed(
-								2,
-							),
-						),
-					}
+				{
+					timings,
+					type: 'loadBlogReadRankings',
+					desc: slug
+						? `Loading team rankings for ${slug}`
+						: 'Loading overall team rankings',
 				},
 			)
-
-			return rankPercentages
 		},
 	})
 
@@ -438,10 +410,8 @@ async function getAllBlogPostReadRankings({
 		getFreshValue: async () => {
 			const posts = await getBlogMdxListItems({ request, timings })
 
-			// each of the getBlogReadRankings calls results in 9 database queries
-			// and we don't want to hit the limit of connections so we limit this
-			// to 2 at a time. Though most of the data should be cached anyway.
-			// This is good to just be certain.
+			// each slug ranking is itself cached; limit concurrency so a cold
+			// all-posts refresh cannot fan out unbounded D1 queries.
 			const limit = pLimit(2)
 			const allPostReadRankings: Record<string, ReadRankings> = {}
 			await Promise.all(
@@ -460,114 +430,140 @@ async function getAllBlogPostReadRankings({
 	})
 }
 
-async function countPostReadsForTeam({
-	slug,
-	team,
-	createdAfter,
-	timings,
-}: {
-	slug?: string
-	team: Team
-	createdAfter?: Date
-	timings?: Timings
-}) {
-	const count = await time(
-		(async () => {
-			if (slug && createdAfter) {
-				const result = await db.exec(
-					sql`SELECT count(*) as count FROM "PostRead" pr
-              INNER JOIN "User" u ON pr."userId" = u."id"
-              WHERE pr."postSlug" = ${slug}
-                AND pr."createdAt" > ${createdAfter.toISOString()}
-                AND u."team" = ${team}`,
-				)
-				return Number(result.rows?.[0]?.count ?? 0)
-			}
-
-			if (slug) {
-				const result = await db.exec(
-					sql`SELECT count(*) as count FROM "PostRead" pr
-              INNER JOIN "User" u ON pr."userId" = u."id"
-              WHERE pr."postSlug" = ${slug}
-                AND u."team" = ${team}`,
-				)
-				return Number(result.rows?.[0]?.count ?? 0)
-			}
-
-			if (createdAfter) {
-				const result = await db.exec(
-					sql`SELECT count(*) as count FROM "PostRead" pr
-              INNER JOIN "User" u ON pr."userId" = u."id"
-              WHERE pr."createdAt" > ${createdAfter.toISOString()}
-                AND u."team" = ${team}`,
-				)
-				return Number(result.rows?.[0]?.count ?? 0)
-			}
-
-			const result = await db.exec(
-				sql`SELECT count(*) as count FROM "PostRead" pr
-            INNER JOIN "User" u ON pr."userId" = u."id"
-            WHERE u."team" = ${team}`,
-			)
-			return Number(result.rows?.[0]?.count ?? 0)
-		})(),
-		{
-			timings,
-			type: createdAfter ? 'getRecentReads' : 'countPostReadsForTeam',
-			desc: createdAfter
-				? `Getting reads of ${slug} by ${team} within the last 6 months`
-				: `Getting total reads for ${team}`,
+async function writeCacheValue<Value>(
+	key: string,
+	value: Value,
+	fallbackTtl: number,
+) {
+	const existing = await cache.get(key)
+	await cache.set(key, {
+		value,
+		metadata: {
+			createdTime: existing?.metadata.createdTime ?? Date.now(),
+			ttl: existing?.metadata.ttl ?? fallbackTtl,
+			swr: existing?.metadata.swr ?? 1000 * 60 * 60 * 24,
 		},
-	)
-	return count
-}
-
-async function getRecentReads({
-	slug,
-	team,
-	timings,
-}: {
-	slug: string | undefined
-	team: Team
-	timings?: Timings
-}) {
-	const withinTheLastSixMonths = subMonths(new Date(), 6)
-
-	return countPostReadsForTeam({
-		slug,
-		team,
-		createdAfter: withinTheLastSixMonths,
-		timings,
 	})
 }
 
-async function getActiveMembers({
-	team,
-	timings,
+async function incrementCachedPostReadCounts({
+	slug,
+	newReader,
 }: {
-	team: Team
-	timings?: Timings
+	slug: string
+	newReader: boolean
 }) {
-	const withinTheLastYear = subYears(new Date(), 1)
+	const countsEntry = await cache.get(POST_READ_COUNTS_CACHE_KEY)
+	if (
+		countsEntry &&
+		typeof countsEntry.value === 'object' &&
+		countsEntry.value !== null &&
+		!Array.isArray(countsEntry.value)
+	) {
+		const value = {
+			...(countsEntry.value as Record<string, number>),
+		}
+		value[slug] = (value[slug] ?? 0) + 1
+		await writeCacheValue(POST_READ_COUNTS_CACHE_KEY, value, 1000 * 60 * 30)
+	}
 
-	const count = await time(
-		(async () => {
-			const result = await db.exec(
-				sql`SELECT count(DISTINCT u."id") as count FROM "User" u
-            INNER JOIN "PostRead" pr ON pr."userId" = u."id"
-            WHERE u."team" = ${team}
-              AND pr."createdAt" > ${withinTheLastYear.toISOString()}`,
+	const slugTotalKey = `total-post-reads:${slug}`
+	const allTotalKey = 'total-post-reads:__all-posts__'
+	const slugTotal = lruCache.get(slugTotalKey)
+	if (typeof slugTotal?.value === 'number') {
+		lruCache.set(slugTotalKey, {
+			...slugTotal,
+			value: slugTotal.value + 1,
+		})
+	}
+	const allTotal = lruCache.get(allTotalKey)
+	if (typeof allTotal?.value === 'number') {
+		lruCache.set(allTotalKey, {
+			...allTotal,
+			value: allTotal.value + 1,
+		})
+	}
+
+	if (newReader) {
+		const readerEntry = await cache.get(READER_COUNT_CACHE_KEY)
+		if (typeof readerEntry?.value === 'number') {
+			await writeCacheValue(
+				READER_COUNT_CACHE_KEY,
+				readerEntry.value + 1,
+				1000 * 60 * 60,
 			)
-			return Number(result.rows?.[0]?.count ?? 0)
-		})(),
-		{
-			timings,
-			type: 'getActiveMembers',
-			desc: `Getting active members of ${team}`,
-		},
-	)
+		}
+	}
+}
 
-	return count
+async function patchAllBlogPostReadRankingsCache(
+	slug: string,
+	rankings: ReadRankings,
+) {
+	const entry = await cache.get(ALL_POST_RANKINGS_CACHE_KEY)
+	if (!entry || typeof entry.value !== 'object' || entry.value === null) {
+		return
+	}
+	await writeCacheValue(
+		ALL_POST_RANKINGS_CACHE_KEY,
+		{
+			...(entry.value as Record<string, ReadRankings>),
+			[slug]: rankings,
+		},
+		1000 * 60 * 5,
+	)
+}
+
+async function applyPostReadToCachedAnalytics({
+	request,
+	slug,
+	team,
+	newlyActive,
+	newReader,
+	beforePostRankings,
+	beforeOverallRankings,
+}: {
+	request: Request
+	slug: string
+	team: Team | null
+	newlyActive: boolean
+	newReader: boolean
+	beforePostRankings: ReadRankings
+	beforeOverallRankings: ReadRankings
+}) {
+	await incrementCachedPostReadCounts({ slug, newReader })
+
+	if (!team) {
+		return {
+			afterPostRankings: beforePostRankings,
+			afterOverallRankings: beforeOverallRankings,
+		}
+	}
+
+	const afterPostRankings = hasIncrementableRankings(beforePostRankings)
+		? incrementTeamRankings(beforePostRankings, team, { newlyActive })
+		: await getBlogReadRankings({ request, slug, forceFresh: true })
+	const afterOverallRankings = hasIncrementableRankings(beforeOverallRankings)
+		? incrementTeamRankings(beforeOverallRankings, team, { newlyActive })
+		: await getBlogReadRankings({ request, forceFresh: true })
+
+	if (hasIncrementableRankings(beforePostRankings)) {
+		await writeCacheValue(
+			blogSlugRankingsCacheKey(slug),
+			afterPostRankings,
+			1000 * 60 * 60 * 24 * 7,
+		)
+	}
+	if (hasIncrementableRankings(beforeOverallRankings)) {
+		await writeCacheValue(
+			OVERALL_RANKINGS_CACHE_KEY,
+			afterOverallRankings,
+			1000 * 60 * 60,
+		)
+	}
+	await patchAllBlogPostReadRankingsCache(slug, afterPostRankings)
+
+	return { afterPostRankings, afterOverallRankings }
 }
 
 async function getSlugReadsByUser({
@@ -581,16 +577,19 @@ async function getSlugReadsByUser({
 	const clientSession = await getClientSession(request, user)
 	const clientId = clientSession.getClientId()
 	const reads = await time(
-		db.findMany(postReadTable, {
-			where: user ? { userId: user.id } : { clientId },
-		}),
+		db
+			.query(postReadTable)
+			.where(user ? { userId: user.id } : { clientId })
+			.groupBy('postSlug')
+			.select('postSlug')
+			.all(),
 		{
 			timings,
 			type: 'getSlugReadsByUser',
 			desc: `Getting reads by ${user ? user.id : clientId}`,
 		},
 	)
-	return Array.from(new Set(reads.map((read) => read.postSlug)))
+	return reads.map((read) => read.postSlug)
 }
 
 async function getPostJson(request: Request) {
@@ -717,6 +716,7 @@ export {
 	getBlogPostReadCounts,
 	getTotalPostReads,
 	getReaderCount,
+	applyPostReadToCachedAnalytics,
 	getPostJson,
 	notifyOfTeamLeaderChangeOnPost,
 	notifyOfOverallTeamLeaderChange,

--- a/services/site/app/utils/db/__tests__/schema-drift.server.test.ts
+++ b/services/site/app/utils/db/__tests__/schema-drift.server.test.ts
@@ -8,6 +8,8 @@ import {
 	homeworkCompletionTable,
 	passkeyTable,
 	passwordTable,
+	postReadReaderTable,
+	postReadSlugCountTable,
 	postReadTable,
 	sessionTable,
 	userTable,
@@ -29,6 +31,8 @@ const appTables = [
 	callKentEpisodeDraftTable,
 	callKentCallerEpisodeTable,
 	postReadTable,
+	postReadSlugCountTable,
+	postReadReaderTable,
 	passkeyTable,
 	favoriteTable,
 	homeworkCompletionTable,
@@ -47,9 +51,9 @@ test('migrated sqlite schema matches data-table definitions', () => {
 		expect(tableRow, `missing table ${tableName}`).toBeTruthy()
 
 		const columnNames = (
-			sqlite
-				.prepare(`PRAGMA table_info("${tableName}")`)
-				.all() as Array<{ name: string }>
+			sqlite.prepare(`PRAGMA table_info("${tableName}")`).all() as Array<{
+				name: string
+			}>
 		).map((column) => column.name)
 
 		for (const columnName of Object.keys(getTableColumns(table))) {

--- a/services/site/app/utils/db/schema.server.ts
+++ b/services/site/app/utils/db/schema.server.ts
@@ -184,6 +184,24 @@ export const postReadTable = table({
 	afterRead: reviveDateColumns(dateColumns.postRead),
 })
 
+export const postReadSlugCountTable = table({
+	name: 'PostReadSlugCount',
+	columns: {
+		postSlug: c.text(),
+		count: c.integer(),
+	},
+	primaryKey: 'postSlug',
+})
+
+export const postReadReaderTable = table({
+	name: 'PostReadReader',
+	columns: {
+		id: c.text(),
+		kind: c.text(),
+	},
+	primaryKey: 'id',
+})
+
 export const passkeyTable = table({
 	name: 'Passkey',
 	columns: {
@@ -365,6 +383,14 @@ export type PostRead = {
 	userId: string | null
 	clientId: string | null
 	postSlug: string
+}
+export type PostReadSlugCount = {
+	postSlug: string
+	count: number
+}
+export type PostReadReader = {
+	id: string
+	kind: string
 }
 export type Passkey = {
 	id: string

--- a/services/site/app/utils/post-read-aggregates.server.ts
+++ b/services/site/app/utils/post-read-aggregates.server.ts
@@ -127,12 +127,16 @@ export async function migrateClientPostReadsToUser({
 	userId: string
 	clientId: string
 }) {
-	await db.updateMany(
+	const updated = await db.updateMany(
 		postReadTable,
 		{ userId, clientId: null },
 		{ where: { clientId } },
 	)
-	await db.exec(insertPostReadReaderSql('user', userId))
+	// Only users who actually had anonymous PostRead rows are unique readers.
+	// Login/signup/reset always call this when a clientId cookie exists.
+	if ((updated.affectedRows ?? 0) > 0) {
+		await db.exec(insertPostReadReaderSql('user', userId))
+	}
 	await db.exec(
 		sql`DELETE FROM "PostReadReader" WHERE "id" = ${postReadReaderId('client', clientId)}`,
 	)

--- a/services/site/app/utils/post-read-aggregates.server.ts
+++ b/services/site/app/utils/post-read-aggregates.server.ts
@@ -1,0 +1,188 @@
+import { and, eq, gt, sql } from '@remix-run/data-table'
+import { db } from '#app/utils/db.server.ts'
+import { postReadTable } from '#app/utils/db/schema.server.ts'
+import { type Team } from '#app/types.ts'
+import {
+	emptyTeamRankings,
+	rankingForTeam,
+	withRankPercentages,
+	type BlogReadRanking,
+} from '#app/utils/blog-rankings.ts'
+import { teams } from '#app/utils/misc.ts'
+
+export function postReadReaderId(kind: 'user' | 'client', id: string) {
+	return kind === 'user' ? `u:${id}` : `c:${id}`
+}
+
+export function incrementPostReadSlugCountSql(postSlug: string) {
+	return sql`
+		INSERT INTO "PostReadSlugCount" ("postSlug", "count")
+		VALUES (${postSlug}, 1)
+		ON CONFLICT("postSlug") DO UPDATE SET "count" = "count" + 1
+	`
+}
+
+export function listPostReadSlugCountsSql() {
+	return sql`SELECT "postSlug", "count" FROM "PostReadSlugCount"`
+}
+
+export function countPostReadReadersSql() {
+	return sql`SELECT COUNT(*) as count FROM "PostReadReader"`
+}
+
+export function insertPostReadReaderSql(kind: 'user' | 'client', id: string) {
+	return sql`
+		INSERT OR IGNORE INTO "PostReadReader" ("id", "kind")
+		VALUES (${postReadReaderId(kind, id)}, ${kind})
+	`
+}
+
+export function teamReadStatsSql({
+	slug,
+	recentAfter,
+}: {
+	slug?: string
+	recentAfter: Date
+}) {
+	const recentAfterIso = recentAfter.toISOString()
+	if (slug) {
+		return sql`
+			SELECT u."team" as team,
+				COUNT(*) as totalReads,
+				SUM(CASE WHEN pr."createdAt" > ${recentAfterIso} THEN 1 ELSE 0 END) as recentReads
+			FROM "PostRead" pr
+			INNER JOIN "User" u ON pr."userId" = u."id"
+			WHERE pr."postSlug" = ${slug}
+			GROUP BY u."team"
+		`
+	}
+	return sql`
+		SELECT u."team" as team,
+			COUNT(*) as totalReads,
+			SUM(CASE WHEN pr."createdAt" > ${recentAfterIso} THEN 1 ELSE 0 END) as recentReads
+		FROM "User" u
+		INNER JOIN "PostRead" pr ON pr."userId" = u."id"
+		GROUP BY u."team"
+	`
+}
+
+export function activeMembersByTeamSql(since: Date) {
+	return sql`
+		SELECT u."team" as team, COUNT(DISTINCT u."id") as count
+		FROM "User" u
+		INNER JOIN "PostRead" pr ON pr."userId" = u."id"
+		WHERE pr."createdAt" > ${since.toISOString()}
+		GROUP BY u."team"
+	`
+}
+
+async function numberFromCountResult(result: {
+	rows?: Array<Record<string, unknown>>
+	affectedRows?: number
+}) {
+	return Number(result.rows?.[0]?.count ?? result.affectedRows ?? 0)
+}
+
+export async function incrementPostReadSlugCount(postSlug: string) {
+	await db.exec(incrementPostReadSlugCountSql(postSlug))
+}
+
+export async function recordPostReadReader(
+	kind: 'user' | 'client',
+	id: string,
+) {
+	const result = await db.exec(insertPostReadReaderSql(kind, id))
+	return Number(result.affectedRows ?? 0) > 0
+}
+
+export async function listPostReadSlugCounts() {
+	const result = await db.exec(listPostReadSlugCountsSql())
+	return Object.fromEntries(
+		(result.rows ?? []).map((row) => [String(row.postSlug), Number(row.count)]),
+	) as Record<string, number>
+}
+
+export async function countPostReadReaders() {
+	const result = await db.exec(countPostReadReadersSql())
+	return numberFromCountResult(result)
+}
+
+export async function userHasPostReadSince({
+	userId,
+	since,
+}: {
+	userId: string
+	since: Date
+}) {
+	const existing = await db.findOne(postReadTable, {
+		where: and(eq('userId', userId), gt('createdAt', since)),
+	})
+	return Boolean(existing)
+}
+
+export async function migrateClientPostReadsToUser({
+	userId,
+	clientId,
+}: {
+	userId: string
+	clientId: string
+}) {
+	await db.updateMany(
+		postReadTable,
+		{ userId, clientId: null },
+		{ where: { clientId } },
+	)
+	await db.exec(insertPostReadReaderSql('user', userId))
+	await db.exec(
+		sql`DELETE FROM "PostReadReader" WHERE "id" = ${postReadReaderId('client', clientId)}`,
+	)
+}
+
+function teamCountMap(
+	rows: Array<Record<string, unknown>> | undefined,
+	valueKey: 'totalReads' | 'recentReads' | 'count',
+) {
+	const counts = new Map<Team, number>()
+	for (const row of rows ?? []) {
+		const team = row.team
+		if (typeof team !== 'string') continue
+		if (!teams.includes(team as Team)) continue
+		counts.set(team as Team, Number(row[valueKey] ?? 0))
+	}
+	return counts
+}
+
+export async function loadBlogReadRankings({
+	slug,
+	recentAfter,
+	activeSince,
+}: {
+	slug?: string
+	recentAfter: Date
+	activeSince: Date
+}): Promise<Array<BlogReadRanking>> {
+	const [readStatsResult, activeMembersResult] = await Promise.all([
+		db.exec(teamReadStatsSql({ slug, recentAfter })),
+		db.exec(activeMembersByTeamSql(activeSince)),
+	])
+	const totalReads = teamCountMap(readStatsResult.rows, 'totalReads')
+	const recentReads = teamCountMap(readStatsResult.rows, 'recentReads')
+	const activeMembers = teamCountMap(activeMembersResult.rows, 'count')
+	if (
+		totalReads.size === 0 &&
+		recentReads.size === 0 &&
+		activeMembers.size === 0
+	) {
+		return emptyTeamRankings()
+	}
+	return withRankPercentages(
+		teams.map((team) =>
+			rankingForTeam({
+				team,
+				totalReads: totalReads.get(team) ?? 0,
+				recentReads: recentReads.get(team) ?? 0,
+				activeMembers: activeMembers.get(team) ?? 0,
+			}),
+		),
+	)
+}

--- a/services/site/migrations/20260904010000_postread_aggregate_tables.sql
+++ b/services/site/migrations/20260904010000_postread_aggregate_tables.sql
@@ -1,0 +1,31 @@
+-- Widen: PostRead lookup indexes + small aggregate tables so request-path
+-- analytics no longer GROUP BY / COUNT(DISTINCT) the ~1M-row PostRead table.
+-- Backfill is a one-time scan; runtime reads hit these tables instead.
+
+CREATE INDEX IF NOT EXISTS "PostRead_userId_createdAt_idx"
+	ON "PostRead"("userId", "createdAt");
+
+CREATE TABLE "PostReadSlugCount" (
+	"postSlug" TEXT NOT NULL PRIMARY KEY,
+	"count" INTEGER NOT NULL
+);
+
+INSERT INTO "PostReadSlugCount" ("postSlug", "count")
+SELECT "postSlug", COUNT(*) FROM "PostRead" GROUP BY "postSlug";
+
+CREATE TABLE "PostReadReader" (
+	"id" TEXT NOT NULL PRIMARY KEY,
+	"kind" TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO "PostReadReader" ("id", "kind")
+SELECT 'u:' || "userId", 'user'
+FROM "PostRead"
+WHERE "userId" IS NOT NULL
+GROUP BY "userId";
+
+INSERT OR IGNORE INTO "PostReadReader" ("id", "kind")
+SELECT 'c:' || "clientId", 'client'
+FROM "PostRead"
+WHERE "clientId" IS NOT NULL
+GROUP BY "clientId";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production D1 `kentcdodds-com-db` is reading ~0.7–1.2B rows/day. `PostRead` is ~963k rows; ~139k rows/query matches user-joined / date-window scans, not a traffic cliff.

KV caching of the aggregates (Aug 2026) was not enough: `/action/mark-as-read` still `forceFresh`’d team rankings on every new read, and each refresh ran **9** `PostRead ⋈ User` aggregates (3 teams × total / recent / active-members). SWR/cache-miss paths also `GROUP BY PostRead` and `COUNT(DISTINCT userId/clientId)` over the whole table.

`cwk-promo-scheduler` is not in this repo; left alone.

## Suspected scan queries

| Query | Where | Why it burned rows |
| --- | --- | --- |
| `SELECT postSlug, COUNT(*) FROM PostRead GROUP BY postSlug` | `getBlogPostReadCounts`, MCP `get_most_popular_posts` | Full index/table scan (~963k) every 30 min + any cache miss |
| `COUNT(DISTINCT userId) + COUNT(DISTINCT clientId)` | `getReaderCount` | Two full PostRead passes every hour |
| 9× `COUNT(*) … JOIN User WHERE team = ?` | `getBlogReadRankings` `forceFresh` on mark-as-read | ~139k user-joined rows × 9 per new read |
| `findMany(PostRead)` for the current reader | `getSlugReadsByUser` | Selected every row instead of distinct slugs |

## What changed

- **Widen migration** `20260904010000_postread_aggregate_tables.sql`:
  - `PostRead_userId_createdAt_idx` covering index
  - `PostReadSlugCount` (one row per slug) + backfill
  - `PostReadReader` (`u:{userId}` / `c:{clientId}`) + backfill
- Request-path popularity / reader counts read those small tables. `addPostRead` increments them; login/signup/reset reassign client → user via `migrateClientPostReadsToUser`.
- Rankings: **2 grouped SQL queries** on cache miss/SWR instead of 9 per-team scans.
- mark-as-read **increments cached rankings** (`totalReads` / `recentReads` / `activeMembers`) instead of `forceFresh`. Fallback `forceFresh` only if a warm cache entry lacks the new fields (one-time after deploy).
- MCP `get_most_popular_posts` uses the cached slug counts.
- `getSlugReadsByUser` `GROUP BY postSlug`.
- **Bugbot fix:** `migrateClientPostReadsToUser` only inserts a `PostReadReader` user row when anonymous `PostRead` rows were actually reassigned. Login/signup/reset with a `clientId` cookie no longer inflate unique-reader counts.

No narrowing follow-up issue: this is add-only (tables + index).

## Before / after (EXPLAIN QUERY PLAN, local migrated SQLite)

```
legacy GROUP BY PostRead
  SCAN PostRead USING COVERING INDEX PostRead_postSlug_createdAt_idx
new PostReadSlugCount
  SCAN PostReadSlugCount

legacy COUNT DISTINCT
  SEARCH PostRead USING COVERING INDEX PostRead_userId_createdAt_idx
  SEARCH PostRead USING COVERING INDEX PostRead_clientId_postSlug_idx
new PostReadReader
  SCAN PostReadReader USING COVERING INDEX sqlite_autoindex_PostReadReader_1

legacy per-team total (×3 teams × 3 query kinds)
  SEARCH User + SEARCH PostRead by userId
new grouped team totals (1 query for totals+recent)
  SCAN User USING INDEX User_team_idx
  SEARCH PostRead USING COVERING INDEX PostRead_userId_createdAt_idx

slug-filtered ranking
  SEARCH PostRead USING INDEX PostRead_postSlug_createdAt_idx
```

Row-count fixture: 2,000 `PostRead` rows collapse to 20 `PostReadSlugCount` rows.

**Expected production impact:** mark-as-read drops from ~9 × ~139k rows to index-point lookups + cache writes. Popularity/reader SWR drops from ~963k (×1–2) to ~slug-count / unique-reader rows. That is well over a 10× cut in daily rows read if the hot path is ranking `forceFresh` + the two full-table aggregates.

## Risk

Schema + analytics. Discord leader notifications still compare before/after leaders; anonymous reads still do not move team rankings (same as the `JOIN User` definition). Sliding-window decay still heals on the existing hourly/weekly SWR. Kent granted merge authority after schema review. Production deploy on `main` applies the D1 migration via `d1:migrations:apply:production` before the worker deploy.

## Test plan

- [x] Unit: ranking increment math
- [x] Unit: EXPLAIN plans + slug/reader increment SQL + 10× row-count fixture
- [x] Unit: mark-as-read skips increment on repeat, never `forceFresh`
- [x] Unit: login migrate does not insert a user reader when no client PostRead rows exist
- [x] Schema drift includes the new tables
- [x] Site backend 409 + browser 23 (local pre-push after Bugbot fix)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `517bb516` · **Head:** `31a5e81a`

**Classification:** extends — no new system primitive; `d1-app-db` schema and PostRead analytics contract change. This repo has no `primitives.yaml`; ids below match the site-worker D1 + KV map.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `d1-app-db` | storage | extends — `PostReadSlugCount`, `PostReadReader`, `PostRead_userId_createdAt_idx` |
| `site-cache-kv` | storage | extends — ranking cache values now include `recentReads` / `activeMembers`; mark-as-read increments instead of `forceFresh` |
| `mark-as-read` | surfaces | extends — no full-table ranking recompute on new reads |

### System map

```mermaid
flowchart LR
	markAsRead["mark-as-read"]:::extended
	blogServer["blog.server analytics"]:::extended
	d1AppDb["d1-app-db"]:::extended
	siteCacheKv["site-cache-kv"]:::extended
	postRead["PostRead"]:::untouched
	markAsRead --> blogServer
	blogServer --> siteCacheKv
	blogServer --> d1AppDb
	d1AppDb --> postRead
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Browser
	participant MarkAsRead
	participant Cache as SITE_CACHE_KV
	participant D1 as APP_DB
	Browser->>MarkAsRead: POST /action/mark-as-read
	MarkAsRead->>Cache: read rankings (no forceFresh)
	MarkAsRead->>D1: indexed week-dedupe + insert PostRead
	MarkAsRead->>D1: increment PostReadSlugCount / PostReadReader
	alt logged-in reader and cache has increment fields
		MarkAsRead->>Cache: increment team totals in place
	else legacy cache shape
		MarkAsRead->>D1: 2 grouped ranking queries once
	end
	MarkAsRead-->>Browser: success
```

### Before / after

| Path | Before | After |
| --- | --- | --- |
| Popularity | `GROUP BY PostRead` (~963k) | `SELECT` `PostReadSlugCount` (~slug count) |
| Reader count | 2× `COUNT(DISTINCT)` on PostRead | `COUNT(*)` `PostReadReader` |
| mark-as-read rankings | `forceFresh` × 9 joins | cache increment (0 PostRead scans) |
| Ranking SWR | 9 per-team scans | 2 grouped queries + covering `userId, createdAt` index |
| Login migrate | always insert `u:{userId}` reader | insert user reader only when client PostRead rows moved |

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a1fa457-ab84-4248-84ec-17b8eefa59ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a1fa457-ab84-4248-84ec-17b8eefa59ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved blog analytics with faster post-read counts, reader totals, and team rankings.
  - Popular posts now use aggregated read data for more efficient results.
  - Read activity updates rankings immediately without requiring full recalculation.
  - Client read history is migrated to user accounts during signup, login, and password reset.

- **Bug Fixes**
  - Prevented duplicate reads from incorrectly changing ranking data.
  - Improved handling of new readers and newly active members.

- **Documentation**
  - Updated analytics, ranking, and caching guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->