### PR TITLE
Filter React Router navigation AbortError noise (KCD-10D)

### DIFF
--- a/docs/agents/bugfix-workflow.md
+++ b/docs/agents/bugfix-workflow.md
@@ -45,6 +45,17 @@ fetch resource` / Safari `Load failed` with React Router stacks
   `shouldShowSpaNavNetworkReconnecting` only renders “Reconnecting…” when
   storage reads show the one-shot is unused **and** a `setItem` write probe
   succeeds (so a write failure cannot leave a stuck reconnecting state).
+- Client `AbortError: signal is aborted without reason` (also
+  `The operation was aborted` / `The user aborted a request`, or
+  DOMException `AbortError` / code 20) with a React Router navigation stack
+  (`startNavigation`, and/or `navigate` / `handleClick` / `doNavigate` from
+  react-router) and no in-app frames is RR cancelling a superseded SPA
+  navigation — not an app bug (KCD-10D). Filter via
+  `isReactRouterNavigationAbortNoise`. Do not add AbortError / "signal is
+  aborted" to `ignoreErrors` (real app AbortErrors from TTS, recording, or
+  fetch timeouts must still alert). Sibling `Failed to fetch` / `Load failed`
+  / `NetworkError` issues (KCD-Y0 / KCD-YC / KCD-QG / KCD-10B) stay on the
+  SPA hard-reload UX, not ignoreErrors.
 - Blog `markAsRead()` (`routes/action/mark-as-read.tsx`) is best-effort read
   tracking. Uncaught `fetch` rejections from that path are app noise: keep the
   catch inside `markAsRead` (KCD-FY / KCD-1R / KCD-ZW / KCD-WV), do not filter

--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -20,6 +20,7 @@ import {
 	isPageTranslatorCallStackOverflow,
 	isReactRouterCsrfAbortError,
 	isReactRouterDataProtocolNoise,
+	isReactRouterNavigationAbortNoise,
 	isReactRouterEdgeHttpStatusError,
 	isReactRouterSanitizedServerError,
 	isReactRouterSanitizedServerErrorInstance,
@@ -270,6 +271,236 @@ test('filters injected elem.firstChild parsers (KCD-ZZ)', () => {
 			"undefined is not an object (evaluating 'elem.firstChild')",
 		),
 	).toBe(true)
+})
+
+test('filters React Router superseded-navigation AbortError (KCD-10D)', () => {
+	const reactRouterNavAbortEvent = {
+		exception: {
+			values: [
+				{
+					type: 'AbortError',
+					value: 'signal is aborted without reason',
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'../../../node_modules/react-router/dist/development/chunk.mjs',
+								function: 'startNavigation',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../node_modules/react-router/dist/development/chunk.mjs',
+								function: 'navigate',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../node_modules/react-router/dist/development/chunk.mjs',
+								function: 'handleClick',
+								inApp: false,
+							},
+							{
+								filename:
+									'../../../node_modules/@sentry/react-router/build/esm/client/hydratedRouter.js',
+								function: 'hydratedRouter.router.navigate',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isReactRouterNavigationAbortNoise(reactRouterNavAbortEvent)).toBe(true)
+	expect(shouldDropSentryEvent(reactRouterNavAbortEvent)).toBe(true)
+	expect(matchesIgnoreError('signal is aborted without reason')).toBe(false)
+	expect(matchesIgnoreError('The operation was aborted.')).toBe(false)
+	expect(matchesIgnoreError('The user aborted a request')).toBe(false)
+
+	const operationAbortedEvent = {
+		exception: {
+			values: [
+				{
+					type: 'DOMException',
+					value: 'The operation was aborted.',
+					stacktrace: {
+						frames: [
+							{
+								filename:
+									'../../../node_modules/react-router/dist/development/chunk.mjs',
+								function: 'doNavigate',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isReactRouterNavigationAbortNoise(operationAbortedEvent)).toBe(true)
+
+	const userAbortedEvent = {
+		exception: {
+			values: [
+				{
+					type: 'AbortError',
+					value: 'The user aborted a request',
+					stacktrace: {
+						frames: [
+							{
+								filename: 'react-router/dist/chunk.mjs',
+								function: 'handleClick',
+								inApp: false,
+							},
+							{
+								filename: 'react-router/dist/chunk.mjs',
+								function: 'navigate',
+								inApp: false,
+							},
+						],
+					},
+				},
+			],
+		},
+	}
+	expect(isReactRouterNavigationAbortNoise(userAbortedEvent)).toBe(true)
+
+	const abortDomException = new DOMException(
+		'signal is aborted without reason',
+		'AbortError',
+	)
+	abortDomException.stack =
+		'AbortError: signal is aborted without reason\n    at startNavigation (react-router/dist/development/chunk.mjs:1:1)'
+	expect(abortDomException.code).toBe(20)
+	expect(
+		isReactRouterNavigationAbortNoise(
+			{
+				exception: {
+					values: [
+						{
+							type: 'DOMException',
+							value: 'signal is aborted without reason',
+							stacktrace: {
+								frames: [
+									{
+										filename:
+											'../../../node_modules/react-router/dist/development/chunk.mjs',
+										function: 'startNavigation',
+										inApp: false,
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+			{ originalException: abortDomException },
+		),
+	).toBe(true)
+
+	// Message alone (no RR navigation stack) must not drop.
+	expect(
+		isReactRouterNavigationAbortNoise({
+			exception: {
+				values: [
+					{
+						type: 'AbortError',
+						value: 'signal is aborted without reason',
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// Generic AbortError without a React Router navigation stack must not drop.
+	expect(
+		isReactRouterNavigationAbortNoise({
+			exception: {
+				values: [
+					{
+						type: 'AbortError',
+						value: 'signal is aborted without reason',
+						stacktrace: {
+							frames: [
+								{
+									filename: '[native code]',
+									function: 'fetch',
+									inApp: false,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// RR data-fetch abort frames without navigation functions are not enough.
+	expect(
+		isReactRouterNavigationAbortNoise({
+			exception: {
+				values: [
+					{
+						type: 'AbortError',
+						value: 'The operation was aborted.',
+						stacktrace: {
+							frames: [
+								{
+									filename:
+										'../../../node_modules/react-router/dist/development/chunk.mjs',
+									function: 'fetchAndDecodeViaTurboStream',
+									inApp: false,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	// In-app frames mean a real app AbortError — keep reporting.
+	expect(
+		isReactRouterNavigationAbortNoise({
+			exception: {
+				values: [
+					{
+						type: 'AbortError',
+						value: 'signal is aborted without reason',
+						stacktrace: {
+							frames: [
+								{
+									filename: '/app/components/calls/recording-form.tsx',
+									function: 'stopRecording',
+									inApp: true,
+								},
+								{
+									filename:
+										'../../../node_modules/react-router/dist/development/chunk.mjs',
+									function: 'startNavigation',
+									inApp: false,
+								},
+							],
+						},
+					},
+				],
+			},
+		}),
+	).toBe(false)
+
+	expect(
+		shouldDropSentryEvent({
+			exception: {
+				values: [
+					{
+						type: 'AbortError',
+						value: 'signal is aborted without reason',
+					},
+				],
+			},
+		}),
+	).toBe(false)
 })
 
 test('filters React Firefox scheduler re-entrancy (KCD-YT)', () => {

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -207,6 +207,29 @@ const REACT_SCHEDULER_ALREADY_WORKING = /^Should not already be working\.?$/i
 const REACT_SCHEDULER_REENTRANCY_FRAME =
 	/performWorkUntilDeadline|performWorkOnRootViaSchedulerTask|performSyncWorkOnRoot|scheduler(?:\.production)?(?:\.min)?\.js|react-dom(?:-client)?(?:\.production)?(?:\.min)?\.js/i
 
+/**
+ * React Router `startNavigation` aborts any in-flight navigation via
+ * `pendingNavigationController.abort()` before starting the next one.
+ * Browsers surface that as AbortError / DOMException code 20 (KCD-10D).
+ * Do not add these phrases to `SENTRY_IGNORE_ERRORS` — app AbortErrors
+ * (TTS, recording, fetch timeouts) must still alert.
+ */
+const REACT_ROUTER_NAV_ABORT_MESSAGE =
+	/signal is aborted without reason|The operation was aborted\.?|The user aborted a request/i
+
+const REACT_ROUTER_NAV_ABORT_FUNCTION_DISTINCTIVE =
+	/(?:^|\.)(?:startNavigation|doNavigate)$/
+
+const REACT_ROUTER_NAV_ABORT_FUNCTION_GENERIC =
+	/(?:^|\.)(?:handleClick|navigate)$/
+
+const DOM_EXCEPTION_ABORT_ERR = 20
+
+function isReactRouterPackageFilename(filename: string): boolean {
+	if (/@sentry\/react-router/i.test(filename)) return false
+	return /(?:^|\/)react-router(?:\/|$)/i.test(filename)
+}
+
 function isReactSchedulerReentrancyFrame(frame: {
 	filename?: string | null
 	function?: string | null
@@ -459,6 +482,115 @@ export function isReactSchedulerAlreadyWorkingNoise(
 		.join('\n')}\n${stackBlob(event, original)}`
 	// Bundled/minified stacks without sourcemaps still count when the only
 	// frames are scheduler / react-dom — reject app route paths.
+	if (/\/app\/|\/routes\/|components\//i.test(blob)) return false
+
+	return true
+}
+
+function exceptionHasAbortErrorIdentity(
+	event: SentryEventLike,
+	original: unknown,
+): boolean {
+	if (
+		(event.exception?.values ?? []).some((value) => value.type === 'AbortError')
+	) {
+		return true
+	}
+
+	if (
+		eventMessages(event).some((message) =>
+			REACT_ROUTER_NAV_ABORT_MESSAGE.test(message),
+		)
+	) {
+		return true
+	}
+
+	if (typeof DOMException !== 'undefined' && original instanceof DOMException) {
+		return (
+			original.name === 'AbortError' ||
+			original.code === DOM_EXCEPTION_ABORT_ERR
+		)
+	}
+
+	if (original instanceof Error && original.name === 'AbortError') {
+		return true
+	}
+
+	if (original && typeof original === 'object') {
+		const name = (original as { name?: unknown }).name
+		const code = (original as { code?: unknown }).code
+		if (name === 'AbortError') return true
+		if (code === DOM_EXCEPTION_ABORT_ERR || code === '20') return true
+		const message = (original as { message?: unknown }).message
+		if (
+			typeof message === 'string' &&
+			REACT_ROUTER_NAV_ABORT_MESSAGE.test(message)
+		) {
+			return true
+		}
+	}
+
+	return false
+}
+
+function frameLooksLikeReactRouterNavigation(frame: {
+	filename?: string | null
+	absPath?: string | null
+	function?: string | null
+}): boolean {
+	const fn = frame.function ?? ''
+	if (REACT_ROUTER_NAV_ABORT_FUNCTION_DISTINCTIVE.test(fn)) return true
+
+	const file = `${frame.filename ?? ''}\n${frame.absPath ?? ''}`
+	return (
+		isReactRouterPackageFilename(file) &&
+		REACT_ROUTER_NAV_ABORT_FUNCTION_GENERIC.test(fn)
+	)
+}
+
+function hasReactRouterNavigationStackEvidence(
+	event: SentryEventLike,
+	original: unknown,
+): boolean {
+	const frames = (event.exception?.values ?? []).flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+	if (frames.some(frameLooksLikeReactRouterNavigation)) return true
+
+	const blob = stackBlob(event, original)
+	if (!/react-router/i.test(blob)) return false
+	return (
+		/\b(?:startNavigation|doNavigate)\b/.test(blob) ||
+		(/react-router(?:\/dist|\/lib)/i.test(blob) &&
+			/\b(?:handleClick|navigate)\b/.test(blob))
+	)
+}
+
+/**
+ * Drop AbortError noise from React Router cancelling a superseded SPA
+ * navigation (`pendingNavigationController.abort()` in `startNavigation`).
+ * Require AbortError identity + RR navigation frames + no in-app frames —
+ * never the abort message alone (KCD-10D).
+ */
+export function isReactRouterNavigationAbortNoise(
+	event: SentryEventLike,
+	hint: { originalException?: unknown } = {},
+): boolean {
+	const original = hint.originalException
+	if (!exceptionHasAbortErrorIdentity(event, original)) return false
+
+	const frames = (event.exception?.values ?? []).flatMap(
+		(value) => value.stacktrace?.frames ?? [],
+	)
+	// Need attributed frames so we can prove exclusivity — message alone is
+	// not enough, and mixed in-app frames must stay reportable.
+	if (frames.length === 0) return false
+	if (frames.some((frame) => frame.inApp)) return false
+	if (!hasReactRouterNavigationStackEvidence(event, original)) return false
+
+	const blob = `${frames
+		.map((frame) => `${frame.filename ?? ''} ${frame.function ?? ''}`)
+		.join('\n')}\n${stackBlob(event, original)}`
 	if (/\/app\/|\/routes\/|components\//i.test(blob)) return false
 
 	return true
@@ -1120,6 +1252,7 @@ export function shouldDropSentryEvent(
 	if (isCloudflareEdgeRouteErrorEvent(event)) return true
 	if (isReactRouterEdgeHttpStatusError(event, hint)) return true
 	if (isReactRouterDataProtocolNoise(event, hint)) return true
+	if (isReactRouterNavigationAbortNoise(event, hint)) return true
 	if (isHtmlDocumentAsScriptNoise(event, hint)) return true
 	if (isReactRouterSanitizedServerError(event, hint)) return true
 	if (event.request?.url?.includes('/lookout')) return true


### PR DESCRIPTION
## Summary
- Narrow client Sentry filter for React Router navigation AbortError (KCD-10D).
- Only drops when AbortError identity + RR nav stack and no in-app frames.
- Docs + tests for the signature and negatives.

## Why
Superseded SPA navigations abort in-flight navigations; noise, not an app bug.

## Test plan
- [x] sentry-noise tests on agent
- [ ] CI Site Gate green