### PR TITLE
Filter browser-extension Sentry noise (KCD-10E, KCD-10F)

### DIFF
--- a/services/site/app/utils/__tests__/sentry-noise.test.ts
+++ b/services/site/app/utils/__tests__/sentry-noise.test.ts
@@ -84,6 +84,43 @@ test('filters injected extension post Method not found (KCD-W9)', () => {
 	expect(matchesIgnoreError('Error invoking post: Method not found')).toBe(true)
 })
 
+test('filters Chrome extension receiving-end-gone messaging (KCD-10F)', () => {
+	expect(
+		matchesIgnoreError(
+			'Could not establish connection. Receiving end does not exist.',
+		),
+	).toBe(true)
+	expect(
+		matchesIgnoreError(
+			'Could not establish connection. Receiving end does not exist',
+		),
+	).toBe(true)
+	// Generic connection failures must still alert.
+	expect(matchesIgnoreError('Could not establish connection.')).toBe(false)
+	expect(matchesIgnoreError('Receiving end does not exist.')).toBe(false)
+})
+
+test('filters injected Symbol.hasInstance redefine (KCD-10E)', () => {
+	expect(
+		matchesIgnoreError(
+			"can't redefine non-configurable property Symbol.hasInstance",
+		),
+	).toBe(true)
+	expect(
+		matchesIgnoreError(
+			'Cannot redefine non-configurable property: Symbol.hasInstance',
+		),
+	).toBe(true)
+	expect(
+		matchesIgnoreError('Cannot redefine property: Symbol.hasInstance'),
+	).toBe(true)
+	// Generic redefine / TypeError must still alert.
+	expect(
+		matchesIgnoreError("can't redefine non-configurable property foo"),
+	).toBe(false)
+	expect(matchesIgnoreError('Cannot redefine property: length')).toBe(false)
+})
+
 test('scopes EIP-1193 wallet user rejection (KCD-ZV)', () => {
 	expect(matchesIgnoreError('user rejected the request')).toBe(false)
 

--- a/services/site/app/utils/sentry-noise.ts
+++ b/services/site/app/utils/sentry-noise.ts
@@ -70,6 +70,13 @@ export const SENTRY_IGNORE_ERRORS: Array<string | RegExp> = [
 	/Invalid call to runtime\.sendMessage\(\)\. Tab not found/,
 	// Injected extension post bridge (KCD-W9).
 	/Error invoking post: Method not found/,
+	// Chrome extension messaging when the receiving end is gone (KCD-10F).
+	// Distinctive chrome.runtime lastError — no chrome-extension:// stack.
+	/Could not establish connection\. Receiving end does not exist\.?/i,
+	// Firefox injected redefine of Symbol.hasInstance (KCD-10E) plus Chrome
+	// sibling wording. Stack is only `<anonymous code>` — not site bundles.
+	/can'?t redefine non-configurable property Symbol\.hasInstance/i,
+	/Cannot redefine (?:non-configurable )?property[: ]*Symbol\.hasInstance/i,
 	// Android in-app browser (Instagram/etc.) native bridge (KCD-ZM).
 	/Error invoking postMessage: Java object is gone/,
 	// Injected social/OG scrapers reading meta tags that aren't present (KCD-2K family).


### PR DESCRIPTION
## Summary
- Narrow client Sentry filters for browser-extension noise covering KCD-10E and KCD-10F.
- Keep real first-party AbortError / connection errors visible.

## Why
Extension stacks (Symbol.hasInstance redefine, Receiving end does not exist) are visitor chrome noise on kentcdodds.com, not site bugs.

## Test plan
- [x] sentry-noise tests on agent
- [ ] CI Site Gate green