### PR TITLE
Add BIOS SPHERE to The Last Software Engineer talks

### DIFF
--- a/services/site/content/data/talks.yml
+++ b/services/site/content/data/talks.yml
@@ -90,6 +90,8 @@
       date: 2026-09-24
     - event: '[All Things Open](https://allthingsopen.org/)'
       date: 2026-10-19
+    - event: '[BIOS SPHERE](https://biossphere.dev/)'
+      date: 2026-11-02
     - event: '[React Summit US](https://reactsummit.us/)'
       date: 2026-11-17
   tags:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the BIOS SPHERE (Vancouver, 2 Nov 2026) presentation to The Last Software Engineer on `/talks`.

## Why
Kent is a revealed speaker at [BIOS SPHERE](https://biossphere.dev/) with **The Last Software Engineer**. The delivery was missing from `services/site/content/data/talks.yml` (confirmed in repo content sources).

## What changed
- Added a presentation under **The Last Software Engineer**:
  - Event: [BIOS SPHERE](https://biossphere.dev/)
  - Date: `2026-11-02`
- Matched existing `talks.yml` delivery shape (`event` markdown link + `date`).
- Did **not** add the morning **AI-Native Product Development** workshop. `/talks` only has talk deliveries; `/workshops` is Kent’s own workshop products, not conference workshops. No new content type.

## How to verify
1. Open `/talks` (or `/talks/the-last-software-engineer`).
2. Confirm **The Last Software Engineer** lists BIOS SPHERE as a presentation dated 2026-11-02 linking to https://biossphere.dev/.

## Local verification
BIOS SPHERE appears under The Last Software Engineer on `/talks` and `/talks/the-last-software-engineer`, dated 2026-11-02, linking to https://biossphere.dev/.

<a href="https://cursor.com/agents/bc-23298096-56ec-4d46-8369-01fae4e16cc2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbiossphere-talks-walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-8f7b76e1-c0e5-4066-9156-9e0cf9d9f28a" alt="biossphere-talks-walkthrough.mp4" /></a>
![BIOS SPHERE presentation on /talks](https://cursor.com/artifacts/c/art-6411fbd0-907d-451d-b7b0-8e90fa00fdec)
![BIOS SPHERE on the talk slug page](https://cursor.com/artifacts/c/art-6b45cfc0-191f-44b7-a6e1-f69111cbb8f4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23298096-56ec-4d46-8369-01fae4e16cc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23298096-56ec-4d46-8369-01fae4e16cc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Events**
  - Added a scheduled delivery of “The Last Software Engineer” at BIOS SPHERE on November 2, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->