### PR TITLE
Update /uses desk setup: compact Magic Keyboard and Trackpad

### DIFF
--- a/services/site/content/pages/uses.mdx
+++ b/services/site/content/pages/uses.mdx
@@ -145,7 +145,10 @@ https://x.com/theKevinShen/status/1869803430757433703
   connects my laptop to the dock. It's the only cable to goes into my laptop.
 - [LG 27MD5KL-B 27 Inch Ultrafine 5K (5120 x 2880) IPS Display with macOS Compatibility, DCI-P3 99% Color Gamut and Thunderbolt 3 Port, Black](https://amazon.com/dp/B07XV9NQSJ) -
   I have 2 of these
-- [Apple Magic Keyboard with TouchID](https://amazon.com/dp/B0DL6KW75T)
+- [Apple Magic Keyboard](https://amazon.com/dp/B0DL6LV7Q6) - The compact one
+  (no numpad).
+- [Apple Magic Trackpad](https://amazon.com/dp/B0DL6ZN6GK) - I use a trackpad
+  instead of a mouse.
 - [Bose Companion 2 Series III Multimedia Speakers](https://amazon.com/dp/B00CD1PTF0/) -
   My computer speakers that sit on either side of my desk.
 - [Mediabridge 3.5mm Male to Male Right Angle Stereo Audio Cable (8 Feet)](https://amazon.com/dp/B00OV41XAM/) -


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent uses a compact Magic Keyboard (no numpad, no Touch ID) and a Magic Trackpad — not a mouse. Desk Setup on `/uses` now matches that.

## Changes

In `services/site/content/pages/uses.mdx`:

- Replace `Apple Magic Keyboard with TouchID` (`B0DL6KW75T`) with the compact `Apple Magic Keyboard` (`B0DL6LV7Q6`)
- Add `Apple Magic Trackpad` (`B0DL6ZN6GK`)
- Keep Amazon `dp` affiliate style (no tracking params)
- No mouse entry

## Verification

Local `http://localhost:3000/uses` Desk Setup now shows:

- Apple Magic Keyboard → `https://amazon.com/dp/B0DL6LV7Q6` (site adds `?tag=kentcdodds-20`)
- Apple Magic Trackpad → `https://amazon.com/dp/B0DL6ZN6GK`
- Touch ID keyboard gone
- No mouse product

Production before this change still listed `Apple Magic Keyboard with TouchID` (`B0DL6KW75T`).

Content-only PR: Site Pipeline is correctly skipped; Refresh Content runs after merge to main.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b617721-a032-4576-b670-78e23effe1b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b617721-a032-4576-b670-78e23effe1b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the Desk Setup section to list the Apple Magic Keyboard and Apple Magic Trackpad separately.
  * Added refreshed product links for both accessories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->