### PR TITLE
Add hardcoded Kody launch promotification

### DIFF
--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -99,6 +99,11 @@ reference:
   leaves the source unmarked and the next sync retries instead of skipping.
   Keep that ordering. `queryLexicalSearch` joins `lexical_sources` so partial
   rows written mid-replace are not searchable until the source is marked.
+- Site-wide promotifications are hardcoded (for example
+  `app/utils/kody-launch-promotification.ts`) and rendered from `root.tsx`
+  via `routes/resources/promotification.tsx`. Tito/workshop automatic
+  promos were removed. A promo getter should return `null` after its
+  `promoEndTime`. Dismiss uses an httpOnly cookie named `promoName`.
 - Content is filesystem-based: blog posts are MDX files in `services/site/content/blog/`.
   `README.md` is repository documentation, not a post, and must stay out of
   `blogList`; syndication routes consume that list directly.

--- a/docs/agents/project-context.md
+++ b/docs/agents/project-context.md
@@ -104,6 +104,9 @@ reference:
   via `routes/resources/promotification.tsx`. Tito/workshop automatic
   promos were removed. A promo getter should return `null` after its
   `promoEndTime`. Dismiss uses an httpOnly cookie named `promoName`.
+  Launch cards should omit `promoEndTime` on `<Promotification>` so the
+  countdown / "Remind me later" chrome stays off unless there is a real
+  sale or event deadline.
 - Content is filesystem-based: blog posts are MDX files in `services/site/content/blog/`.
   `README.md` is repository documentation, not a post, and must stay out of
   `blogList`; syndication routes consume that list directly.

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -32,11 +32,16 @@ import {
 import { type Route } from './+types/root'
 import { AppHotkeys } from './components/app-hotkeys.tsx'
 import { ArrowLink } from './components/arrow-button.tsx'
+import { ButtonLink } from './components/button.tsx'
 import { ErrorPage, FourHundred, FourOhFour } from './components/errors.tsx'
 import { Footer } from './components/footer.tsx'
 import { Grimmacing } from './components/kifs.tsx'
 import { Navbar } from './components/navbar.tsx'
 import { NotificationMessage } from './components/notification-message.tsx'
+import {
+	Promotification,
+	getPromoCookieValue,
+} from './routes/resources/promotification.tsx'
 import { Spacer } from './components/spacer.tsx'
 import { TeamCircle } from './components/team-circle.tsx'
 import { illustrationImages, images } from './images.tsx'
@@ -48,6 +53,10 @@ import vendorStyles from './styles/vendors.css?url'
 import { ClientHintCheck, getHints } from './utils/client-hints.tsx'
 import { getClientSession } from './utils/client.server.ts'
 import { getPublicEnv } from './utils/env.server.ts'
+import {
+	KODY_LAUNCH_URL,
+	getKodyLaunchPromotification,
+} from './utils/kody-launch-promotification.ts'
 import { getLoginInfoSession } from './utils/login.server.ts'
 import { useNonce } from './utils/nonce-provider.ts'
 import { getSession } from './utils/session.server.ts'
@@ -121,6 +130,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 	const randomFooterImageKey = randomFooterImageKeys[
 		Math.floor(Math.random() * randomFooterImageKeys.length)
 	] as keyof typeof illustrationImages
+	const kodyLaunchPromotification = getKodyLaunchPromotification()
 
 	const requestInfo = {
 		hints: getHints(request),
@@ -141,6 +151,18 @@ export async function loader({ request }: Route.LoaderArgs) {
 		latestPodcastSeasonLinks: PODCAST_LINKS_FALLBACK,
 		ENV: getPublicEnv(),
 		randomFooterImageKey,
+		kodyLaunchPromotification: kodyLaunchPromotification
+			? {
+					...kodyLaunchPromotification,
+					promoEndTime: kodyLaunchPromotification.promoEndTime.toISOString(),
+				}
+			: null,
+		kodyLaunchPromotificationCookieValue: kodyLaunchPromotification
+			? getPromoCookieValue({
+					promoName: kodyLaunchPromotification.promoName,
+					request,
+				})
+			: undefined,
 		requestInfo,
 		rootSocialMetas: (
 			await import('#app/og/page-meta.server.ts')
@@ -354,6 +376,30 @@ function App({
 			</head>
 			<body className="bg-white transition duration-500 dark:bg-gray-900">
 				<PageLoadingMessage />
+				{data.kodyLaunchPromotification ? (
+					<Promotification
+						key={data.kodyLaunchPromotification.promoName}
+						position="top-center"
+						promoName={data.kodyLaunchPromotification.promoName}
+						cookieValue={data.kodyLaunchPromotificationCookieValue}
+						promoEndTime={new Date(data.kodyLaunchPromotification.promoEndTime)}
+						hidePermanentlyOnInteraction
+					>
+						<div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+							<p className="max-w-md text-base leading-snug font-semibold">
+								{data.kodyLaunchPromotification.message}
+							</p>
+							<ButtonLink
+								to={KODY_LAUNCH_URL}
+								variant="secondary"
+								size="medium"
+								className="justify-self-start sm:justify-self-end"
+							>
+								{data.kodyLaunchPromotification.buttonText}
+							</ButtonLink>
+						</div>
+					</Promotification>
+				) : null}
 				<NotificationMessage queryStringKey="message" delay={0.3} />
 				<Navbar />
 				<AppHotkeys />

--- a/services/site/app/root.tsx
+++ b/services/site/app/root.tsx
@@ -153,8 +153,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 		randomFooterImageKey,
 		kodyLaunchPromotification: kodyLaunchPromotification
 			? {
-					...kodyLaunchPromotification,
-					promoEndTime: kodyLaunchPromotification.promoEndTime.toISOString(),
+					promoName: kodyLaunchPromotification.promoName,
+					message: kodyLaunchPromotification.message,
+					buttonText: kodyLaunchPromotification.buttonText,
 				}
 			: null,
 		kodyLaunchPromotificationCookieValue: kodyLaunchPromotification
@@ -382,7 +383,6 @@ function App({
 						position="top-center"
 						promoName={data.kodyLaunchPromotification.promoName}
 						cookieValue={data.kodyLaunchPromotificationCookieValue}
-						promoEndTime={new Date(data.kodyLaunchPromotification.promoEndTime)}
 						hidePermanentlyOnInteraction
 					>
 						<div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">

--- a/services/site/app/routes/resources/__tests__/promotification.test.ts
+++ b/services/site/app/routes/resources/__tests__/promotification.test.ts
@@ -81,6 +81,30 @@ test('getPromoCookieValue reads the hidden dismiss cookie for the promo name', (
 	).toBe('hidden')
 })
 
+test('action rejects non-POST methods', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'kody-launch-2026-09')
+
+	const result = (await action({
+		request: new Request('http://localhost/resources/promotification', {
+			method: 'PUT',
+			body: formData,
+		}),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(405)
+	expect(new Headers(result.init?.headers).get('Allow')).toBe('POST')
+	expect(result.data).toEqual({
+		success: false,
+		error: 'Method Not Allowed',
+	})
+})
+
 test('loader rejects get requests with method not allowed', async () => {
 	const result = (await loader()) as {
 		type?: string

--- a/services/site/app/routes/resources/__tests__/promotification.test.ts
+++ b/services/site/app/routes/resources/__tests__/promotification.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { expect, test } from 'vitest'
+
+import { action, getPromoCookieValue, loader } from '../promotification.tsx'
+
+function makeRequest(formData: FormData) {
+	return new Request('http://localhost/resources/promotification', {
+		method: 'POST',
+		body: formData,
+	})
+}
+
+test('action stores a hidden cookie for a valid promo name', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'kody-launch-2026-09')
+	formData.set('maxAge', String(60 * 60 * 24))
+
+	const result = (await action({
+		request: makeRequest(formData),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBeUndefined()
+	const cookieHeader = new Headers(result.init?.headers).get('Set-Cookie')
+	expect(cookieHeader).toContain('kody-launch-2026-09=hidden')
+	expect(cookieHeader).toContain('Max-Age=86400')
+})
+
+test('action rejects invalid promo names', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'invalid promo name')
+
+	const result = (await action({
+		request: makeRequest(formData),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(400)
+	expect(result.data).toEqual({
+		success: false,
+		error: 'Invalid promoName',
+	})
+})
+
+test('action caps one-time promo cookie max age', async () => {
+	const formData = new FormData()
+	formData.set('promoName', 'kody-launch-2026-09')
+	formData.set('maxAge', String(60 * 60 * 24 * 365 * 20))
+
+	const result = (await action({
+		request: makeRequest(formData),
+	} as any)) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	const cookieHeader = new Headers(result.init?.headers).get('Set-Cookie')
+	expect(cookieHeader).toContain(`Max-Age=${60 * 60 * 24 * 365 * 10}`)
+})
+
+test('getPromoCookieValue reads the hidden dismiss cookie for the promo name', () => {
+	const request = new Request('http://localhost/', {
+		headers: { Cookie: 'kody-launch-2026-09=hidden' },
+	})
+
+	expect(
+		getPromoCookieValue({
+			promoName: 'kody-launch-2026-09',
+			request,
+		}),
+	).toBe('hidden')
+})
+
+test('loader rejects get requests with method not allowed', async () => {
+	const result = (await loader()) as {
+		type?: string
+		data?: unknown
+		init?: ResponseInit | null
+	}
+
+	expect(result.type).toBe('DataWithResponseInit')
+	expect(result.init?.status).toBe(405)
+	expect(new Headers(result.init?.headers).get('Allow')).toBe('POST')
+	expect(result.data).toEqual({
+		success: false,
+		error: 'Method Not Allowed',
+	})
+})

--- a/services/site/app/routes/resources/promotification.tsx
+++ b/services/site/app/routes/resources/promotification.tsx
@@ -53,6 +53,13 @@ export async function loader() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+	if (request.method !== 'POST') {
+		return json({ success: false, error: 'Method Not Allowed' } as const, {
+			status: 405,
+			headers: { Allow: 'POST' },
+		})
+	}
+
 	const formData = await request.formData()
 	const promoName = formData.get('promoName')
 	invariantResponse(typeof promoName === 'string', 'promoName must be a string')

--- a/services/site/app/routes/resources/promotification.tsx
+++ b/services/site/app/routes/resources/promotification.tsx
@@ -1,0 +1,269 @@
+// A full stack component + action for promotional notification messages.
+// The user can dismiss a promo via an httpOnly cookie, either temporarily or once.
+import { invariantResponse } from '@epic-web/invariant'
+import * as cookie from 'cookie'
+import * as React from 'react'
+import { useEffect, useState } from 'react'
+import { useFetcher, useRevalidator, data as json } from 'react-router'
+import { useSpinDelay } from 'spin-delay'
+
+import { useCountdown } from '#app/components/hooks/use-countdown.ts'
+import { AlarmIcon } from '#app/components/icons.tsx'
+import { NotificationMessage } from '#app/components/notification-message.tsx'
+import { Spinner } from '#app/components/spinner.tsx'
+import { type SerializeFrom } from '#app/utils/serialize-from.ts'
+import { type Route } from './+types/promotification'
+
+export const PROMO_HIDDEN_COOKIE_VALUE = 'hidden'
+const DEFAULT_PROMO_MAX_AGE_SECONDS = 60 * 60 * 24 * 7 * 2
+const MAX_PROMO_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10
+
+export function getPromoCookieValue({
+	promoName,
+	request,
+}: {
+	promoName: string
+	request: Request
+}) {
+	const cookies = cookie.parse(request.headers.get('Cookie') || '')
+	return cookies[promoName]
+}
+
+export function createPromoHiddenSetCookieHeader({
+	promoName,
+	maxAge = DEFAULT_PROMO_MAX_AGE_SECONDS,
+}: {
+	promoName: string
+	maxAge?: number
+}) {
+	return cookie.serialize(promoName, PROMO_HIDDEN_COOKIE_VALUE, {
+		httpOnly: true,
+		secure: true,
+		sameSite: 'lax',
+		path: '/',
+		maxAge,
+	})
+}
+
+export async function loader() {
+	return json({ success: false, error: 'Method Not Allowed' } as const, {
+		status: 405,
+		headers: { Allow: 'POST' },
+	})
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const formData = await request.formData()
+	const promoName = formData.get('promoName')
+	invariantResponse(typeof promoName === 'string', 'promoName must be a string')
+
+	// Cookie names must be a valid RFC 6265 token (no whitespace, semicolons, etc).
+	// This is developer-controlled in our forms, but the endpoint is public.
+	if (!/^[a-zA-Z0-9._-]+$/.test(promoName)) {
+		return json({ success: false, error: 'Invalid promoName' } as const, {
+			status: 400,
+		})
+	}
+
+	const rawMaxAge = Number(formData.get('maxAge'))
+	const maxAge =
+		Number.isFinite(rawMaxAge) && rawMaxAge > 0
+			? Math.min(Math.floor(rawMaxAge), MAX_PROMO_MAX_AGE_SECONDS)
+			: DEFAULT_PROMO_MAX_AGE_SECONDS
+
+	const cookieHeader = createPromoHiddenSetCookieHeader({ promoName, maxAge })
+	return json({ success: true } as const, {
+		headers: { 'Set-Cookie': cookieHeader },
+	})
+}
+
+type NotificationMessageProps = Parameters<typeof NotificationMessage>[0]
+const ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10
+
+export function Promotification({
+	children,
+	promoName,
+	dismissTimeSeconds = 60 * 60 * 24 * 4,
+	cookieValue,
+	promoEndTime,
+	hidePermanentlyOnInteraction = false,
+	...props
+}: {
+	promoName: string
+	/** maxAge for the cookie */
+	dismissTimeSeconds?: number
+	cookieValue: string | undefined
+	promoEndTime?: Date
+	hidePermanentlyOnInteraction?: boolean
+} & NotificationMessageProps & {
+		queryStringKey?: never
+		autoClose?: never
+		visibleMs?: never
+	} & Required<Pick<NotificationMessageProps, 'children'>>) {
+	const promoEndTimeMs = promoEndTime?.getTime() ?? null
+	const [isPastEndTime, setIsPastEndTime] = useState(() =>
+		promoEndTimeMs ? promoEndTimeMs <= Date.now() : false,
+	)
+
+	const [visible, setVisible] = useState(
+		cookieValue !== PROMO_HIDDEN_COOKIE_VALUE,
+	)
+	const [submittedPromoName, setSubmittedPromoName] = useState<string | null>(
+		null,
+	)
+	const fetcher = useFetcher<SerializeFrom<typeof action>>()
+	const revalidator = useRevalidator()
+	const revalidatedEndTimeRef = React.useRef<number | null>(null)
+	const showSpinner = useSpinDelay(fetcher.state !== 'idle')
+	const dismissedSubmittedPromo =
+		fetcher.data?.success && submittedPromoName === promoName
+	const disableLink = fetcher.state !== 'idle' || dismissedSubmittedPromo
+
+	function submitDismiss(maxAge: number) {
+		const formData = new FormData()
+		formData.set('promoName', promoName)
+		formData.set('maxAge', String(maxAge))
+		setSubmittedPromoName(promoName)
+		fetcher.submit(formData, {
+			action: '/resources/promotification',
+			method: 'POST',
+		})
+	}
+
+	function handleInteraction(event: React.MouseEvent<HTMLDivElement>) {
+		if (!hidePermanentlyOnInteraction) return
+		if (fetcher.state !== 'idle' || dismissedSubmittedPromo) return
+		const target = event.target
+		if (!(target instanceof HTMLElement)) return
+		const interactiveElement = target.closest(
+			'a, button, input, select, textarea, [role="button"], [role="link"]',
+		)
+		if (!interactiveElement) return
+		if (interactiveElement.closest('[data-promotification-snooze]')) return
+		setVisible(false)
+		submitDismiss(ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS)
+	}
+
+	useEffect(() => {
+		if (dismissedSubmittedPromo) {
+			setVisible(false)
+		}
+	}, [dismissedSubmittedPromo])
+
+	useEffect(() => {
+		setVisible(cookieValue !== PROMO_HIDDEN_COOKIE_VALUE)
+		setSubmittedPromoName(null)
+	}, [cookieValue, promoName])
+
+	const dismissError =
+		fetcher.state === 'idle' && fetcher.data && fetcher.data.success === false
+			? fetcher.data.error
+			: null
+
+	useEffect(() => {
+		// `promoEndTime` can change if a parent swaps promos; keep this derived.
+		setIsPastEndTime(promoEndTimeMs ? promoEndTimeMs <= Date.now() : false)
+	}, [promoEndTimeMs])
+
+	// Key fix for issue #462: compute from absolute end time each tick so we jump
+	// after tab inactivity rather than counting down rapidly to catch up.
+	const timeLeft = useCountdown(promoEndTimeMs ?? 0, 1000)
+	const completed = promoEndTimeMs ? timeLeft <= 0 : false
+	const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24))
+	const hours = Math.floor((timeLeft / (1000 * 60 * 60)) % 24)
+	const minutes = Math.floor((timeLeft / 1000 / 60) % 60)
+	const seconds = Math.floor((timeLeft / 1000) % 60)
+
+	useEffect(() => {
+		if (!completed || !promoEndTimeMs) return
+		setIsPastEndTime(true)
+		if (revalidatedEndTimeRef.current === promoEndTimeMs) return
+		revalidatedEndTimeRef.current = promoEndTimeMs
+		revalidator.revalidate()
+	}, [completed, promoEndTimeMs, revalidator])
+
+	if (promoEndTime && (isPastEndTime || completed)) return null
+
+	return (
+		<NotificationMessage
+			{...props}
+			autoClose={false}
+			visible={visible}
+			onDismiss={() => {
+				setVisible(false)
+				if (hidePermanentlyOnInteraction) {
+					submitDismiss(ONE_TIME_PROMOTIFICATION_MAX_AGE_SECONDS)
+				}
+			}}
+		>
+			<div onClickCapture={handleInteraction}>
+				{children}
+				{promoEndTime ? (
+					<div className="mt-4">
+						<>
+							<div className="flex flex-col gap-4 border-t border-gray-700 pt-4 sm:flex-row sm:items-center sm:justify-between">
+								<div
+									aria-label="promotion time remaining"
+									className="grid grid-cols-4 gap-2 text-center tabular-nums"
+								>
+									<span className="rounded-md bg-white/10 px-2 py-1">
+										<span className="block text-base font-semibold">
+											{days}
+										</span>
+										<span className="text-secondary block text-xs tracking-wide uppercase">
+											day{days === 1 ? '' : 's'}
+										</span>
+									</span>
+									<span className="rounded-md bg-white/10 px-2 py-1">
+										<span className="block text-base font-semibold">
+											{hours}
+										</span>
+										<span className="text-secondary block text-xs tracking-wide uppercase">
+											hour{hours === 1 ? '' : 's'}
+										</span>
+									</span>
+									<span className="rounded-md bg-white/10 px-2 py-1">
+										<span className="block text-base font-semibold">
+											{minutes}
+										</span>
+										<span className="text-secondary block text-xs tracking-wide uppercase">
+											min{minutes === 1 ? '' : 's'}
+										</span>
+									</span>
+									<span className="rounded-md bg-white/10 px-2 py-1">
+										<span className="block text-base font-semibold">
+											{seconds}
+										</span>
+										<span className="text-secondary block text-xs tracking-wide uppercase">
+											sec{seconds === 1 ? '' : 's'}
+										</span>
+									</span>
+								</div>
+								<div className="flex flex-wrap items-center gap-2 sm:justify-end">
+									{dismissError ? (
+										<p className="text-sm text-red-500" role="alert">
+											{dismissError}
+										</p>
+									) : null}
+									<button
+										type="button"
+										className={`inline-flex items-center gap-1 rounded-full border border-white/20 px-3 py-2 text-sm font-medium whitespace-nowrap text-white transition hover:bg-white/10 focus:ring-2 focus:ring-white/50 focus:outline-none ${
+											showSpinner ? 'opacity-50' : ''
+										}`}
+										data-promotification-snooze
+										disabled={disableLink}
+										onClick={() => submitDismiss(dismissTimeSeconds)}
+									>
+										<span>Remind me later</span>
+										<AlarmIcon />
+									</button>
+									<Spinner size={16} showSpinner={showSpinner} />
+								</div>
+							</div>
+						</>
+					</div>
+				) : null}
+			</div>
+		</NotificationMessage>
+	)
+}

--- a/services/site/app/utils/__tests__/kody-launch-promotification.test.ts
+++ b/services/site/app/utils/__tests__/kody-launch-promotification.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import { expect, test } from 'vitest'
+
+import {
+	KODY_LAUNCH_PROMOTIFICATION_END_TIME,
+	KODY_LAUNCH_PROMOTIFICATION_NAME,
+	getKodyLaunchPromotification,
+} from '../kody-launch-promotification.ts'
+
+test('returns the Kody launch promotification before it expires', () => {
+	const promotification = getKodyLaunchPromotification(
+		new Date('2026-09-08T12:00:00.000Z'),
+	)
+
+	expect(promotification).toEqual({
+		promoName: KODY_LAUNCH_PROMOTIFICATION_NAME,
+		promoEndTime: KODY_LAUNCH_PROMOTIFICATION_END_TIME,
+		message: 'Kody is live — your AI teammate that ships real work with you.',
+		buttonText: 'Meet Kody',
+	})
+})
+
+test('returns no promotification once the launch window ends', () => {
+	const promotification = getKodyLaunchPromotification(
+		KODY_LAUNCH_PROMOTIFICATION_END_TIME,
+	)
+
+	expect(promotification).toBeNull()
+})

--- a/services/site/app/utils/kody-launch-promotification.ts
+++ b/services/site/app/utils/kody-launch-promotification.ts
@@ -1,0 +1,29 @@
+export const KODY_LAUNCH_URL = 'https://kody.codes/'
+
+export const KODY_LAUNCH_PROMOTIFICATION_NAME = 'kody-launch-2026-09'
+
+export const KODY_LAUNCH_PROMOTIFICATION_END_TIME = new Date(
+	'2026-10-06T06:00:00.000Z',
+)
+
+export type KodyLaunchPromotification = {
+	promoName: string
+	promoEndTime: Date
+	message: string
+	buttonText: string
+}
+
+export function getKodyLaunchPromotification(
+	now = new Date(),
+): KodyLaunchPromotification | null {
+	if (now >= KODY_LAUNCH_PROMOTIFICATION_END_TIME) {
+		return null
+	}
+
+	return {
+		promoName: KODY_LAUNCH_PROMOTIFICATION_NAME,
+		promoEndTime: KODY_LAUNCH_PROMOTIFICATION_END_TIME,
+		message: 'Kody is live — your AI teammate that ships real work with you.',
+		buttonText: 'Meet Kody',
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a single hardcoded Kody launch card on kentcdodds.com (top-center). Follows the #801 wiring pattern without Tito/auto workshop plumbing, and without workshop countdown chrome.

#811 removed the workshop promo **and** the `Promotification` route/component. This restores dismiss infrastructure, then wires one Kody launch banner.

- **Copy:** “Kody is live — your AI teammate that ships real work with you.” / **Meet Kody**
- **CTA:** https://kody.codes/
- **Auto-stops:** getter returns `null` at `2026-10-06T06:00:00.000Z` (midnight MDT Oct 6)
- **Cookie name:** `kody-launch-2026-09`
- **UI:** dismissible card only (X or Meet Kody). No countdown / “Remind me later”.

![Homepage showing the dismissible Kody launch card without countdown](https://cursor.com/artifacts/c/art-0099f401-7664-46cd-8a99-b0007fa6cfaf)

## Changes

- `getKodyLaunchPromotification()` returns the promo until the end time, then `null`
- Restore `routes/resources/promotification.tsx` (cookie dismiss; countdown still available for future sale/event promos)
- Wire loader + `<Promotification position="top-center">` in `root.tsx` **without** `promoEndTime` so launch chrome stays simple
- Dismiss action accepts POST only (matches `Allow: POST`)
- Unit tests for before/after expiry and the dismiss cookie
- Agent doc: launch cards omit countdown unless there is a real deadline

## Review notes left as-is

- CSRF on dismiss cookie: worker pipeline already CSRF-rejects cross-origin POSTs
- Delay Meet Kody until cookie write: would block the primary CTA; X dismiss still persists
- Client-side expiry without countdown: getter returns null on the next load; a tab left open past Oct 6 is not a real launch concern

## Test plan

- [x] Unit tests: promo before end time, `null` at/after end time
- [x] Unit tests: dismiss action sets `kody-launch-2026-09=hidden`; PUT rejected
- [x] Browser: dismissible launch card; Meet Kody → https://kody.codes/; no countdown
- [x] CI green on Connie-alignment commit; latest commit in flight

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c28d9c8-f6f8-47ce-a234-25efe6f149d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c28d9c8-f6f8-47ce-a234-25efe6f149d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a site-wide Kody launch promotional banner with a link to learn more.
  * Added promotional notifications with secure dismissal preferences, optional countdowns, and snooze controls.
  * Launch messaging omits countdown and “Remind me later” controls when no applicable deadline exists.

* **Bug Fixes**
  * Prevented expired promotions from being displayed.
  * Added validation and safeguards for promotional dismissal settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->